### PR TITLE
Apply default value

### DIFF
--- a/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSC.cmp
+++ b/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSC.cmp
@@ -8,7 +8,7 @@
  <aura:handler name="init" value="{!this}" action="{!c.init}"/>
   <lightning:select  class="slds-size_1-of-2" name="selectItem" label="Select an item" value="{!v.value}">
     <aura:iteration items="{!v.options}" var="option">
-      <option value="{!option.value}">{!option.label}</option>
+      <option value="{!option.value}" selected="{!option.selected}">{!option.label}</option>
     </aura:iteration>
   </lightning:select>
 

--- a/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSCController.js
+++ b/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSCController.js
@@ -4,8 +4,9 @@
     let options = component.get("v.options")
     let object = component.get("v.object")
     let field = component.get("v.field")
+    let defaultVal = component.get("v.value");
     if (options.length === 0) {
-      helper.fireApex("c.getPicklistValues", { fld: field, obj: object }, "v.options");
+      helper.fireApex("c.getPicklistValues", { fld: field, obj: object }, "v.options", defaultVal);
     }
   },
 })

--- a/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSCHelper.js
+++ b/flow_screen_components/dynamicPicklistFSC/force-app/main/default/aura/dynamicPicklistFSC/dynamicPicklistFSCHelper.js
@@ -100,7 +100,7 @@
     helper.createComponent(compName, attributes, location, true);
   },
 
-  fireApexHelper: function (ApexFunctionName, params, resolve, attributeName) {
+  fireApexHelper: function (ApexFunctionName, params, resolve, attributeName, defaultVal) {
     let component = this.component
     let helper = this;
     let action = component.get(ApexFunctionName);
@@ -110,19 +110,24 @@
         console.log("There was an error:");
         console.log(a.getError());
       } else if (a.getState() === 'SUCCESS') {
+        var options = a.getReturnValue();
+        for (var option of options) {
+            if (option.value === defaultVal) {
+                option.selected = true;
+            }
+        }
         if (attributeName) component.set(attributeName, a.getReturnValue());
         resolve(a.getReturnValue());
-        console.log(a.getReturnValue());
       }
 
     });
     $A.enqueueAction(action);
   },
 
-  fireApex: function (ApexFunctionName, params, attributeName) {
+  fireApex: function (ApexFunctionName, params, attributeName, defaultVal) {
     let component = this.component
     let helper = this;
-    let p = new Promise((resolve) => { helper.fireApexHelper(ApexFunctionName, params, resolve, attributeName) });
+    let p = new Promise((resolve) => { helper.fireApexHelper(ApexFunctionName, params, resolve, attributeName, defaultVal) });
     return p
   },
 


### PR DESCRIPTION
When a value is passed into the component from the `value` attribute, select it as the default value in the option list that is returned from the server.

This gets around the limitation of the built-in picklist input in flows. The workaround described in the following blog post shows the selected option twice:
http://www.sfdcr.com/automation/visual-flow-series-default-current-picklist-value/