### PR TITLE
Revert "Revert "MODIFY: Fix Regex Search in ExecuteSOQL to Handle Nested Queries""

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -15,7 +15,7 @@ public with sharing class ExecuteSOQL {
     public static String replaceWithFormattedValues(String soqlQuery) {
         String endingClause = '';
         soqlQuery = soqlQuery.toLowerCase().replaceAll('\r\n|\n|\r|\t',' ');
-        List<String> clausesToRemove = new List<String>{' order by ', ' limit '};
+        List<String> clausesToRemove = new List<String>{' order by ', ' limit ', ' group by ', ' offset ' };
         for (String curClause : clausesToRemove) {
             if (soqlQuery.contains(curClause)) {
                 endingClause = curClause + soqlQuery.substringAfter(curClause);

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -78,7 +78,7 @@ public with sharing class ExecuteSOQL {
         	}
             return resultMap; 
         } else {
-            throw new ExecuteSOQLException('Unable to get sObject Type for name: '+ cleanObjectName);
+            throw new ExecuteSOQLException('Unable to get sObject Type for name: '+ sObjectTypeName);
         }
     }
     public static String putFormattedValues(String query, Map<String, String> fieldNameValueMap, Map<String, String> fieldTypes) {

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -1,26 +1,19 @@
 public with sharing class ExecuteSOQL {
+    class ExecuteSOQLException extends Exception {}
     @InvocableMethod
     public static List <Results> getEligibleProducts(List<Requests> requestList) {
-
         Results results = new Results();
         List<Results> responseWrapper = new List<Results>();
-
         for(Requests curRequest : requestList) {
-
             String soqlQuery = curRequest.soqlQuery;
             soqlQuery = replaceWithFormattedValues(soqlQuery);
             results.sObjects = Database.query(soqlQuery);
-    
-    
             responseWrapper.add(results);
-            
         }
         return responseWrapper;
-       
     }
-
     public static String replaceWithFormattedValues(String soqlQuery) {
-        soqlQuery = soqlQuery.toLowerCase();
+        soqlQuery = soqlQuery.toLowerCase().replaceAll('\r\n|\n|\r|\t',' ');
         List<String> clausesToRemove = new List<String>{
                 ' order by ', ' limit '
         };
@@ -29,53 +22,66 @@ public with sharing class ExecuteSOQL {
                 soqlQuery = soqlQuery.substring(0, soqlQuery.indexOf(curClause));
             }
         }
-
         if (soqlQuery != null && soqlQuery.contains(' from ') && soqlQuery.contains('select ') && soqlQuery.contains(' where ')) {
-            Pattern mPattern = pattern.compile('(?<=from )(.*)(?= where)');
+            Pattern mPattern = pattern.compile('(?<=from )(.*)(?= where .+(\\(select .+\\)))');
             Matcher mMatcher = mPattern.matcher(soqlQuery);
-            mMatcher.find();
-            String sObjectType = mMatcher.group(0);
+            Boolean found = mMatcher.find();
+            String sObjectType = '';
+            if (found) {
+                sObjectType = mMatcher.group(0);
+                // Recurse through sub-queries
+                Pattern subPattern = pattern.compile('\\(select .+\\)');
+                Matcher subMatcher = subPattern.matcher(soqlQuery);
+                while (subMatcher.find()) {
+                    String subQuery = subMatcher.group(0).removeStart('(').removeEnd(')');
+                    String formattedSubQuery = replaceWithFormattedValues(subQuery);
+                   	soqlQuery = soqlQuery.replace(subQuery, formattedSubQuery);
+                }
+            } else {
+                mPattern = pattern.compile('(?<=from )(.*)(?= where)');            
+                mMatcher = mPattern.matcher(soqlQuery);
+                if (mMatcher.find()) {
+                    sObjectType = mMatcher.group(0);
+                } else {
+                    throw new ExecuteSOQLException('Unable to parse query string: ' + soqlQuery);
+                }
+            }
             Map<String, String> fieldNameValueMap = new Map<String, String>();
             List<String> fieldNames = new List<String>();
-
             mPattern = pattern.compile('(?<=where )(.*)');
             mMatcher = mPattern.matcher(soqlQuery);
             while (mMatcher.find()) {
-                String whereClause = mMatcher.group(0);
-                fieldNames.addAll(whereClause.split('\\(|\\)|>=|<=|!=|=|>|<| in\\(| like | in:| or| and'));
+                String whereClause = mMatcher.group(0).replaceAll('\\(select .+\\)', '(SUBQUERY)');
+                fieldNames.addAll(whereClause.split('\\(|\\)|>=|<=|!=|=|>|<| in\\(| not in\\(| like | in:| or| and'));
             }
-
             if (!fieldNames.isEmpty()) {
-                for (Integer i = fieldNames.size() - 1; i >= 0; i -= 2) {
+               for (Integer i = fieldNames.size() - 1; i >= 1; i -= 2) {
                     fieldNames[i - 1] = fieldNames[i - 1].replaceAll(' ', '');
                     fieldNameValueMap.put(fieldNames[i - 1], fieldNames.remove(i));
                 }
             }
-
             Map<String, String> fieldTypes = getFieldTypes(sObjectType, fieldNames);
             soqlQuery = putFormattedValues(soqlQuery, fieldNameValueMap, fieldTypes);
         }
-
         return soqlQuery;
     }
-
-    public static Map<String, String> getFieldTypes(String sObjectType, List<String> fieldNames) {
-        SObjectType r = ((SObject) (Type.forName('Schema.' + sObjectType).newInstance())).getSObjectType();
-        Map<String, String> resultMap = new Map<String, String>();
-        DescribeSObjectResult d = r.getDescribe();
-        Map<String, SObjectField> fieldMap = d.fields.getMap();
-
-        for (String fieldName : fieldNames) {
-            if (fieldMap.containsKey(fieldName)) {
-                resultMap.put(fieldName, fieldMap.get(fieldName).getDescribe().getType().name());
-            }
+    public static Map<String, String> getFieldTypes(String sObjectTypeName, List<String> fieldNames) {
+        Schema.SObjectType objectType = Schema.getGlobalDescribe().get(sObjectTypeName);
+        if (objectType != null) {
+            Map<String, String> resultMap = new Map<String, String>();
+        	DescribeSObjectResult d = objectType.getDescribe();
+        	Map<String, SObjectField> fieldMap = d.fields.getMap();
+        	for (String fieldName : fieldNames) {
+            	if (fieldMap.containsKey(fieldName)) {
+                	resultMap.put(fieldName, fieldMap.get(fieldName).getDescribe().getType().name());
+            	}
+        	}
+            return resultMap; 
+        } else {
+            throw new ExecuteSOQLException('Unable to get sObject Type for name: '+ cleanObjectName);
         }
-
-        return resultMap;
     }
-
     public static String putFormattedValues(String query, Map<String, String> fieldNameValueMap, Map<String, String> fieldTypes) {
-
         Set<String> typesWithSpecialFormatting = new Set<String>{
                 'DATETIME', 'DATE'
         };
@@ -86,7 +92,6 @@ public with sharing class ExecuteSOQL {
             }
         }
         return query;
-
     }
     private static String getFormattedValue(String fieldValue, String fieldType) {
         if (fieldType == 'DATETIME' || fieldType == 'DATE') {
@@ -102,42 +107,38 @@ public with sharing class ExecuteSOQL {
                     isDate = true;
                 }
             }
-
             if (isDate) {
                 fieldValue = fieldValue.replaceAll(', ', '/');
                 fieldValue = fieldValue.replaceAll('/ ', '/');
-                fieldValue += ', 00:00 AM';
+                fieldValue += ' 12:00 am';
             }
-
             return Datetime.parse(fieldValue).format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }
-
         return fieldValue;
     }
-
     //Workaround to get local month name to month number map
     private static Map<String, String> getLocalMonthNumbers() {
         Datetime dt = Datetime.newInstance(2020, 1, 1);
-
         Map<String, String> resultMap = new Map<String, String>();
         for (Integer i = 1; i < 12; i++) {
-            resultMap.put(dt.format('MMMM').toLowerCase(), String.valueOf(i));
+            String month = String.valueOf(i);
+            if (month.length() == 1) {
+                month = '0' + month;
+            }
+            resultMap.put(dt.format('MMMM').toLowerCase(), month);
             dt = dt.addMonths(1);
         }
         return resultMap;
     }
-
     public class Requests {
         @InvocableVariable(required=true)
         public String soqlQuery;
     }
-
     public class Results {
         public Results() {
             sObjects = new List<SObject>();
         }
         @InvocableVariable
         public List<SObject> sObjects;
-
     }
 }

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -13,13 +13,14 @@ public with sharing class ExecuteSOQL {
         return responseWrapper;
     }
     public static String replaceWithFormattedValues(String soqlQuery) {
+        String endingClause = '';
         soqlQuery = soqlQuery.toLowerCase().replaceAll('\r\n|\n|\r|\t',' ');
-        List<String> clausesToRemove = new List<String>{
-                ' order by ', ' limit '
-        };
+        List<String> clausesToRemove = new List<String>{' order by ', ' limit '};
         for (String curClause : clausesToRemove) {
             if (soqlQuery.contains(curClause)) {
-                soqlQuery = soqlQuery.substring(0, soqlQuery.indexOf(curClause));
+                endingClause = curClause + soqlQuery.substringAfter(curClause);
+                soqlQuery = soqlQuery.remove(endingClause);
+                break;
             }
         }
         if (soqlQuery != null && soqlQuery.contains(' from ') && soqlQuery.contains('select ') && soqlQuery.contains(' where ')) {
@@ -63,7 +64,7 @@ public with sharing class ExecuteSOQL {
             Map<String, String> fieldTypes = getFieldTypes(sObjectType, fieldNames);
             soqlQuery = putFormattedValues(soqlQuery, fieldNameValueMap, fieldTypes);
         }
-        return soqlQuery;
+        return soqlQuery + endingClause;
     }
     public static Map<String, String> getFieldTypes(String sObjectTypeName, List<String> fieldNames) {
         Schema.SObjectType objectType = Schema.getGlobalDescribe().get(sObjectTypeName);

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
@@ -1,31 +1,62 @@
 @isTest
 public class ExecuteSOQLTest {
     @isTest
-    public static void testExecuteSOQL() {
+    public static void testExecuteSOQLDateTime() {
         Account acc = new Account(Name = 'Test Account');
         insert acc;
 
         //Not formatted DateTime
         ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
-        requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 4/12/2020, 3:24 PM';
+        requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 04/12/2020 03:24 PM';
+
+        Test.startTest();
         List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
                 requests
         });
+        Test.stopTest();
         System.assertEquals(acc.Id, results[0].sObjects[0].Id);
+    }
+    
+    @isTest
+    private static void testExecuteSOQLShortDate() {
+        Account acc = new Account(Name = 'Test Account');
+        insert acc;
 
         //Not formatted Date
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
         requests.soqlQuery = 'Select Id From Account Where CreatedDate >= April 12, 2020';
-        results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
                 requests
         });
+        Test.stopTest();
+
         System.assertEquals(acc.Id, results[0].sObjects[0].Id);
+    }
+    
+    @isTest
+    private static void testExecuteSOQLLonDateTime() {
+        Account acc = new Account(Name = 'Test Account');
+        insert acc;
 
         //Formatted date time
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
         requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 2020-04-12T15:24:00Z';
-        results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
                 requests
         });
+        Test.stopTest();
+
         System.assertEquals(acc.Id, results[0].sObjects[0].Id);
+    }
+
+    @isTest
+    private static void testExecuteSOQLMultipleRecords() {
+        Account acc = new Account(Name = 'Test Account');
+        insert acc;
 
         //Multiple records returned
         Set<Id> accIds = new Set<Id>();
@@ -33,13 +64,41 @@ public class ExecuteSOQLTest {
         acc = new Account(Name = 'Test Account2');
         insert acc;
         accIds.add(acc.Id);
+        
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
         requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' ORDER BY CreatedDate LIMIT 2';
-        results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+                
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
                 requests
         });
+        Test.stopTest();
+        
         for (SObject so : results[0].sObjects) {
             System.assertEquals(true, accIds.contains(so.Id));
         }
+    }
 
