### PR TITLE
Evan minimize utility item

### DIFF
--- a/flow_action_components/Summer18/MinimizeUtilityItem/README.md
+++ b/flow_action_components/Summer18/MinimizeUtilityItem/README.md
@@ -1,0 +1,26 @@
+# MinimizeUtilityItem - Finish your utility bar embeded Flow by closing it #
+
+### A Flow Action extension  ###
+
+This Flow element causes the open utility bar item to minimize. This works great for flows embeded in a utility bar that need to close when they reach the end instead of starting over.
+
+
+## Install this Component Into Your Org ##
+
+Coming Soon
+
+Important Operations Notes:
+This flow action does NOT work when run from Flow Setup. It ONLY works when run on a Lightning Page. (Even if you're using Lightning Experience, the Flow Setup page is an old "Classic" page, and has some limitations in how it executes flows. )
+
+## How It Works ##
+
+This component has no editable attributes. It will call the UtilityBarAPI method that closes the open utility bar item. 
+
+
+## Resources ##
+
+Want to suggest an improvement or report a bug? Do that [here](/issues)
+
+[Learn more about how Flow Components work](/README.md)
+
+Want to add some improvements? {Pull requests are welcome}(/pulls).

--- a/flow_action_components/Summer18/MinimizeUtilityItem/force-app/main/default/aura/MinimizeUtilityItem/MinimizeUtilityItem.cmp
+++ b/flow_action_components/Summer18/MinimizeUtilityItem/force-app/main/default/aura/MinimizeUtilityItem/MinimizeUtilityItem.cmp
@@ -1,0 +1,3 @@
+<aura:component implements="lightning:availableForFlowActions">
+    <lightning:utilityBarAPI aura:id="utilitybar" />
+</aura:component>

--- a/flow_action_components/Summer18/MinimizeUtilityItem/force-app/main/default/aura/MinimizeUtilityItem/MinimizeUtilityItemController.js
+++ b/flow_action_components/Summer18/MinimizeUtilityItem/force-app/main/default/aura/MinimizeUtilityItem/MinimizeUtilityItemController.js
@@ -1,0 +1,13 @@
+({
+	invoke : function(component, event, helper) {        
+        var utilityAPI = component.find("utilitybar");
+        utilityAPI.getUtilityInfo().then(function(response) {
+            if (response.utilityVisible) {
+                utilityAPI.minimizeUtility();
+            }
+        })
+        .catch(function(error) {
+            console.log(error);
+        });
+    }
+})


### PR DESCRIPTION
I created a component that will minimize the utility bar item. This is used at the end of flows that are embedded in the utility bar so that they close instead of starting over. If you also use the same flow in non-utility bar configurations, this component will not throw any errors.