### PR TITLE
Bulkify ExecuteSOQL and GetLayoutFields actions

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -4,12 +4,15 @@ public with sharing class ExecuteSOQL {
 
         Results results = new Results();
         List<Results> responseWrapper = new List<Results>();
-        String soqlQuery = requestList[0].soqlQuery;
-        soqlQuery = replaceWithFormattedValues(soqlQuery);
-        results.sObjects = Database.query(soqlQuery);
+        
+        for (Requests req : requestList) {
+            String soqlQuery = req.soqlQuery;
+            soqlQuery = replaceWithFormattedValues(soqlQuery);
+            results.sObjects = Database.query(soqlQuery);
 
 
-        responseWrapper.add(results);
+            responseWrapper.add(results);
+        }
         return responseWrapper;
     }
 

--- a/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
+++ b/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
@@ -6,33 +6,36 @@ public with sharing class GetLayoutFields {
     @InvocableMethod
     public static List <Results> get(List<Requests> requestList) {
         Results response = new Results();
-        String layoutName = requestList[0].layoutName;
-        String objectName = requestList[0].objectName;
-        String layoutFieldsCSV = '';
+        List<Results> responseWrapper = new List<Results>();
+        
+        for (Requests req : requestList) {
+            String layoutName = req.layoutName;
+            String objectName = req.objectName;
+            String layoutFieldsCSV = '';
 
-        layoutName = objectName + '-' + layoutName;
-        List<Metadata.Metadata> layouts = 
-            Metadata.Operations.retrieve(Metadata.MetadataType.Layout, 
-                                        new List<String> {layoutName});
+            layoutName = objectName + '-' + layoutName;
+            List<Metadata.Metadata> layouts = 
+                Metadata.Operations.retrieve(Metadata.MetadataType.Layout, 
+                                            new List<String> {layoutName});
 
-        Metadata.Layout layoutMd = (Metadata.Layout)layouts.get(0);
+            Metadata.Layout layoutMd = (Metadata.Layout)layouts.get(0);
 
-        for (Metadata.LayoutSection section : layoutMd.layoutSections) {
-            for (Metadata.LayoutColumn column : section.layoutColumns) {
-                if (column.layoutItems != null) {
-                    for (Metadata.LayoutItem item : column.layoutItems) {
-                            layoutFieldsCSV = layoutFieldsCSV + ',' +item.field;
-                        
-                            
+            for (Metadata.LayoutSection section : layoutMd.layoutSections) {
+                for (Metadata.LayoutColumn column : section.layoutColumns) {
+                    if (column.layoutItems != null) {
+                        for (Metadata.LayoutItem item : column.layoutItems) {
+                                layoutFieldsCSV = layoutFieldsCSV + ',' +item.field;
+
+
+                        }
                     }
                 }
             }
+
+
+            response.layoutFieldsCSV = layoutFieldsCSV;
+            responseWrapper.add(response);
         }
-
-
-        response.layoutFieldsCSV = layoutFieldsCSV;
-        List<Results> responseWrapper = new List<Results>();
-        responseWrapper.add(response);
         return responseWrapper;
 
 


### PR DESCRIPTION
When this component is executed in multiple flow interviews during a single transaction, it should iterate through the requestList instead of only acting on the first item. This solves the "The number of results does not match the number of interviews that were executed in a single bulk execution request." error