### PR TITLE
Added Multi-Lingual, test cases and others identified in pull request

### DIFF
--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
@@ -1,16 +1,32 @@
-public with sharing class SendHTMLEmail {
+/**
+ * @File Name          : SendHTMLEmail.cls
+ * @Description        : Uses Spring/Summer '20 EmailTemplate Object + ContentVersion with multi-lingual
+ * @Author             : various, including Salesforce, Alex Edelstein, https://digitalflask.com/blog/send-email-attachments-salesforce-apex/
+ * @Group              : unofficialSF
+ * @Last Modified By   : jack.pond@psitex.com
+ * @Last Modified On   : 2/5/2020, 4:02:33 PM
+ * @Modification Log   : 
+ * @License            : LICENSE found in https://github.com/alexed1/LightningFlowComponents
+ * Ver       Date            Author      		    Modification
+ * 1.32    2/5/2020   jack.pond@psitex.com     Modified for multi-lingual and to throw InvocableActionException on exceptions
+**/
+
+public without sharing class SendHTMLEmail {
 
     @invocableMethod(label='Send HTML Email')
     public static List<Response>  SendEmail(List<Request> requests) {
         
+        Response response = new Response();
         String HTMLbody = requests[0].HTMLbody;
         String plainTextBody = requests[0].plainTextBody;
         String subject = requests[0].subject;
         String replyEmailAddress = requests[0].replyEmailAddress;
         String senderDisplayName = requests[0].senderDisplayName;
         String templateID = requests[0].templateID;
+        String templateName = requests[0].templateName;
+        String templateLanguage = requests[0].templateLanguage;
         String templateTargetObjectId = requests[0].templateTargetObjectId;
-        String orgWideEmailAddressId = requests[0].orgWideEmailAddressId;    
+        String orgWideEmailAddressId = requests[0].orgWideEmailAddressId;
         Boolean saveAsActivity = requests[0].saveAsActivity;
         Id recordId = requests[0].recordId;
 
@@ -32,11 +48,8 @@ public with sharing class SendHTMLEmail {
         //String[] toAddresses = new String[] {oneAddress}; 
         Map<String, Object> m = GenerateMap(requests[0]);
         String[] toAddresses = BuildAddressList('TO',m); 
-        System.debug('toAddresses is: ' + toAddresses);
         String[] ccAddresses = BuildAddressList('CC',m); 
-        System.debug('ccAddresses is: ' + ccAddresses);
         String[] bccAddresses = BuildAddressList('BCC', m);
-        System.debug('bccAddresses is: ' + bccAddresses);
         
 
         // Assign the addresses for the To and CC lists to the mail object.
@@ -72,51 +85,57 @@ public with sharing class SendHTMLEmail {
 
         mail = AddAttachments(mail, requests[0].contentDocumentAttachments, null);
          
+        if (templateName != null && templateID != null)
+            throw new InvocableActionException('You\'re trying to pass in both the name of the template and a template ID. Gotta pick one or the other. Use templateName to select the first matching template qualified with \'Language="xxx_YY"\' in the Description.  The templateId represents a specific Salesforce Email Template (either Classic or Lightning).');
+
+        if (templateName != null){
+            templateID = getTemplateIdFromName(templateName,templateLanguage);
+            if (templateID == null){
+	            throw new InvocableActionException('Could not find email template named "'+templateName+'".  Please have your administrator check the name and/or accessibility of this template');
+            }
+            Response.templateUsed = TemplateId;
+        }
         if (templateID != null && ((HTMLbody != null) || (plainTextBody != null)))
-            throw new InvocableActionException('you\'re trying to pass in both a plaintext/html body and a template ID. Gotta pick one or the other. Make sure you\'re not confusing the Text Template resources in Flow, (which you can pass into either the HTMLBody or the plainTextBody) with the templateId, which represents a Salesforce Email Template (either Classic or Lightning).');
+            throw new InvocableActionException('You\'re trying to pass in both a plaintext/html body and a template ID. Gotta pick one or the other. Make sure you\'re not confusing the Text Template resources in Flow, (which you can pass into either the HTMLBody or the plainTextBody) with the templateId, which represents a Salesforce Email Template (either Classic or Lightning).');
            
-        if ((templateID != null && templateTargetObjectId == null) || (templateID == null && templateTargetObjectId != null))
-            throw new InvocableActionException('templateId and templateTargetObjectId have to be used together. the target recordID determines how to fill in the mergefields in the template.');
-        
         if (templateID == null  && HTMLbody == null && plainTextBody == null)
-            throw new InvocableActionException(' Body text must be provided to Send HTML Email Action, either via HTMLbody, plainTextBody, or a templateId');
+            throw new InvocableActionException('Body text must be provided to Send HTML Email Action, either via HTMLbody, plainTextBody, or a templateId');
               
         if (saveAsActivity == true && recordId == null) {
             throw new InvocableActionException('In order to log this email send to activity history, you need to pass in a recordId');
         }
         
-        mail.setTemplateID(templateID);
-        mail.setTargetObjectId(templateTargetObjectId);
-        System.debug('templateID is:' + templateID);
+        Boolean completed = true;
+        String error;
+        Messaging.SendEmailResult[] emailResponse;
+        if (templateTargetObjectId != NULL) mail.setTargetObjectId(templateTargetObjectId);
+        if (recordId != null) mail.setWhatId(recordId);
         
         // Specify the text content of the email.
-        mail.setPlainTextBody(plainTextBody);
-
-        mail.setHtmlBody(HTMLbody);
-        System.debug('mail is:' + mail);
-        Messaging.SendEmailResult[] emailResponse;
-        Boolean completed;
-        String error;
+        if (plainTextBody != NULL) mail.setPlainTextBody(plainTextBody);
+        if (HTMLbody != NULL) mail.setHtmlBody(HTMLbody);
+        if (saveAsActivity != NULL) mail.setSaveAsActivity(saveAsActivity);
+        if (templateID != NULL){
+        	try {
+            	mail.setTemplateID(templateID);
+            } catch (Exception e){
+                completed = false;
+                error = e.getMessage();
+            	throw new InvocableActionException(e.getMessage());
+        	}
+        }
         // Send the email you have created.
         try {
-            emailResponse = Messaging.sendEmail(new Messaging.SingleEmailMessage[]{
-                    mail
-            });
-            System.debug('emailResponse is: ' + emailResponse);
+
+            emailResponse = Messaging.sendEmail(new Messaging.SingleEmailMessage[]{mail});
             completed = true;
-        } catch (InvocableActionException e){
-            System.debug ('exception occured: ' + e.getMessage());
+        } catch (Exception e){
             completed = false;
             error = e.getMessage();
-        } catch (System.EmailException e){
-            System.debug ('exception occured: ' + e.getMessage());
-            completed = false;
-            error = e.getMessage();
+            throw new InvocableActionException(e.getMessage());
         }
-       
         //report back the results
-        Response response = new Response();
-        if (completed == true) {
+        if (completed) {
             if (emailResponse[0].isSuccess() != true) {
                 Messaging.SendEmailError[] curErrors = emailResponse[0].getErrors();
                 String errorReport = '';
@@ -128,22 +147,19 @@ public with sharing class SendHTMLEmail {
             } else {
                 response.isSuccess = true;
             }
-            if (saveAsActivity == true && recordId != null) {
-                if (recordId != null) {
-                    try {
-                        createActivity(recordId, subject, toAddresses + ',' + ccAddresses + ',' + bccAddresses);
-                    } catch (Exception ex) {
-                        response.errors = ex.getMessage();
-                        response.isSuccess = false;
-                    }
+            if (saveAsActivity == true) {
+                try {
+                    createActivity(recordId, subject, toAddresses + ',' + ccAddresses + ',' + bccAddresses);
+                } catch (Exception e) {
+                    response.errors = e.getMessage();
+                    response.isSuccess = false;
+                    throw new InvocableActionException(e.getMessage());
                 }
             }
-
         } else {
             response.errors = error;
             response.isSuccess = false;
         }
-        
         List<Response> responseList = new List<Response>();
         responseList.add(response);
         return responseList;
@@ -181,26 +197,19 @@ public with sharing class SendHTMLEmail {
     }
 
     public static String[] BuildAddressList(string type, Map<String, Object> m) {
-        
         String[] addressList = new List<String>();
         String curEmail;
-        
         //build address list
         //handle individual addresses
         String oneAddress = (String)m.get('Send' + type + 'thisOneEmailAddress');
         if ( oneAddress != null) {
             addressList.add(oneAddress);
-            System.debug('address list is:' + addressList);
         }
-
         //handle inputs involving collections of String addresses
         List<String> stringAddresses = (List<String>)m.get('Send' + type + 'thisStringCollectionOfEmailAddresses');
         if (stringAddresses != null) {
             addressList.addAll(stringAddresses);
-            System.debug('address list is:' + addressList);
         }
-        
-        
         //handle inputs involving collections of Contacts
         List<Contact> curContacts = (List<Contact>)m.get('Send' + type + 'theEmailAddressesFromThisCollectionOfContacts');        
         if (curContacts != null) {
@@ -210,7 +219,6 @@ public with sharing class SendHTMLEmail {
                 if (curEmail != null) extractedEmailAddresses.add(curEmail);
             }
             addressList.addAll(extractedEmailAddresses);
-            System.debug('address list is now:' + addressList); 
         }
         
         //handle inputs involving collections of Users
@@ -222,7 +230,6 @@ public with sharing class SendHTMLEmail {
                 if (curEmail != null) extractedEmailAddresses.add(curEmail);
             }
             addressList.addAll(extractedEmailAddresses);
-            System.debug('address list is now:' + addressList);
         }
         
         //handle inputs involving collections of Leads
@@ -234,12 +241,8 @@ public with sharing class SendHTMLEmail {
                 if (curEmail != null) extractedEmailAddresses.add(curEmail);
             }
             addressList.addAll(extractedEmailAddresses);
-            System.debug('address list is now:' + addressList);
         }
-
-
-        return addressList;
-
+       return addressList;
     }
 
     //this map makes it easier to efficiently use the same code to handle To, CC, and BCC.
@@ -262,8 +265,7 @@ public with sharing class SendHTMLEmail {
            'SendBCCtheEmailAddressesFromThisCollectionOfContacts' => request.SendBCCtheEmailAddressesFromThisCollectionOfContacts,
            'SendBCCtheEmailAddressesFromThisCollectionOfUsers' => request.SendBCCtheEmailAddressesFromThisCollectionOfUsers,
            'SendBCCtheEmailAddressesFromThisCollectionOfLeads' => request.SendBCCtheEmailAddressesFromThisCollectionOfLeads 
-  };
-       
+        };
     }
 
     private static void createActivity(Id recordId, String subject, String recipientList) {
@@ -275,7 +277,26 @@ public with sharing class SendHTMLEmail {
                 WhatId = recordId);
         insert t;
     }
-
+    private static String getTemplateIdFromName(String templateName, String templateLanguage){
+        String retTemplateId;
+        String blankTemplate;
+        List<EmailTemplate> et = [SELECT Id,Description FROM EmailTemplate WHERE Name=:templateName AND isActive = TRUE];
+        if (et.size() > 0){
+            String localeKey = [Select LanguageLocaleKey From Organization Limit 1].LanguageLocaleKey;
+            if (templateLanguage == NULL) templateLanguage = [Select LanguageLocaleKey From Organization limit 1].LanguageLocaleKey;
+            for (EmailTemplate thisTemplate: et){
+                if (thisTemplate.Description.Contains('Language="')){
+                    if (thisTemplate.Description.substringAfter('Language="').substringBefore('"') == templateLanguage){
+                        retTemplateID = thisTemplate.Id;
+                        break;
+                    }
+                }else{
+                    blankTemplate = (blankTemplate == NULL) ? thisTemplate.Id : blankTemplate;
+                }
+            }
+        }
+        return (retTemplateId == NULL)? blankTemplate : retTemplateId;
+    }
 
     public class Request {
         @invocableVariable
@@ -286,9 +307,6 @@ public with sharing class SendHTMLEmail {
         
         @invocableVariable
         public String templateID;
-        
-        @invocableVariable(label='Template Target Record Id' description='If you are passing in a template Id, you need to also pass in the Id of context record. It can be a Contact, Lead, or User. It will determine which data gets merged into the template')
-        public String templateTargetObjectID;
         
         @invocableVariable
         public String subject;
@@ -365,9 +383,18 @@ public with sharing class SendHTMLEmail {
 
         @invocableVariable
         public Boolean saveAsActivity;
-        @invocableVariable
-        public Id recordId;
 
+        @invocableVariable(label='Template Name' description='Used in conjuction with Template Language. Finds templates with the name matching Template Name for \'Language="xxx_YY"\' in the Description.')
+        public String templateName;
+        
+        @invocableVariable(label='Template Language' description='Used in conjuction with Template Name, Finds templates with the name matching Template Name for \'Language="xxx_YY"\' in the Description.  Template Selection criteria order first found Name with: 1)If empty, Org LanguageLocaleKey 2)Language found in Description 3)First without \'Language="\'')
+        public String templateLanguage;
+        
+        @invocableVariable(label='Template Target Record Id' description='If you are passing in a template Id, you need to also pass in the Id of context record. It can be a Contact, Lead, or User. It will determine which data gets merged into the template')
+        public String templateTargetObjectId;
+
+        @invocableVariable(label='Associated RecordId(WhatId/recordId for template and activity)' description='If you specify a contact for the targetObjectId field, you can specify an optional whatId as well. This helps to further ensure that merge fields in the template contain the correct data. This is used for merge fields and for associating activities and attachments.')
+        public Id recordId;
     }
 
     public class Response {
@@ -375,11 +402,12 @@ public with sharing class SendHTMLEmail {
         public Boolean isSuccess; 
         
         @invocableVariable
+        public String templateUsed; 
+        
+        @invocableVariable
         public String errors;
 
     }
-            
+
     public class InvocableActionException extends Exception {}
-
-
 }

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
@@ -1,103 +1,472 @@
+/**
+ * @File Name          : SendHTMLEmailTest.cls
+ * @Description        : Test the SendHTMLEmail Action Component. Uses Spring/Summer '20 EmailTemplate Object + ContentVersion with multi-lingual
+ * @NotTested		   : OrgWideEmailAddress - cannot be assured deployment org actually has any and test insert not allowed
+ * @Author             : various, including Salesforce, Alex Edelstein, https://digitalflask.com/blog/send-email-attachments-salesforce-apex/
+ * @Group              : unofficialSF
+ * @Last Modified By   : jack.pond@psitex.com
+ * @Last Modified On   : 2/5/2020, 4:02:33 PM
+ * @Modification Log   : 
+ * @License            : LICENSE found in https://github.com/alexed1/LightningFlowComponents
+ * Ver       Date            Author      		    Modification
+ * 1.32    2/5/2020   jack.pond@psitex.com     Updated Versioning
+**/
 @isTest
 public with sharing class SendHTMLEmailTest {
-	
-    private static Boolean EmailDeliverabilityEnabled(){
-        Boolean EmailDeliverabilityEnabled = true;
+/**
+    Test classes that create standard object records can cause failures if the deploying org has customized required fields,  
+    validations, triggers, . . . because it is complex to find and mimic these customizations and a failure in creation will stop the deployment
+    Inversely, not doing these tests can cause code coverage % failures.  For pre-deployment testing purposes, TEST_WITH_CREATED_RECORDS should be set to true,
+    but for version release, should be set to false.
+**/
+    private Static Final Boolean TEST_WITH_CREATED_RECORDS = false;
+//
+    private Static Final String TEMPLATE_NAME = 'xxxyyy Test Email Template yyyxxx';
+    private Static Final String TEMPLATE_DEVNAME = 'xxxyyy_Test_Email_Template_yyyxxx';
+    private Static Final String TEMPLATE_LANGUAGE = 'en_US';
+    private Static Final String TEMPLATE_NOSUCH = 'ZZXZ_XYZZY';
+    private Static Final String TEMPLATE_NAME_NOSUCH = 'ZZXZ XYZZY';
+    private Static Final String EMAIL_SUBJECT = 'this is the subject';
+    private Static Final String EMAIL_BODY = 'this is the body';
+    private Static Final String EMAIL_NOSUCH = 'test@foo.com';
+    private Static Final String EMAIL_NAME_NOSUCH = 'Do Not Reply';
+    private Static Final Integer TEST_CONTACTS_COUNT = 1;
+
+//	set up two email templates - one language enabled, the other not.   These will also be used as the relatedTo (WhatId/recordId)
+	@testSetup static void testSetupdata(){
+            EmailTemplate validEmailTemplate = new EmailTemplate(
+            isActive = true,
+            Name = TEMPLATE_NAME,
+            DeveloperName = TEMPLATE_DEVNAME,
+            TemplateType = 'custom',
+    		// UIType = 2,
+    		// RelatedEntityType = 'Case',
+            Description = 'Test Email Template - No Language Specified',
+            FolderId = UserInfo.getUserId(),
+            Subject = 'Test Email Template'
+        );
+        insert validEmailTemplate;
+
+        validEmailTemplate = new EmailTemplate(
+            isActive = true,
+            Name = TEMPLATE_NAME,
+            DeveloperName = TEMPLATE_DEVNAME+'_'+TEMPLATE_LANGUAGE,
+            TemplateType = 'custom',
+    		// UIType = 2,
+    		// RelatedEntityType = 'Case',
+            Description = 'Test Email Template - Language Specified (Language="'+TEMPLATE_LANGUAGE+'")',
+            FolderId = UserInfo.getUserId(),
+            Subject = 'Test Email Template - Language'
+        );
+        insert validEmailTemplate;
+    }
+// Check to see if email is deliverable (enabled and capacity not exceeded)    
+    private static Boolean emailDeliverabilityEnabled(){
+        Boolean emailDeliverabilityEnabled = true;
         try {
             Messaging.reserveSingleEmailCapacity(1);
             Messaging.reserveMassEmailCapacity(1);
         } catch (System.NoAccessException e) {
-            EmailDeliverabilityEnabled = false;
+            emailDeliverabilityEnabled = false;
         }
-        return EmailDeliverabilityEnabled;
+        return emailDeliverabilityEnabled;
     }
 
+//  Create Content and content links for testing 'attachments'
+    private static List<ContentDocumentLink> emailCreateAttachments(ID validEmailTemplateId){
+        ContentVersion content=new ContentVersion(); 
+            content.Title='Test_Content'; 
+            content.PathOnClient='/' + content.Title + '.txt'; 
+            Blob bodyBlob=Blob.valueOf('Unit Test ContentVersion Body'); 
+            content.VersionData=bodyBlob; 
+            //content.LinkedEntityId=sub.id;
+            content.origin = 'H';
+        insert content;
+        ContentDocumentLink contentlink=new ContentDocumentLink();
+            contentlink.LinkedEntityId=validEmailTemplateId;
+            contentlink.contentdocumentid=[select contentdocumentid from contentversion where id =: content.id].contentdocumentid;
+            contentlink.ShareType = 'V';
+            test.starttest();
+        insert contentlink;
+        List<ContentDocumentLink> cdls=new List<ContentDocumentLink>();
+        cdls.add(contentlink);
+        System.assertEquals(1, cdls.size());
+        return cdls;
+    }
+//	Create a contact to test email field merge (recipient && relatedTo[WhichId,relatedId])
+    private static List<Contact> emailCreateTestContacts(integer howMany){
+        List<Contact> ctList = new List<Contact>();
+        for (Integer i = 0; i < howMany; i++){
+            ctList.add(new Contact(
+                    LastName    = 'Contact '+ ('0000'+i).right(4),
+                    FirstName   = 'Test',
+                	email		= 'e'+('0000'+i).right(4)+EMAIL_NOSUCH
+                )
+            );
+        }
+        insert ctList;
+        return ctList;
+    }
+//	Create leads to test coverage for sent to leads)
+    private static List<Lead> emailCreateTestLeads(integer howMany){
+        List<Lead> ldList = new List<Lead>();
+        for (Integer i = 0; i < howMany; i++){
+            ldList.add(new Lead(
+                    LastName    = 'Lead '+ ('0000'+i).right(4),
+                    FirstName   = 'Test',
+                	email		= 'e'+('0000'+i).right(4)+EMAIL_NOSUCH
+                )
+            );
+        }
+        insert ldList;
+        return ldList;
+    }
+
+//	Create a contact to test email field merge (recipient && relatedTo[WhichId,relatedId])
+    private static List<Case> emailCreateTestCases(integer howMany, ID relatedContactId){
+        List<Case> caseList = new List<Case>();
+        for (Integer i = 0; i < howMany; i++){
+            caseList.add(new Case(
+                    Subject    	= 'Test Case '+ ('0000'+i).right(4),
+                	ContactId	= relatedContactId
+                )
+            );
+        }
+        insert caseList;
+        return caseList;
+    }
+
+    
+// @Test t001_canSendEmail: emailDeliverabilityEnabled and capacity not exceeded or not emailDeliverabilityEnabled
     @isTest
-    public static void CanSendEmail () {
+    public static void t001_canSendEmail () {
 
         SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
-        testReq.HTMLbody = 'this is the body';
-        testReq.Subject = 'this is the subject';
-        testReq.SendTOthisOneEmailAddress = 'test@foo.com';
-        testReq.SendCCthisOneEmailAddress = 'test@foo.com';
-        testReq.SendBCCthisOneEmailAddress = 'test@foo.com';
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.HTMLbody = EMAIL_BODY;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        testReq.SendCCthisOneEmailAddress = EMAIL_NOSUCH;
+        testReq.SendBCCthisOneEmailAddress = EMAIL_NOSUCH;
 
         List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
         reqList.add(testReq);
 
-        List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+		Boolean exceptionHit = false;
+        try {            
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            exceptionHit=true;
+            system.debug('t001_errorIfNoAddress: '+e.getMessage());
+        }
 	    
-        Boolean EmailDeliverabilityEnabled = EmailDeliverabilityEnabled();
-        if(EmailDeliverabilityEnabled){
-            System.assertEquals(testResponseList[0].isSuccess,true);
+        Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
+        if(emailDeliverabilityEnabled){
+            System.assertEquals(exceptionHit,false,'emailDeliverabilityEnabled and capacity exceeded');
         } else {
-            System.assertEquals(EmailDeliverabilityEnabled,false);
+            System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityEnabled');
         }
-
     }
 
+// @Test t002_errorIfNoAddress: Error expected if no addresses specified
     @isTest
-    public static void errorIfNoAddress () {
+    public static void t002_errorIfNoAddress () {
 
         SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
-        testReq.HTMLbody = 'this is the body';
-        testReq.Subject = 'this is the subject';
-        //testReq.SendTOthisOneEmailAddress = 'test@foo.com';
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.HTMLbody = EMAIL_BODY;
+        //testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
 
         List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
         reqList.add(testReq);
-
-        List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
-        System.assertEquals(testResponseList[0].isSuccess,false);
-
-
-
+		Boolean exceptionHit = false;
+        try {            
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            exceptionHit=true;
+            system.debug('t002_errorIfNoAddress: '+e.getMessage());
+        }
+        System.assertEquals(exceptionHit,true,'Error expected if no addresses specified');
     }
 
+// @Test t003_errorIfBothTemplateAndBody: Error expected if both body and templateId set
     @isTest
-    public static void errorIfBothTemplateandBody () {
+    public static void t003_errorIfBothTemplateAndBody () {
 
         SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
-        testReq.HTMLbody = 'this is the body';
-        testReq.templateID = 'temp';
-        testReq.Subject = 'this is the subject';
-        testReq.SendTOthisOneEmailAddress = 'test@foo.com';
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.HTMLbody = EMAIL_BODY;
+        testReq.templateID = TEMPLATE_NOSUCH;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
 
         List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
         reqList.add(testReq);
         Boolean exceptionHit=false;
         try {
             List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
-        
         } catch (SendHTMLEmail.InvocableActionException e) {
             exceptionHit=true;
+            system.debug('t003_errorIfBothTemplateAndBody error: '+e.getMessage());
         }
-        System.assertEquals(true, exceptionHit);
-
-
-
+        System.assertEquals(true, exceptionHit,'Error expected if flow attempts to set both body and templateId');
     }
 
-     @isTest
-    public static void errorIfTemplateButNoContextRecord () {
+// @Test t004_errorIfTemplateButNoContextRecord: Error expected if templateID does not exist
+    @isTest
+    public static void t004_errorIfTemplateButNoContextRecord () {
 
         SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
-        //testReq.HTMLbody = 'this is the body';
-        testReq.templateID = 'temp';
-        testReq.Subject = 'this is the subject';
-        testReq.SendTOthisOneEmailAddress = 'test@foo.com';
+        testReq.Subject = EMAIL_SUBJECT;
+        //testReq.HTMLbody = EMAIL_BODY;
+        testReq.templateID = TEMPLATE_NOSUCH;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
 
         List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
         reqList.add(testReq);
 		Boolean exceptionHit=false;
         try {
             List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
-        
         } catch (SendHTMLEmail.InvocableActionException e) {
             exceptionHit=true;
+            system.debug('t004_errorIfTemplateButNoContextRecord error: '+e.getMessage());
         }
-        System.assertEquals(true, exceptionHit);
-       
+        System.assertEquals(true, exceptionHit,'Error expected if templateID does not exist');
+    }
 
+// @Test t005_errorIfTemplateNameAndTemplateID: Error expected if templateID and templateName both used
+    @isTest
+    public static void t005_errorIfTemplateNameAndTemplateID () {
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.Subject = EMAIL_SUBJECT;
+        //testReq.HTMLbody = EMAIL_BODY;
+        testReq.templateID = TEMPLATE_NOSUCH;
+        testReq.templateName = TEMPLATE_NAME_NOSUCH;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+		Boolean ExceptionHit=false;
+        try {
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            ExceptionHit=true;
+            system.debug('t005_errorIfTemplateNameAndTemplateID error: '+e.getMessage());
+        }
+        System.assertEquals(true, ExceptionHit,'Error expected if templateID and templateName both used');
+    }
+// @Test t006_coverageIfTemplateNameAndNoLanguage: Can select the Organization LanguageLocaleKey template if no language specified.  However, if LanguageLocaleKey isn't en_US, still works
+    @isTest
+    public static void t006_coverageIfTemplateNameAndNoLanguage() {
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.templateName = TEMPLATE_NAME;
+        testReq.templateTargetObjectId = UserInfo.getUserId();
+        // if templateTargetObjectId type = user, saveAsActivity must be false
+        testReq.saveAsActivity = false;
+
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+		Boolean noExceptionHit=true;
+        List<SendHTMLEmail.Response> testResponseList;
+        try {
+            testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            noExceptionHit=false;
+            system.debug('t006_coverageIfTemplateNameAndNoLanguage error: '+e.getMessage());
+        }
+//		Depending on the organization locallangage key, could be either
+        if ([Select LanguageLocaleKey From Organization limit 1].LanguageLocaleKey == TEMPLATE_LANGUAGE){
+			System.assertEquals(testResponseList[0].templateUsed,
+                                [Select Id from EmailTemplate where DeveloperName=:(TEMPLATE_DEVNAME+'_'+TEMPLATE_LANGUAGE)].Id);
+        } else {
+			System.assertEquals(testResponseList[0].templateUsed, [Select Id from EmailTemplate where DeveloperName=:TEMPLATE_DEVNAME].Id);
+        }
+    }
+
+// @Test t007_coverageIfTemplateNameDoesntExist: Error expected if Named Template non-existent 
+    @isTest
+    public static void t007_coverageIfTemplateNameDoesntExist() {
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.templateName = TEMPLATE_NOSUCH;
+
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+		Boolean ExceptionHit=false;
+        List<SendHTMLEmail.Response> testResponseList;
+        try {
+            testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            ExceptionHit=true;
+            system.debug('t007_coverageIfTemplateNameDoesntExist error: '+e.getMessage());
+        }
+        System.assertEquals(true, ExceptionHit,'Error expected if Named Template non-existent');
+    }
+// @Test t008_coverageWithAttachments: Can add Attachments and send to collections (Contact, Lead, User)
+    @isTest
+    public static void t008_coverageWithAttachments() {
+        String devName = TEMPLATE_DEVNAME+'_'+TEMPLATE_LANGUAGE;
+        EmailTemplate validEmailTemplate = [Select Id,Name from EmailTemplate where DeveloperName=:devName];
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+    	List<ContentDocumentLink> cdls = emailCreateAttachments(validEmailTemplate.Id);
+        testReq.templateName = validEmailTemplate.Name;
+        testReq.recordId = validEmailTemplate.Id;
+        if (TEST_WITH_CREATED_RECORDS){
+            List<Contact>sendToContactCollection = emailCreateTestContacts(TEST_CONTACTS_COUNT);
+			testReq.templateTargetObjectId = sendToContactCollection[0].Id;
+        	testReq.recordId = emailCreateTestCases(1,testReq.templateTargetObjectId)[0].Id;
+			// also do code coverage test for sentTo Contact Collection
+            List<Id> theseIds = new List<Id>();
+            for (Contact thisContact : sendToContactCollection) theseIds.Add(thisContact.Id);
+            sendToContactCollection = [Select Id,Email from Contact where Id in :theseIds ];
+            testReq.SendBCCtheEmailAddressesFromThisCollectionOfContacts = sendToContactCollection;
+			// also do code coverage test for sentTo Lead Collection
+            List<Lead>sendToLeadCollection = emailCreateTestLeads(TEST_CONTACTS_COUNT);
+            theseIds = new List<Id>();
+            for (Lead thisLead : sendToLeadCollection) theseIds.Add(thisLead.Id);
+            sendToLeadCollection = [Select Id,Email from Lead where Id in :theseIds ];
+            testReq.SendBCCtheEmailAddressesFromThisCollectionOfLeads = sendToLeadCollection;
+
+            // Contact showContact = [SELECT Id,Name,Email from Contact where Id = :testReq.templateTargetObjectId];
+            // system.debug('showContact.Id: '+ showContact.Id + ' showContact.Name: '+ showContact.Name + ' showContact.Email: '+ showContact.Email);
+        }else{
+        	testReq.templateTargetObjectId = UserInfo.getUserId();
+        	testReq.recordId = validEmailTemplate.Id;
+            // if templateTargetObjectId type = user, saveAsActivity must be false
+            testReq.saveAsActivity = false;
+        	testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        }
+		testReq.contentDocumentAttachments = cdls;
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+        system.debug('attachlist: '+cdls);
+		Boolean ExceptionHit=false;
+        try {
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            ExceptionHit=true;
+            system.debug('t008_coverageWithAttachments error: '+e.getMessage());
+        }
+		// This will fail to send because WhatId is not available for sending emails to UserIds.
+        if (TEST_WITH_CREATED_RECORDS){
+	        System.assertEquals(false, ExceptionHit,'Cannot add Attachments and/or send to collections (Contact, Lead, User)');
+        } else {
+	        System.assertEquals(true, ExceptionHit,'WhatId is not available for sending emails to UserIds when using User as targetObject');
+        }
+    }
+
+// @Test t009_coverageTestActivity: Can allow email record as activity on recordId object
+    @isTest
+    public static void t009_coverageTestActivity() {
+        String devName = TEMPLATE_DEVNAME+'_'+TEMPLATE_LANGUAGE;
+        EmailTemplate validEmailTemplate = [Select Id,Name from EmailTemplate where DeveloperName=:devName];
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.templateName = validEmailTemplate.Name;
+        testReq.recordId = validEmailTemplate.Id;
+        if (TEST_WITH_CREATED_RECORDS){
+			testReq.templateTargetObjectId = emailCreateTestContacts(TEST_CONTACTS_COUNT)[0].Id;
+        	testReq.recordId = emailCreateTestCases(1,testReq.templateTargetObjectId)[0].Id;
+        	testReq.saveAsActivity = true;
+        }else{
+        	testReq.templateTargetObjectId = UserInfo.getUserId();
+        	// if templateTargetObjectId type = user, saveAsActivity must be false
+            testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        	testReq.saveAsActivity = false;
+        }
+
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+		Boolean ExceptionHit=False;
+        try {
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+            system.debug('testResponseList: ' + testResponseList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            ExceptionHit=true;
+            String error = e.getMessage();
+            system.debug('t009_coverageTestActivity error: '+e.getMessage());
+        }
+        if (TEST_WITH_CREATED_RECORDS){
+	        System.assertEquals(false, ExceptionHit,'Cannot allow email record as activity on recordId object');
+        } else {
+	        System.assertEquals(true, ExceptionHit,'WhatId is not available for sending emails to UserIds when using User as targetObject');
+        }
+    }
+
+// @Test t010_canSendEmailCCUsers: Can send email to a collection of users, email addresses and useSalesforceSignature
+    @isTest
+    public static void t010_canSendEmailCCToCollectionOfUsers() {
+
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.HTMLbody = EMAIL_BODY;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        testReq.SendBCCthisOneEmailAddress = EMAIL_NOSUCH;
+        testReq.SendCCtheEmailAddressesFromThisCollectionOfUsers = [Select Id,Email from User where Id=:UserInfo.getUserId()];
+        testReq.SendBCCthisStringCollectionOfEmailAddresses = new List<String>{EMAIL_NOSUCH};
+		testReq.useSalesforceSignature = true;
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+
+		Boolean exceptionHit = false;
+        try {            
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            exceptionHit=true;
+            system.debug('t001_errorIfNoAddress: '+e.getMessage());
+        }
+	    
+        Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
+        if(emailDeliverabilityEnabled){
+            System.assertEquals(exceptionHit,false,'Cannot send email to a collection of users and email addresses and/or useSalesforceSignature');
+        } else {
+            System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityDisabled Enabled or capacity exceeded');
+        }
+    }
+// @Test t011_ErrorIfNoBody: Error expected if (templateID == null  && HTMLbody == null && plainTextBody == null)
+    @isTest
+    public static void t011_ErrorIfNoBody() {
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+
+		Boolean exceptionHit = false;
+        try {            
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            exceptionHit=true;
+            system.debug('t011_ErrorIfNoBody: '+e.getMessage());
+        }
+	    
+        Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
+        if(emailDeliverabilityEnabled){
+            System.assertEquals(exceptionHit,true,'Error not received when (templateID == null  && HTMLbody == null && plainTextBody == null)');
+        } else {
+            System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityDisabled Enabled or capacity exceeded');
+        }
+    }
+// @Test t012_ErrorIfSaveAsActivityAndNoRecordId: Error expected if (saveAsActivity == true && recordId/whatId == null)
+    @isTest
+    public static void t012_ErrorIfSaveAsActivityAndNoRecordId() {
+        SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+        testReq.Subject = EMAIL_SUBJECT;
+        testReq.HTMLbody = EMAIL_BODY;
+        testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+        testReq.saveAsActivity = true;
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        reqList.add(testReq);
+
+		Boolean exceptionHit = false;
+        try {            
+            List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
+        } catch (SendHTMLEmail.InvocableActionException e) {
+            exceptionHit=true;
+            system.debug('t011_ErrorIfNoBody: '+e.getMessage());
+        }
+	    
+        Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
+        if(emailDeliverabilityEnabled){
+            System.assertEquals(exceptionHit,true,'Error not received when (saveAsActivity == true && recordId/whatId == null)');
+        } else {
+            System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityDisabled Enabled or capacity exceeded');
+        }
     }
 }


### PR DESCRIPTION
Replaces previous Pull request - cleaned.

I think this is ready to look at. Sorry it took so long - the day job got in the way. Some areas for checking:

1. **Added functionality for EmailTemplates**. EmailTemplates with the same name can have tags in their description (ex: "Language=es_MX") that distinguishes them as being a translation of all other EmailTempalates of the same name with the specified language.
2. **Modified SendHTMLEmail to use** "without sharing". This is for Community Guest (and Registered) users. There is an existing support request about accessibility (See Success Community Log) that has been running for a while. That sharing setting will be required for both Community and eventually EnhancedLetterheads when they get it fixed.
3. **Significant modifications for tests**. Code coverage now SendHTMLEmail(91% 164/179 with created records and 80% 144/179 without. Added several test and a switch TEST_WITH_CREATED_RECORDS that modifies testing as documented in SendHTMLEmailTest.
4. **Changed several handling of InvocableActionException.**  There were several places where a generated exception would not trigger a flow exception. Personally, I learned a lot from this as to which objects are valid and what can be done with them. Without this, no flow exception is thrown and the email disappears to never-never land requiring log-level debugging.
5. **Changed the RecordId parameter.** It's now 'Associated RecordId(WhatId/recordId for template and activity)'
6. **Fixed #270.** This was part of the whole mixed use of RecordId (for merge fields, templates, activities, attachments, . . .)

Take a look and tell me what you think. My email is jack.pond@psitex.com and I'd be glad to create a draft of the revised wordpress documention for approval too.