### PR TITLE
MODIFY: Add support for date literals in query parameters (ExecuteSOQL)

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -1,4 +1,5 @@
-public with sharing class ExecuteSOQL {
+public without sharing class ExecuteSOQL {
+    private static Set<String> DATE_LITERAL_FORMATS = new Set<String>{'YESTERDAY','TODAY','TOMORROW','LAST_WEEK','THIS_WEEK','NEXT_WEEK','LAST_MONTH','THIS_MONTH','NEXT_MONTH','LAST_90_DAYS','NEXT_90_DAYS','LAST_N_DAYS','NEXT_N_DAYS','NEXT_N_WEEKS','LAST_N_WEEKS','NEXT_N_MONTHS','LAST_N_MONTHS','THIS_QUARTER','LAST_QUARTER','NEXT_QUARTER','NEXT_N_QUARTERS','LAST_N_QUARTERS','THIS_YEAR','LAST_YEAR','NEXT_YEAR','NEXT_N_YEARS','LAST_N_YEARS','THIS_FISCAL_QUARTER','LAST_FISCAL_QUARTER','NEXT_FISCAL_QUARTER','NEXT_N_FISCAL_QUARTERS','LAST_N_FISCAL_QUARTERS','THIS_FISCAL_YEAR','LAST_FISCAL_YEAR','NEXT_FISCAL_YEAR','NEXT_N_FISCAL_YEARS','LAST_N_FISCAL_YEARS'};
     class ExecuteSOQLException extends Exception {}
     @InvocableMethod
     public static List <Results> getEligibleProducts(List<Requests> requestList) {
@@ -67,7 +68,7 @@ public with sharing class ExecuteSOQL {
         return soqlQuery + endingClause;
     }
     public static Map<String, String> getFieldTypes(String sObjectTypeName, List<String> fieldNames) {
-        Schema.SObjectType objectType = Schema.getGlobalDescribe().get(sObjectTypeName);
+        Schema.SObjectType objectType = Schema.getGlobalDescribe().get(sObjectTypeName.replace(' ', ''));
         if (objectType != null) {
             Map<String, String> resultMap = new Map<String, String>();
         	DescribeSObjectResult d = objectType.getDescribe();
@@ -94,9 +95,14 @@ public with sharing class ExecuteSOQL {
         }
         return query;
     }
-    private static String getFormattedValue(String fieldValue, String fieldType) {
+    private static String getFormattedValue(String fieldValue, String fieldType) {		
         if (fieldType == 'DATETIME' || fieldType == 'DATE') {
             //Datetime is already formatted
+            for (String literal: DATE_LITERAL_FORMATS) {
+                if (fieldValue.contains(literal.toLowerCase())) {
+                    return fieldValue;
+                }
+            }
             if (fieldValue.contains('t') && fieldValue.contains('z') && fieldValue.indexOf('t') == 11) {
                 return fieldValue;
             }

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -8,6 +8,7 @@ public without sharing class ExecuteSOQL {
         for(Requests curRequest : requestList) {
             String soqlQuery = curRequest.soqlQuery;
             soqlQuery = replaceWithFormattedValues(soqlQuery);
+            System.debug('Logs: query: ' + soqlQuery);
             results.sObjects = Database.query(soqlQuery);
             responseWrapper.add(results);
         }
@@ -15,7 +16,7 @@ public without sharing class ExecuteSOQL {
     }
     public static String replaceWithFormattedValues(String soqlQuery) {
         String endingClause = '';
-        soqlQuery = soqlQuery.toLowerCase().replaceAll('\r\n|\n|\r|\t',' ');
+        soqlQuery = soqlQuery.replaceAll('\r\n|\n|\r|\t',' ');
         List<String> clausesToRemove = new List<String>{' order by ', ' limit ', ' group by ', ' offset ' };
         for (String curClause : clausesToRemove) {
             if (soqlQuery.contains(curClause)) {
@@ -25,14 +26,14 @@ public without sharing class ExecuteSOQL {
             }
         }
         if (soqlQuery != null && soqlQuery.contains(' from ') && soqlQuery.contains('select ') && soqlQuery.contains(' where ')) {
-            Pattern mPattern = pattern.compile('(?<=from )(.*)(?= where .+(\\(select .+\\)))');
+            Pattern mPattern = pattern.compile('(?i)(?<=from )(.*)(?= where .+(\\(select .+\\)))');
             Matcher mMatcher = mPattern.matcher(soqlQuery);
             Boolean found = mMatcher.find();
             String sObjectType = '';
             if (found) {
                 sObjectType = mMatcher.group(0);
                 // Recurse through sub-queries
-                Pattern subPattern = pattern.compile('\\(select .+\\)');
+                Pattern subPattern = pattern.compile('(?i)\\(select .+\\)');
                 Matcher subMatcher = subPattern.matcher(soqlQuery);
                 while (subMatcher.find()) {
                     String subQuery = subMatcher.group(0).removeStart('(').removeEnd(')');
@@ -40,7 +41,7 @@ public without sharing class ExecuteSOQL {
                    	soqlQuery = soqlQuery.replace(subQuery, formattedSubQuery);
                 }
             } else {
-                mPattern = pattern.compile('(?<=from )(.*)(?= where)');            
+                mPattern = pattern.compile('(?i)(?<=from )(.*)(?= where)');            
                 mMatcher = mPattern.matcher(soqlQuery);
                 if (mMatcher.find()) {
                     sObjectType = mMatcher.group(0);
@@ -50,10 +51,10 @@ public without sharing class ExecuteSOQL {
             }
             Map<String, String> fieldNameValueMap = new Map<String, String>();
             List<String> fieldNames = new List<String>();
-            mPattern = pattern.compile('(?<=where )(.*)');
+            mPattern = pattern.compile('(?i)(?<=where )(.*)');
             mMatcher = mPattern.matcher(soqlQuery);
             while (mMatcher.find()) {
-                String whereClause = mMatcher.group(0).replaceAll('\\(select .+\\)', '(SUBQUERY)');
+                String whereClause = mMatcher.group(0).replaceAll('(?i)\\(select .+\\)', '(SUBQUERY)');
                 fieldNames.addAll(whereClause.split('\\(|\\)|>=|<=|!=|=|>|<| in\\(| not in\\(| like | in:| or| and'));
             }
             if (!fieldNames.isEmpty()) {
@@ -97,20 +98,21 @@ public without sharing class ExecuteSOQL {
     }
     private static String getFormattedValue(String fieldValue, String fieldType) {		
         if (fieldType == 'DATETIME' || fieldType == 'DATE') {
+            String caseInsensitiveValue = fieldValue.toLowerCase();
             //Datetime is already formatted
             for (String literal: DATE_LITERAL_FORMATS) {
-                if (fieldValue.contains(literal.toLowerCase())) {
+                if (caseInsensitiveValue.contains(literal.toLowerCase())) {
                     return fieldValue;
                 }
             }
-            if (fieldValue.contains('t') && fieldValue.contains('z') && fieldValue.indexOf('t') == 11) {
+            if (caseInsensitiveValue.contains('t') && caseInsensitiveValue.contains('z') && caseInsensitiveValue.indexOf('t') == 11) {
                 return fieldValue;
             }
             Map<String, String> localMonthNumbers = getLocalMonthNumbers();
             Boolean isDate = false;
             for (String monthName : localMonthNumbers.keySet()) {
-                if (fieldValue.contains(monthName)) {
-                    fieldValue = fieldValue.replaceAll(monthName, localMonthNumbers.get(monthName) + ',');
+                if (caseInsensitiveValue.contains(monthName)) {
+                    fieldValue = caseInsensitiveValue.replaceAll(monthName, localMonthNumbers.get(monthName) + ',');
                     isDate = true;
                 }
             }

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -19,13 +19,13 @@ public without sharing class ExecuteSOQL {
         soqlQuery = soqlQuery.replaceAll('\r\n|\n|\r|\t',' ');
         List<String> clausesToRemove = new List<String>{' order by ', ' limit ', ' group by ', ' offset ' };
         for (String curClause : clausesToRemove) {
-            if (soqlQuery.contains(curClause)) {
-                endingClause = curClause + soqlQuery.substringAfter(curClause);
-                soqlQuery = soqlQuery.remove(endingClause);
+            if (soqlQuery.containsIgnoreCase(curClause)) {
+                endingClause = curClause + soqlQuery.toLowerCase().substringAfter(curClause.toLowerCase());
+                soqlQuery = soqlQuery.removeEndIgnoreCase(endingClause);
                 break;
             }
         }
-        if (soqlQuery != null && soqlQuery.contains(' from ') && soqlQuery.contains('select ') && soqlQuery.contains(' where ')) {
+        if (soqlQuery != null && soqlQuery.containsIgnoreCase(' from ') && soqlQuery.containsIgnoreCase('select ') && soqlQuery.containsIgnoreCase(' where ')) {
             Pattern mPattern = pattern.compile('(?i)(?<=from )(.*)(?= where .+(\\(select .+\\)))');
             Matcher mMatcher = mPattern.matcher(soqlQuery);
             Boolean found = mMatcher.find();
@@ -45,6 +45,7 @@ public without sharing class ExecuteSOQL {
                 mMatcher = mPattern.matcher(soqlQuery);
                 if (mMatcher.find()) {
                     sObjectType = mMatcher.group(0);
+                    System.debug('Logs: match found: sobject: ' + sObjectType);
                 } else {
                     throw new ExecuteSOQLException('Unable to parse query string: ' + soqlQuery);
                 }
@@ -54,7 +55,10 @@ public without sharing class ExecuteSOQL {
             mPattern = pattern.compile('(?i)(?<=where )(.*)');
             mMatcher = mPattern.matcher(soqlQuery);
             while (mMatcher.find()) {
-                String whereClause = mMatcher.group(0).replaceAll('(?i)\\(select .+\\)', '(SUBQUERY)');
+                String statement = mMatcher.group(0);
+                                    System.debug('Logs: match found: fields: ' + statement);
+
+                String whereClause = statement.replaceAll('(?i)\\(select .+\\)', '(SUBQUERY)');
                 fieldNames.addAll(whereClause.split('\\(|\\)|>=|<=|!=|=|>|<| in\\(| not in\\(| like | in:| or| and'));
             }
             if (!fieldNames.isEmpty()) {
@@ -98,21 +102,20 @@ public without sharing class ExecuteSOQL {
     }
     private static String getFormattedValue(String fieldValue, String fieldType) {		
         if (fieldType == 'DATETIME' || fieldType == 'DATE') {
-            String caseInsensitiveValue = fieldValue.toLowerCase();
             //Datetime is already formatted
             for (String literal: DATE_LITERAL_FORMATS) {
-                if (caseInsensitiveValue.contains(literal.toLowerCase())) {
+                if (fieldValue.containsIgnoreCase(literal)) {
                     return fieldValue;
                 }
             }
-            if (caseInsensitiveValue.contains('t') && caseInsensitiveValue.contains('z') && caseInsensitiveValue.indexOf('t') == 11) {
+            if (fieldValue.containsIgnoreCase('t') && fieldValue.containsIgnoreCase('z') && fieldValue.indexOfIgnoreCase('t') == 11) {
                 return fieldValue;
             }
             Map<String, String> localMonthNumbers = getLocalMonthNumbers();
             Boolean isDate = false;
             for (String monthName : localMonthNumbers.keySet()) {
-                if (caseInsensitiveValue.contains(monthName)) {
-                    fieldValue = caseInsensitiveValue.replaceAll(monthName, localMonthNumbers.get(monthName) + ',');
+                if (fieldValue.containsIgnoreCase(monthName)) {
+                    fieldValue = fieldValue.replaceAll('(?i)' + monthName, localMonthNumbers.get(monthName) + ',');
                     isDate = true;
                 }
             }
@@ -134,7 +137,7 @@ public without sharing class ExecuteSOQL {
             if (month.length() == 1) {
                 month = '0' + month;
             }
-            resultMap.put(dt.format('MMMM').toLowerCase(), month);
+            resultMap.put(dt.format('MMMM'), month);
             dt = dt.addMonths(1);
         }
         return resultMap;

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
@@ -84,6 +84,22 @@ public class ExecuteSOQLTest {
         
         System.assertEquals(2, results[0].sObjects.size());  
     }
+
+    @isTest
+    private static void testExecuteSOQLId() {      
+        Account searchAccount = new Account(Name = 'Test 3');  
+        insert new List<Account>{searchAccount, new Account(Name = 'Test 1'), new Account(Name = 'Test 2')};
+        
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
+        requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' AND Id = \'' + searchAccount.Id + '\'';
+                
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        Test.stopTest();
+        
+        System.assertEquals(1, results[0].sObjects.size());  
+        System.assertEquals(searchAccount.Id, results[0].sObjects[0].Id);  
+    }
     
     @isTest
     private static void testExecuteSOQLOrderBy() {

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
@@ -52,6 +52,24 @@ public class ExecuteSOQLTest {
 
         System.assertEquals(acc.Id, results[0].sObjects[0].Id);
     }
+    
+        @isTest
+    private static void testExecuteSOQLDateLiteral() {
+        Account acc = new Account(Name = 'Test Account');
+        insert acc; 
+
+        //Formatted date time
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
+        requests.soqlQuery = 'Select Id From Account Where CreatedDate = LAST_n_DAYS:14';
+
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+                requests
+        });
+        Test.stopTest();
+		System.assertEquals(1, results[0].sObjects.size());
+        System.assertEquals(acc.Id, results[0].sObjects[0].Id);
+    }
 
     @isTest
     private static void testExecuteSOQLLimit() {        


### PR DESCRIPTION
ExecuteSOQL action fails when date literals are provided as query parameters for date fields. This PR adds support for date literals and adds associated unit test for validation. 