### PR TITLE
Quick choice fsc v1.4

### DIFF
--- a/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.html
+++ b/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.html
@@ -16,6 +16,14 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObject
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
+4/19/20 -   Eric Smith -    Version 1.4
+                            Added help text for all configuration attributes to make this component easier to use
+                            Fixed a bug where only the last selected visual card would display a check when multiple Quick Choice components were on the same screen
+
+4/16/20 -   unofficialsf -  Version 1.3
+                            The test class utility MockHTTPResponseGenerator was renamed to eliminate conflicts with existing installations that use this utility
+                            New Output Attributes: allValues and allLabels
+                            New Output Attribute: selectedLabel
 
 3/2/20 -    Eric Smith -    Version 1.27
                             Added ability to display both images & icons on visual cards
@@ -45,7 +53,7 @@ Additional components packaged with this LWC:
             <div class={gridClass} style={gridStyle}>
                 <template for:each={items} for:item="item">
                     <div key={item.name} class={columnClass}>
-                        <input type="radio" id={item.name} value={item.name} name="visualList" data-id={item.name} onclick={handleChange} />
+                        <input type="radio" id={item.name} value={item.name} name={masterLabel} data-id={item.name} onclick={handleChange} />
                         <label for={item.name}>
 
                             <!-- Display Visual Card Pickers with Icons-->

--- a/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js
+++ b/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js
@@ -270,11 +270,13 @@ export default class SmartChoiceFSC extends LightningElement {
 	}
 
 	handleChange(event) {
+console.log('EVENT',event);
 		this.selectedValue = (this.showVisual) ? event.target.value : event.detail.value;
 		console.log("selected value is: " + this.selectedValue);
 		this.dispatchFlowAttributeChangedEvent('value', this.selectedValue);
 
 	}
+
 	setSelectedLabel(){
 		if(this.options && this.options.length){
 			let selectedOption = this.options.find(curOption=>curOption.value === this.selectedValue);

--- a/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js-meta.xml
+++ b/flow_screen_components/quickChoiceFSCproject/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js-meta.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>48.0</apiVersion>
     <isExposed>true</isExposed>
-    <masterLabel>Quick Choice FSC</masterLabel>
+    <masterLabel>Quick Choice FSC v1.4</masterLabel>
     <targets>
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
-            <property name="value" label="Value" type="String"/>
-            <property name="selectedLabel" label="Selected Label" type="String" role="outputOnly"/>
-            <property name="allValues" label="All Values" type="String[]" role="outputOnly"/>
-            <property name="allLabels" label="All Labels" type="String[]" role="outputOnly"/>
-            <property name="choiceValues" label="Choice Values (String Collection)" type="String[]"/>
-            <property name="choiceLabels" label="Choice Labels (String Collection)" type="String[]"/>
-            <property name="choiceIcons" label="Card Mode - Choice Icons (String Collection)" type="String[]"/>
-            <property name="includeIcons" label="Card Mode - Include Icons in Display Box?" type="Boolean"/>
-            <property name="iconSize" label="Card Mode - Icon Size" type="String"/>
-            <property name="numberOfColumns" label="Card Mode - Number of Display Box Columns (1 or 2)" type="String"/>
-            <property name="inputMode" label="Input Mode" type="String"/>
-            <property name="masterLabel" label="Master Label" type="String"/>
-            <property name="required" label="Required" type="Boolean" default="false"/>
-            <property name="displayMode" label="Display Mode" type="String"/>
-            <property name="recordTypeId" label="Record Type Id" type="String"/>
-            <property name="objectName" label="Object Name" type="String"/>
-            <property name="fieldName" label="Field Name" type="String"/>
-            <property name="allowNoneToBeChosen" label="Allow 'None' to be Chosen" type="Boolean"/>
-            <property name="style_width" label="Set Width in Pixels" type="Integer"/>
+            <property name="value" label="Value" type="String" description="The selected value(Output). This can be passed into QuickChoice, allowing you to set the default value dynamically(Input)."/>
+            <property name="selectedLabel" label="Selected Label" type="String" role="outputOnly" description="The selected Label (V1.3+)"/>
+            <property name="allValues" label="All Values" type="String[]" role="outputOnly" description="The complete set of values provided to the user. (V1.3+)"/>
+            <property name="allLabels" label="All Labels" type="String[]" role="outputOnly" description="The complete set of labels provided to the user (V1.3+)"/>
+            <property name="choiceValues" label="Choice Values (String Collection)" type="String[]" description="The values of your choices (should be unique) - The selected Value will be returned by the component - Extra descriptive text on visual cards"/>
+            <property name="choiceLabels" label="Choice Labels (String Collection)" type="String[]" description="The labels of your choices"/>
+            <property name="choiceIcons" label="Card Mode - Choice Icons (String Collection)" type="String[]" description="Icon names or image names"/>
+            <property name="includeIcons" label="Card Mode - Include Icons in Display Box?" type="Boolean" description="Display the provided icons in the visual card when set to True"/>
+            <property name="iconSize" label="Card Mode - Icon Size" type="String" description="Options include x-small, small, medium, or large. This value defaults to medium."/>
+            <property name="numberOfColumns" label="Card Mode - Number of Display Box Columns (1 or 2)" type="String" description="1 or blank (default) for a single column or 2 for dual columns"/>
+            <property name="inputMode" label="Input Mode" type="String" description="“Single String Collection”, “Dual String Collections”, “Picklist Field”, or ” Visual Text Box ” are currently supported"/>
+            <property name="masterLabel" label="Master Label" type="String" description="The main label for the picklist or radio button group"/>
+            <property name="required" label="Required" type="Boolean" default="false" description="Will prevent transition if set to {!$GlobalConstant.True}"/>
+            <property name="displayMode" label="Display Mode" type="String" description="Either “Visual”, “Picklist” or “Radio”, depending on which control you want"/>
+            <property name="recordTypeId" label="Record Type Id" type="String" description="Record Type Id (for Picklist Field)"/>
+            <property name="objectName" label="Object Name" type="String" description="Object Name (for Picklist Field)"/>
+            <property name="fieldName" label="Field Name" type="String" description="Field Name (for Picklist Field)"/>
+            <property name="allowNoneToBeChosen" label="Allow 'None' to be Chosen" type="Boolean" description="Set this to true to include a None choice. (For Input Mode “Picklist Field” only)"/>
+            <property name="style_width" label="Set Width in Pixels" type="Integer" description="Set the width of the component for Picklist and Radio Buttons (Default 320 pixels)"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
Added help text for all configuration attributes to make this component easier to use

Fixed a bug where only the last selected visual card would display a check when multiple Quick Choice components were on the same screen