### PR TITLE
SendHTMLEmail Version 1.33.01 Updates for Issues #308,#316

### DIFF
--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
@@ -11,6 +11,7 @@
  * 1.32    2/5/2020   jack.pond@psitex.com      Modified for multi-lingual and to throw InvocableActionException on exceptions
  * 1.32    2/11/2020  alex@edelstein.org        Bulkified and Changed recordId to String
  * 1.33    3/22/2020  jack.pond@psitex.com      Added consistency checks, modified Labels and alphabetized params
+ * 1.33.1  4/11/2020  jack.pond@psitex.com      Issues 308,316
 **/
 
 public without sharing class SendHTMLEmail {
@@ -19,7 +20,7 @@ public without sharing class SendHTMLEmail {
     public static List<Response> SendEmail(List<Request> requests) {
 
         List<Response> responseList = new List<Response>();
-		system.debug('Got here SendEmail');
+//		system.debug('Got here SendEmail');
         for (Request curRequest : requests) {
             Response response = new Response();
 
@@ -60,7 +61,6 @@ public without sharing class SendHTMLEmail {
             String[] ccAddresses = BuildAddressList('CC',m); 
             String[] bccAddresses = BuildAddressList('BCC', m);
                 
-
             // Assign the addresses for the To and CC lists to the mail object.
             mail.setToAddresses(toAddresses);
             mail.setCcAddresses(ccAddresses);
@@ -99,26 +99,25 @@ public without sharing class SendHTMLEmail {
                 }
                 Response.templateUsed = TemplateId;
             }
+
             if (templateID != null && ((HTMLbody != null) || (plainTextBody != null)))
                 throw new InvocableActionException('You\'re trying to pass in both a plaintext/html body and a template ID. Gotta pick one or the other. Make sure you\'re not confusing the Text Template resources in Flow, (which you can pass into either the HTMLBody or the plainTextBody) with the templateId, which represents a Salesforce Email Template (either Classic or Lightning).');
             
             if (templateID == null  && HTMLbody == null && plainTextBody == null)
                 throw new InvocableActionException('Body text must be provided to Send HTML Email Action, either via HTMLbody, plainTextBody, or a templateId');
                 
-            if (saveAsActivity == true && recordId == null) {
+            if (saveAsActivity == true && recordId == null)
                 throw new InvocableActionException('In order to log this email send to activity history, you need to pass in a recordId');
-            }
             
             Boolean completed = true;
             String error;
             Messaging.SendEmailResult[] emailResponse;
             if (templateTargetObjectId != NULL) mail.setTargetObjectId(templateTargetObjectId);
-            System.debug('recordId is: ' + recordId);
+//            System.debug('recordId is: ' + recordId);
             if (recordId != null) {
                 mail.setWhatId(ID.valueOf(recordId));
             }
-               
-            
+
             // Specify the text content of the email.
             if (plainTextBody != NULL) mail.setPlainTextBody(plainTextBody);
             if (HTMLbody != NULL) mail.setHtmlBody(HTMLbody);
@@ -126,22 +125,26 @@ public without sharing class SendHTMLEmail {
             if (templateID != NULL){
                 try {
                     mail.setTemplateID(templateID);
+//                    system.debug('Set TemplateId: '+ templateID);
                 } catch (Exception e){
                     completed = false;
                     error = e.getMessage();
                     throw new InvocableActionException(e.getMessage());
                 }
             }
+
             // Send the email you have created.
             try {
-
+//                system.debug('About to send Email: '+ mail);
                 emailResponse = Messaging.sendEmail(new Messaging.SingleEmailMessage[]{mail});
+//                system.debug('Sent Email Successfully: '+ mail);
                 completed = true;
             } catch (Exception e){
                 completed = false;
                 error = e.getMessage();
                 throw new InvocableActionException(e.getMessage());
             }
+
             //report back the results
             if (completed) {
                 if (emailResponse[0].isSuccess() != true) {
@@ -155,7 +158,17 @@ public without sharing class SendHTMLEmail {
                 } else {
                     response.isSuccess = true;
                 }
+ 
                 if (saveAsActivity == true) {
+//                    system.debug('saveAsActivity: '+ saveAsActivity);
+                    if (templateID != null && subject == null){
+                        subject = [SELECT Subject FROM EmailTemplate WHERE Id=:templateID AND isActive = TRUE ].Subject;
+                    }
+                    if (toAddresses.size() == 0){
+                        toAddresses.add((String) (Database.query('Select Email From ' +
+                            ((Id)templateTargetObjectId).getSObjectType().getDescribe().getName() + 
+                            ' Where Id = \''+ templateTargetObjectId +'\' limit 1'))[0].get('Email'));
+                    }
                     try {
                         createActivity(recordId, subject, toAddresses + ',' + ccAddresses + ',' + bccAddresses);
                     } catch (Exception e) {
@@ -168,14 +181,9 @@ public without sharing class SendHTMLEmail {
                 response.errors = error;
                 response.isSuccess = false;
             }
-
-        responseList = new List<Response>();
-        responseList.add(response);
-    }
-
-    
-    return responseList;
-
+            responseList.add(response);
+        }
+        return responseList;
     }
 
     //credit to https://digitalflask.com/blog/send-email-attachments-salesforce-apex/
@@ -185,6 +193,7 @@ public without sharing class SendHTMLEmail {
             List<String> staticResourceNamesList = staticResourceNames.replaceAll('[^A-Z0-9]+//ig', ',').split(',');
             curAttachments.addAll([SELECT Id, Body, Name, ContentType FROM StaticResource WHERE Name IN:staticResourceNamesList]);
         }
+ 
         if (contentDocumentLinks != null && !contentDocumentLinks.isEmpty()) {
             Set<Id> cdIds = new Set<Id>();
             for (ContentDocumentLink cdl : contentDocumentLinks) {
@@ -195,7 +204,9 @@ public without sharing class SendHTMLEmail {
                 curAttachments.add(new StaticResource(Name = cv.PathOnClient, Body = cv.VersionData));
             }
         }
+
         List<Messaging.EmailFileAttachment> attachments = new List<Messaging.EmailFileAttachment>();
+
         if (curAttachments != null) {
             for (SObject file : curAttachments) {
                 Messaging.EmailFileAttachment efa = new Messaging.EmailFileAttachment();
@@ -212,12 +223,14 @@ public without sharing class SendHTMLEmail {
     public static String[] BuildAddressList(string type, Map<String, Object> m) {
         String[] addressList = new List<String>();
         String curEmail;
+
         //build address list
         //handle individual addresses
         String oneAddress = (String)m.get('Send' + type + 'thisOneEmailAddress');
         if ( oneAddress != null) {
             addressList.add(oneAddress);
         }
+
         //handle inputs involving collections of String addresses
         List<String> stringAddresses = (List<String>)m.get('Send' + type + 'thisStringCollectionOfEmailAddresses');
         if (stringAddresses != null) {
@@ -282,19 +295,24 @@ public without sharing class SendHTMLEmail {
     }
 
     private static void createActivity(Id recordId, String subject, String recipientList) {
+//        system.debug('Create Activity with subject: '+ subject +' OwnerId: '+UserInfo.getUserId());
         Task t = new Task(OwnerId = UserInfo.getUserId(),
                 Subject = 'Sent Email: ' + subject,
                 Description = 'Sent Email : ' + subject + ' to recipient(s): ' + recipientList.replaceAll('[()]|,\\(\\)+', ''),
                 Status = 'Closed',
                 Priority = 'Normal',
+				ActivityDate = Date.today(),
                 WhatId = recordId);
         insert t;
     }
+
     private static String getTemplateIdFromName(String templateName, String templateLanguage){
         String retTemplateId;
         String blankTemplate;
         List<EmailTemplate> et = [SELECT Id,Description FROM EmailTemplate WHERE Name=:templateName AND isActive = TRUE];
-        system.debug('TemplateNames: '+ et);
+
+//        system.debug('TemplateNames: '+ et);
+
         if (et.size() > 0){
             String localeKey = [Select LanguageLocaleKey From Organization Limit 1].LanguageLocaleKey;
             if (templateLanguage == NULL) templateLanguage = [Select LanguageLocaleKey From Organization limit 1].LanguageLocaleKey;
@@ -380,11 +398,11 @@ public without sharing class SendHTMLEmail {
         public List<Lead> SendBCCtheEmailAddressesFromThisCollectionOfLeads;
         
         /*
-        Static resources do not store file extensions, thus email attachments will have file names without extensions,
-        which is inconvenient for an end user. Disabling this option for now.
-        Possible workarounds:
-        1. Specify full file name in Description of static resource
-        2. Let the user pass file names together with static resource names
+            Static resources do not store file extensions, thus email attachments will have file names without extensions,
+            which is inconvenient for an end user. Disabling this option for now.
+            Possible workarounds:
+            1. Specify full file name in Description of static resource
+            2. Let the user pass file names together with static resource names
          */
 //        @invocableVariable
 //        public String staticResourceAttachmentNames;

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
@@ -20,7 +20,7 @@ public with sharing class SendHTMLEmailTest {
     Inversely, not doing these tests can cause code coverage % failures.  For pre-deployment testing purposes, TEST_WITH_CREATED_RECORDS should be set to true,
     but for version release, should be set to false.
 **/
-    private Static Final Boolean TEST_WITH_CREATED_RECORDS = true;
+    private Static Final Boolean TEST_WITH_CREATED_RECORDS = false;
 //
     private Static Final String TEMPLATE_NAME = 'xxxyyy Test Email Template yyyxxx';
     private Static Final String TEMPLATE_DEVNAME = 'xxxyyy_Test_Email_Template_yyyxxx';

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
@@ -9,7 +9,8 @@
  * @Modification Log   : 
  * @License            : LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * Ver       Date            Author      		    Modification
- * 1.32    2/5/2020   jack.pond@psitex.com     Updated Versioning
+ * 1.32    2/05/2020   jack.pond@psitex.com     Updated Versioning
+ * 1.33.1  4/11/2020   jack.pond@psitex.com     Added tests for Issues 308,316
 **/
 @isTest
 public with sharing class SendHTMLEmailTest {
@@ -19,7 +20,7 @@ public with sharing class SendHTMLEmailTest {
     Inversely, not doing these tests can cause code coverage % failures.  For pre-deployment testing purposes, TEST_WITH_CREATED_RECORDS should be set to true,
     but for version release, should be set to false.
 **/
-    private Static Final Boolean TEST_WITH_CREATED_RECORDS = false;
+    private Static Final Boolean TEST_WITH_CREATED_RECORDS = true;
 //
     private Static Final String TEMPLATE_NAME = 'xxxyyy Test Email Template yyyxxx';
     private Static Final String TEMPLATE_DEVNAME = 'xxxyyy_Test_Email_Template_yyyxxx';
@@ -39,12 +40,14 @@ public with sharing class SendHTMLEmailTest {
             Name = TEMPLATE_NAME,
             DeveloperName = TEMPLATE_DEVNAME,
             TemplateType = 'custom',
-    		// UIType = 2,
-    		// RelatedEntityType = 'Case',
             Description = 'Test Email Template - No Language Specified',
             FolderId = UserInfo.getUserId(),
             Subject = 'Test Email Template'
         );
+        if (TEST_WITH_CREATED_RECORDS){
+            validEmailTemplate.UIType = 'SFX';
+            validEmailTemplate.RelatedEntityType = 'Account';
+        }
         insert validEmailTemplate;
 
         validEmailTemplate = new EmailTemplate(
@@ -52,12 +55,14 @@ public with sharing class SendHTMLEmailTest {
             Name = TEMPLATE_NAME,
             DeveloperName = TEMPLATE_DEVNAME+'_'+TEMPLATE_LANGUAGE,
             TemplateType = 'custom',
-    		// UIType = 2,
-    		// RelatedEntityType = 'Case',
             Description = 'Test Email Template - Language Specified (Language="'+TEMPLATE_LANGUAGE+'")',
             FolderId = UserInfo.getUserId(),
             Subject = 'Test Email Template - Language'
         );
+        if (TEST_WITH_CREATED_RECORDS){
+            validEmailTemplate.UIType = 'SFX';
+            validEmailTemplate.RelatedEntityType = 'Account';
+        }
         insert validEmailTemplate;
     }
 // Check to see if email is deliverable (enabled and capacity not exceeded)    
@@ -123,17 +128,16 @@ public with sharing class SendHTMLEmailTest {
     }
 
 //	Create a contact to test email field merge (recipient && relatedTo[WhichId,relatedId])
-    private static List<Case> emailCreateTestCases(integer howMany, ID relatedContactId){
-        List<Case> caseList = new List<Case>();
+    private static List<Account> emailCreateTestAccount(integer howMany, ID relatedContactId){
+        List<Account> accountList = new List<Account>();
         for (Integer i = 0; i < howMany; i++){
-            caseList.add(new Case(
-                    Subject    	= 'Test Case '+ ('0000'+i).right(4),
-                	ContactId	= relatedContactId
+            accountList.add(new Account(
+                    Name    	= 'Test Account '+ ('0000'+i).right(4)	
                 )
             );
         }
-        insert caseList;
-        return caseList;
+        insert AccountList;
+        return AccountList;
     }
 
     
@@ -311,7 +315,7 @@ public with sharing class SendHTMLEmailTest {
         if (TEST_WITH_CREATED_RECORDS){
             List<Contact>sendToContactCollection = emailCreateTestContacts(TEST_CONTACTS_COUNT);
 			testReq.templateTargetObjectId = sendToContactCollection[0].Id;
-        	testReq.recordId = emailCreateTestCases(1,testReq.templateTargetObjectId)[0].Id;
+        	testReq.recordId = emailCreateTestAccount(1,testReq.templateTargetObjectId)[0].Id;
 			// also do code coverage test for sentTo Contact Collection
             List<Id> theseIds = new List<Id>();
             for (Contact thisContact : sendToContactCollection) theseIds.Add(thisContact.Id);
@@ -362,7 +366,7 @@ public with sharing class SendHTMLEmailTest {
         testReq.recordId = validEmailTemplate.Id;
         if (TEST_WITH_CREATED_RECORDS){
 			testReq.templateTargetObjectId = emailCreateTestContacts(TEST_CONTACTS_COUNT)[0].Id;
-        	testReq.recordId = emailCreateTestCases(1,testReq.templateTargetObjectId)[0].Id;
+        	testReq.recordId = emailCreateTestAccount(1,testReq.templateTargetObjectId)[0].Id;
         	testReq.saveAsActivity = true;
         }else{
         	testReq.templateTargetObjectId = UserInfo.getUserId();
@@ -459,7 +463,7 @@ public with sharing class SendHTMLEmailTest {
             List<SendHTMLEmail.Response> testResponseList = SendHTMLEmail.SendEmail(reqList);
         } catch (SendHTMLEmail.InvocableActionException e) {
             exceptionHit=true;
-            system.debug('t011_ErrorIfNoBody: '+e.getMessage());
+            system.debug('t012_ErrorIfSaveAsActivityAndNoRecordId: '+e.getMessage());
         }
 	    
         Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
@@ -467,6 +471,41 @@ public with sharing class SendHTMLEmailTest {
             System.assertEquals(exceptionHit,true,'Error not received when (saveAsActivity == true && recordId/whatId == null)');
         } else {
             System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityDisabled Enabled or capacity exceeded');
+        }
+    }
+// @Test t013_CoverageAttemptForOrgWideEmailAddress : Error expected if (saveAsActivity == true && recordId/whatId == null)
+    @isTest
+    public static void t013_ErrorIfSaveAsActivityAndNoRecordId() {
+        List<SendHTMLEmail.Request> reqList = new List<SendHTMLEmail.Request>();
+        for (OrgWideEmailAddress orgAddrs : [SELECT id, DisplayName, Address FROM OrgWideEmailAddress]){
+        	SendHTMLEmail.Request testReq = new SendHTMLEmail.Request();
+            testReq.Subject = EMAIL_SUBJECT;
+            testReq.HTMLbody = EMAIL_BODY;
+            testReq.SendTOthisOneEmailAddress = EMAIL_NOSUCH;
+            testReq.orgWideEmailAddressId = orgAddrs.Id;
+            reqList.add(testReq);
+    	}
+        if (reqList.size() > 0){
+            Boolean exceptionHit = false;
+            List<SendHTMLEmail.Response> testResponseList = new List<SendHTMLEmail.Response>();
+            try {            
+                testResponseList = SendHTMLEmail.SendEmail(reqList);
+            } catch (SendHTMLEmail.InvocableActionException e) {
+                exceptionHit=true;
+                system.debug('t013_CoverageAttemptForOrgWideEmailAddress: '+e.getMessage());
+            }
+            
+            Boolean emailDeliverabilityEnabled = emailDeliverabilityEnabled();
+            if(emailDeliverabilityEnabled){
+                for(SendHTMLEmail.Response thisTest : testResponseList){
+                    system.debug('t013_CoverageAttemptForOrgWideEmailAddress Response:' + thisTest.isSuccess + ' Template Errors: ' + thisTest.errors + ' Template Used: '+ thisTest.templateUsed);
+                }
+//                System.assertEquals(exceptionHit,false,'Error on orgWideEmailAddressId');
+            } else {
+                System.assertEquals(emailDeliverabilityEnabled,false,'emailDeliverabilityDisabled Enabled or capacity exceeded');
+            }
+        } else {
+            System.Debug('Unable to test orgWideEmailAddressId.  No orgWideEmailAddress available.');
         }
     }
 }

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/flows/Send_HTML_Email_Testflow.flow-meta.xml
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/flows/Send_HTML_Email_Testflow.flow-meta.xml
@@ -189,7 +189,7 @@
         <inputParameters>
             <name>saveAsActivity</name>
             <value>
-                <booleanValue>false</booleanValue>
+                <booleanValue>true</booleanValue>
             </value>
         </inputParameters>
         <inputParameters>
@@ -251,7 +251,7 @@
         <inputParameters>
             <name>saveAsActivity</name>
             <value>
-                <booleanValue>false</booleanValue>
+                <booleanValue>true</booleanValue>
             </value>
         </inputParameters>
         <inputParameters>
@@ -863,7 +863,7 @@
         </connector>
         <fields>
             <name>Example3Details</name>
-            <fieldText>&lt;p&gt;For this example, you will need to create or use a record to which attachments can be made (e.g.,  a Contact).  Create the record and then use the recordId of that record to attach files.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This sends out a simple plaintext email with attachments from uploaded files to the addressee in [Recipient Email Address] from [ReplyTo Email Address] with the name [Sender Name] using [Subject] and [Body]&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;All of the above can be created by assigning variables.  To create a body with line breaks, use a formula variable (see example variable testPlainTextLineFeeds)&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Note&lt;/b&gt;:  This example as distributed uses the formula variable &quot;&lt;span style=&quot;background-color: rgb(243, 242, 242); color: rgb(0, 109, 204);&quot;&gt;testPlainTextLineFeeds&lt;/span&gt;&quot; to create a plain text body without signature&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;For this example, you will need to create or use a record to which attachments can be made (e.g.,  a Contact).  Create the record and then use the recordId of that record to attach files.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This sends out a simple plaintext email with attachments from uploaded files to the addressee in [Recipient Email Address] from [ReplyTo Email Address] with the name [Sender Name] using [Subject] and [Body]&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;All of the above can be created by assigning variables.  To create a body with line breaks, use a formula variable (see example variable testPlainTextLineFeeds)&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;It also creates a task (completed) that shows the email has been sent (saveAsActivity)&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;b&gt;Note&lt;/b&gt;:  This example as distributed uses the formula variable &quot;&lt;span style=&quot;color: rgb(0, 109, 204); background-color: rgb(243, 242, 242);&quot;&gt;testPlainTextLineFeeds&lt;/span&gt;&quot; to create a plain text body without signature&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>
@@ -1306,8 +1306,8 @@
     <screens>
         <name>X4_Email_Using_Template</name>
         <label>4. Email Using Template</label>
-        <locationX>259</locationX>
-        <locationY>961</locationY>
+        <locationX>260</locationX>
+        <locationY>960</locationY>
         <allowBack>false</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -1316,7 +1316,7 @@
         </connector>
         <fields>
             <name>Example4Details</name>
-            <fieldText>&lt;p&gt;This sends out an email using a specified EmailTemplate with the addressee specified through the TargetObjectId and optionally (dependent on your Template) merge fields with an associated object record using that record&#39;s Id.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;For this example, you will need to create or use a template.  Templates also require that you have a recipient record (targetObjectId) (e.g., Contact, User, . . .) which must also pre-exist.  You will be required enter the ID for that record as the  &lt;span style=&quot;background-color: rgb(255, 255, 255); color: rgb(62, 62, 60);&quot;&gt; (targetObjectId).  Additionally if you intend to test merge fields (RelatedTo) with your template, you must also pre-create the related object record and have available the Id for that record as an ID for the Record Object Id (RecordId).&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;This sends out an email using a specified EmailTemplate with the addressee specified through the TargetObjectId and optionally (dependent on your Template) merge fields with an associated object record using that record&#39;s Id.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;For this example, you will need to create or use a template.  Templates also require that you have a recipient record (targetObjectId) (e.g., Contact, User, . . .) which must also pre-exist.  You will be required enter the ID for that record as the  &lt;span style=&quot;color: rgb(62, 62, 60); background-color: rgb(255, 255, 255);&quot;&gt; (targetObjectId).  Additionally if you intend to test merge fields (RelatedTo) with your template, you must also pre-create the related object record and have available the Id for that record as an ID for the Record Object Id (RecordId).&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;color: rgb(62, 62, 60); background-color: rgb(255, 255, 255);&quot;&gt;This example also creates an activity for the email which will be assigned to the running user and related to the RecordId.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;You can create test templates (sendHTMLEmailTest)  by running example 5.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;If you use the default test templates (&lt;span style=&quot;background-color: rgb(255, 255, 255); color: rgb(62, 62, 60);&quot;&gt;sendHTMLEmailTest) the Target ID should be a ContactId and the Related Record should be an AccountID.&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>
@@ -1331,7 +1331,7 @@
             <dataType>String</dataType>
             <fieldText>Template Target Record Id</fieldText>
             <fieldType>InputField</fieldType>
-            <helpText>&lt;p&gt;This must be an existing record of a type that allows File Attachments.&lt;/p&gt;</helpText>
+            <helpText>&lt;p&gt;This must be an existing record.  If you are using the default test templates (sendHTMLEmailTest), it should be a ContactId&lt;/p&gt;</helpText>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -1339,6 +1339,7 @@
             <dataType>String</dataType>
             <fieldText>Related Record Id (for testing merge fields)</fieldText>
             <fieldType>InputField</fieldType>
+            <helpText>&lt;p&gt;&lt;span style=&quot;background-color: rgb(255, 255, 255); color: rgb(62, 62, 60);&quot;&gt;This must be an existing record of a type that allows File Attachments.  If you are using the default test templates (sendHTMLEmailTest), it should be an AccountId&lt;/span&gt;&lt;/p&gt;</helpText>
             <isRequired>false</isRequired>
         </fields>
         <fields>
@@ -1408,7 +1409,7 @@
         </connector>
         <fields>
             <name>Example5Details</name>
-            <fieldText>&lt;p&gt;SendHTMLEmail provides multi-lingual support within the same flow by allowing the language to be specified, then selecting the appropriate template for that language.&amp;nbsp;For this functionality, each language localization has its own template with all localizations sharing a common EmailTemplate.Name. To differentiate the localizations, add a tag to the EmailTemplate.Description field in the format: ‘Language=”en_US”‘ (or whatever corresponding to your organization localizations)&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This example uses the template set sendHTMLTest with english (en_US) and spanish (es_MX) versions.  If the templates do not exist, this example will automatically create them for you (sendHTMLEmailTest).&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;You will also need to:&lt;/p&gt;&lt;p&gt;1) Create a Contact (for Target Object) and have its Id available.&lt;/p&gt;&lt;p&gt;2) Create an Account (for Related Record) and have its Id available.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;You can, of course, vary the templates and object records to reflect your organization&#39;s needs.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This sends out an email using a specified EmailTemplate with the addressee specified through the TargetObjectId and optionally (dependent on your Template) merge fields with an associated object record using that record&#39;s Id.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;For this example, you will need to create or use one or more templates.  Templates also require that you have a recipient record (targetObjectId) (e.g., Contact, User, . . .) which must also pre-exist.  You will be required enter the ID for that record as the  &lt;span style=&quot;background-color: rgb(255, 255, 255); color: rgb(62, 62, 60);&quot;&gt; (targetObjectId).  Additionally if you intend to test merge fields (RelatedTo) with your template, you must also pre-create the related object record and have available the Id for that record as an ID for the Record Object Id (RecordId).&lt;/span&gt;&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;SendHTMLEmail provides multi-lingual support within the same flow by allowing the language to be specified, then selecting the appropriate template for that language.&amp;nbsp;For this functionality, each language localization has its own template with all localizations sharing a common EmailTemplate.Name. To differentiate the localizations, add a tag to the EmailTemplate.Description field in the format: ‘Language=”en_US”‘ (or whatever corresponding to your organization localizations)&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This example uses the template set sendHTMLTest with english (en_US) and spanish (es_MX) versions.  If the templates do not exist, this example will automatically create them for you (sendHTMLEmailTest).&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;You will also need to:&lt;/p&gt;&lt;p&gt;1) Create a Contact (for Target Object) and have its Id available.&lt;/p&gt;&lt;p&gt;2) Create an Account (for Related Record) and have its Id available.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;You can, of course, vary the templates and object records to reflect your organization&#39;s needs.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;This sends out an email using a specified EmailTemplate with the addressee specified through the TargetObjectId and optionally (dependent on your Template) merge fields with an associated object record using that record&#39;s Id.&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;For this example, you will need to create or use one or more templates.  Templates also require that you have a recipient record (targetObjectId) (e.g., Contact, User, . . .) which must also pre-exist.  You will be required enter the ID for that record as the  &lt;span style=&quot;color: rgb(62, 62, 60); background-color: rgb(255, 255, 255);&quot;&gt; (targetObjectId).  Additionally if you intend to test merge fields (RelatedTo) with your template, you must also pre-create the related object record and have available the Id for that record as an ID for the Record Object Id (RecordId).&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot;color: rgb(62, 62, 60); background-color: rgb(255, 255, 255);&quot;&gt;&lt;span class=&quot;ql-cursor&quot;&gt;﻿&lt;/span&gt;If you use the default test templates (sendHTMLEmailTest) the Target ID should be a ContactId and the Related Record should be an AccountID.&lt;/span&gt;&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <fields>
@@ -1438,7 +1439,7 @@
             <dataType>String</dataType>
             <fieldText>Template Target Record Id</fieldText>
             <fieldType>InputField</fieldType>
-            <helpText>&lt;p&gt;This must be an existing record of a type that allows File Attachments.&lt;/p&gt;</helpText>
+            <helpText>&lt;p&gt;This must be an existing record.  If you are using the default test Template set (sendHTMLEmailTest), this should be a ContactId.&lt;/p&gt;</helpText>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -1446,6 +1447,7 @@
             <dataType>String</dataType>
             <fieldText>Related Record Id (for testing merge fields)</fieldText>
             <fieldType>InputField</fieldType>
+            <helpText>&lt;p&gt;&lt;span style=&quot;background-color: rgb(255, 255, 255); color: rgb(62, 62, 60);&quot;&gt;This must be an existing record.  If you are using the default test Template set (sendHTMLEmailTest), this should be a AccountId.&lt;/span&gt;&lt;/p&gt;</helpText>
             <isRequired>false</isRequired>
         </fields>
         <fields>
@@ -1514,7 +1516,7 @@
         <description>sendHTMLEmail Test - Create Test Templates if Needed</description>
         <name>Create_Test_Templates_if_Needed_5</name>
         <label>Create Test Templates if Needed</label>
-        <locationX>634</locationX>
+        <locationX>633</locationX>
         <locationY>1085</locationY>
         <connector>
             <targetReference>X5_Multi_Lingual_Using_Email_Templates_Action</targetReference>

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -9,16 +9,16 @@
         },
         {
             "path": "force-app",
-            "package": "sendHTMLEmail",
-            "versionName": "ver 1.33",
-            "versionNumber": "1.33.0.NEXT",
+            "package": "sendHTMLEmail(No Tests)",
+            "versionName": "ver 1.33.01",
+            "versionNumber": "1.33.1.NEXT",
             "default": false
         },
         {
             "path": "force-app",
-            "package": "sendHTMLEmail(With Tests)",
-            "versionName": "ver 1.33",
-            "versionNumber": "1.33.0.NEXT",
+            "package": "sendHTMLEmail",
+            "versionName": "ver 1.33.01",
+            "versionNumber": "1.33.1.NEXT",
             "default": false
         }
     ],

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -2,7 +2,7 @@
     "packageDirectories": [
         {
             "path": "force-app",
-            "default": true,
+            "default": false,
             "package": "SendHTMLEmailPrA",
             "versionName": "ver 0.1",
             "versionNumber": "0.1.0.NEXT"
@@ -19,7 +19,7 @@
             "package": "sendHTMLEmail",
             "versionName": "ver 1.33.01",
             "versionNumber": "1.33.01.NEXT",
-            "default": false
+            "default": true
         }
     ],
     "namespace": "",
@@ -31,6 +31,8 @@
         "SendHTMLEmailPrA@0.1.0-2": "04tB0000000ORBxIAO",
         "sendHTMLEmail": "0Ho3h000000Gmb2CAC",
         "sendHTMLEmail(No Tests)": "0Ho3h000000GmbCCAS",
-        "sendHTMLEmail@1.33.1-0": "04t3h000002Ne4QAAS"
+        "sendHTMLEmail(Without Examples)": "0Ho3h0000008OTFCA2",
+        "sendHTMLEmail@1.33.1-0": "04t3h000002Ne4QAAS",
+        "sendHTMLEmail(Without Examples)@1.33.1-0": "04t3h000002Ne4kAAC"
     }
 }

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -9,16 +9,16 @@
         },
         {
             "path": "force-app",
-            "package": "sendHTMLEmail(No Tests)",
+            "package": "sendHTMLEmail(Without Examples)",
             "versionName": "ver 1.33.01",
-            "versionNumber": "1.33.1.NEXT",
+            "versionNumber": "1.33.01.NEXT",
             "default": false
         },
         {
             "path": "force-app",
             "package": "sendHTMLEmail",
             "versionName": "ver 1.33.01",
-            "versionNumber": "1.33.1.NEXT",
+            "versionNumber": "1.33.01.NEXT",
             "default": false
         }
     ],
@@ -29,13 +29,8 @@
         "SendHTMLEmailPrA": "0HoB0000000CavEKAS",
         "SendHTMLEmailPrA@0.1.0-1": "04tB0000000OE9cIAG",
         "SendHTMLEmailPrA@0.1.0-2": "04tB0000000ORBxIAO",
-        "SendHTMLEmail@0.1.0-1": "04tB0000000Awk2IAC",
-        "sendHTMLEmail": "0Ho0P000000GmadSAC",
-        "sendHTMLEmail@0.1.0-1": "04t0P000000TUsXQAW",
-        "sendHTMLEmail@1.3.0-1": "04t0P000000TUscQAG",
-        "sendHTMLEmail@1.33.0-1": "04t0P000000TUshQAG",
-        "sendHTMLEmail(With Tests)": "0Ho0P000000GmadSAC",
-        "sendHTMLEmail@1.33.0-2": "04t0P000000TUsrQAG",
-        "sendHTMLEmail@1.33.0-0": "04t0P000000TUswQAG"
+        "sendHTMLEmail": "0Ho3h000000Gmb2CAC",
+        "sendHTMLEmail(No Tests)": "0Ho3h000000GmbCCAS",
+        "sendHTMLEmail@1.33.1-0": "04t3h000002Ne4QAAS"
     }
 }


### PR DESCRIPTION
1.	Add STRONG Documentation/Release notification that saveAsActivity is now default to false. Emails previously saved as activities without explicitly using saveAsActivity = true will stop
2.	Default saveAsActivity now set to false
3.	Activities created with Templates now have subject and recipients in Task Comments
4.	Added Activity Date (Today) to Task Activity
5.	Update Documentation with new example flow information
6.	Changed the test to use Account versus Case for full test
7.	Added @Test t013_CoverageAttemptForOrgWideEmailAddress
8. 	Updated package name that does not contain the examples to "sendHTMLEmail(Without Examples)"
9.	Create and maintain a managed package(2, one for with test, one without) for this component

SendHTMLEmailTest test results:
78% with TEST_WITH_CREATED_RECORDS = false (released value)
92% with TEST_WITH_CREATED_RECORDS = true (test prior to released value)