+    @isTest
+    private static void testExecuteSOQLRelationshipQuery() {
+        Account act = new Account(Name = 'Test1');
+        insert act;
+
+        Contact ct = new Contact(LastName='Test Contact', AccountId=act.Id);
+        insert ct;
+
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
+        requests.soqlQuery = 'Select Id, AccountId, Account.Name From Contact Where AccountId in (SELECT Id from Account WHERE Name in (\'Test1\', \'Test2\', \'Test3\')) ';
+
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        Test.stopTest();
+
+        System.assertEquals(1, results[0].sObjects.size());
+
+        Contact returnedContact = (Contact) (results[0].sObjects[0]);
+        System.assertEquals(ct.Id, returnedContact.Id);
+        System.assertEquals(act.Id, returnedContact.AccountId);
+        System.assertEquals('Test1', returnedContact.Account.Name);
     }
 }

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
@@ -54,29 +54,35 @@ public class ExecuteSOQLTest {
     }
 
     @isTest
-    private static void testExecuteSOQLMultipleRecords() {
-        Account acc = new Account(Name = 'Test Account');
-        insert acc;
-
-        //Multiple records returned
-        Set<Id> accIds = new Set<Id>();
-        accIds.add(acc.Id);
-        acc = new Account(Name = 'Test Account2');
-        insert acc;
-        accIds.add(acc.Id);
+    private static void testExecuteSOQLLimit() {        
+        insert new List<Account>{new Account(Name = 'Test 3'), new Account(Name = 'Test 1'), new Account(Name = 'Test 2')};
         
         ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
-        requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' ORDER BY CreatedDate LIMIT 2';
+        requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' LIMIT 2';
                 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
-                requests
-        });
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
         Test.stopTest();
         
