### PR TITLE
Updated LightningLookup and added Deploy to DX button(s) to readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ You do not need to be using the lightning experience to use these flow extension
 
 # [A Note about SFDX](./sfdxintro.md)
 
+[![Deploy](https://deploy-to-sfdx.com/dist/assets/images/DeployToSFDX.svg)](https://deploy-to-sfdx.com/)
+
 # Submissions Encouraged!
 Have you built a useful or interesting Flow Component? We encourage you to make a pull request and add it to this repo. Also feel free to enhance or fix any existing component.
 

--- a/flow_screen_components/lookupFSC/README.md
+++ b/flow_screen_components/lookupFSC/README.md
@@ -10,7 +10,7 @@ This is a simple adaptation of the excellent [Lightning Lookup control](https://
 
 [Install this Component](https://sites.google.com/view/flowunofficial/flow-screen-components/lookup).
 
-
+[![Deploy](https://deploy-to-sfdx.com/dist/assets/images/DeployToSFDX.svg)](https://deploy-to-sfdx.com/)
 
 ## How It Works ##
 

--- a/flow_screen_components/lookupFSC/force-app/main/default/aura/LightningLookup/LightningLookup.cmp
+++ b/flow_screen_components/lookupFSC/force-app/main/default/aura/LightningLookup/LightningLookup.cmp
@@ -15,7 +15,8 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -->
 <aura:component controller="LightningLookupController">
 
-	<ltng:require scripts="/resource/jQuery_LookupCmp/jQuery1_11_2.js"/>
+	<!--<ltng:require scripts="/resource/jQuery_LookupCmp/jQuery1_11_2.js"/>-->
+    <ltng:require scripts="{!$Resource.jQuery_LookupCmp + '/jQuery1_11_2.js'}"/>
 	
 	<aura:attribute name="sObjectName" type="String" access="public" required="false" description="Name of the sObjectName to gather records from"/>
 	<aura:attribute name="sObjectField" type="String" access="public" required="false" description="Full name of the SObject field the component is for"/>


### PR DESCRIPTION
Updated the LightningLookup component to utilize a static resource URL in lieu of hard coding the URL of the jquery library.

Also, I added a Deploy to DX button for the component.  Going forward, you should include a Deploy to DX button on the readmes of all your components, as it's a nice and easy way to deploy any repository or project utilizing Salesforce DX.