### PR TITLE
Update LightningLookupHelper.js

### DIFF
--- a/flow_screen_components/lookupFSC/force-app/main/default/aura/LightningLookup/LightningLookupHelper.js
+++ b/flow_screen_components/lookupFSC/force-app/main/default/aura/LightningLookup/LightningLookupHelper.js
@@ -275,7 +275,7 @@ IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
             }
             else{
                 var searchWhereClause = component.get("v.displayedFieldName") + " LIKE '%" +
-                    searchString + "%'";
+                    searchString.replace(/'/g,'\\\'') + "%'";
                 component.set("v.searchWhereClause", searchWhereClause);	
             }
             


### PR DESCRIPTION
Fixed issue where a value with an apostrophe in it would crash the SOQL lookup