-        for (SObject so : results[0].sObjects) {
-            System.assertEquals(true, accIds.contains(so.Id));
-        }
+        System.assertEquals(2, results[0].sObjects.size());  
+    }
+    
+    @isTest
+    private static void testExecuteSOQLOrderBy() {
+        insert new List<Account>{new Account(Name = 'Apple'), new Account(Name = 'Pear'), new Account(Name = 'Cucumber')};
+        
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
+        requests.soqlQuery = 'Select Id,Name From Account Order By Name';
+                
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        Test.stopTest();
+        
+        System.assertEquals(true, results[0].sObjects.size() == 3);
+        List<Account> accounts = (List<Account>)results[0].sObjects;
+        System.assertEquals('Apple', accounts[0].Name);
+      	System.assertEquals('Cucumber', accounts[1].Name);
+		System.assertEquals('Pear', accounts[2].Name);
     }
 
     @isTest


### PR DESCRIPTION
Reverts alexed1/LightningFlowComponents#348

Fixes revert reason:  Replace variable name used in exception throw in `getFieldTypes(String sObjectTypeName, List<String> fieldNames)`. 

Bonus fix:

Commit (0cd9c0f3e07b995c3263dfbb1bc9deebbfea5cab)
-  Addresses broken 'order by' and 'limit' queries that I speculated were not working [the original PR](https://github.com/alexed1/LightningFlowComponents/pull/347), and updated unit test suite to make assertion against both.