### PR TITLE
New Input variable to store api names of fields to be excluded from page layout

### DIFF
--- a/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
+++ b/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
@@ -11,6 +11,7 @@ public with sharing class GetLayoutFields {
         for (Requests req : requestList) {
             String layoutName = req.layoutName;
             String objectName = req.objectName;
+            String excludeFields = requestList[0].excludeFields;
             String layoutFieldsCSV = '';
 
             layoutName = objectName + '-' + layoutName;
@@ -24,9 +25,9 @@ public with sharing class GetLayoutFields {
                 for (Metadata.LayoutColumn column : section.layoutColumns) {
                     if (column.layoutItems != null) {
                         for (Metadata.LayoutItem item : column.layoutItems) {
+                            if(!excludeFields.contains(item.field)){
                                 layoutFieldsCSV = layoutFieldsCSV + ',' +item.field;
-
-
+                            }
                         }
                     }
                 }
@@ -49,6 +50,9 @@ public with sharing class GetLayoutFields {
 
         @InvocableVariable 
         public String objectName;
+
+        @InvocableVariable 
+        global String excludeFields;
 
     }
 

--- a/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFieldsTest.cls
+++ b/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFieldsTest.cls
@@ -7,13 +7,15 @@ public with sharing class GetLayoutFieldsTest {
 
             List<GetLayoutFields.Requests> requestList = new List<GetLayoutFields.Requests>();
            
-            String objectName = 'Account';
-            String layoutName = 'Account Layout';
+            String objectName = 'Case';
+            String layoutName = 'Case Layout';
+            String excludeFields = 'ContactId';
             
 
             GetLayoutFields.Requests request = new GetLayoutFields.Requests();
             request.objectName = objectName;
             request.layoutName = layoutName;
+            request.excludeFields = excludeFields;
             
             requestList.add(request);
             


### PR DESCRIPTION
Feature to exclude fields that are in the page layout from appearing in the flow component.

Classic use case is for standard fields that cannot be removed from page layout (like Case Origin or Contact Name).

Account object and Account Layout were failing the test class on my org (not sure why exactly), but it passed when I changed it to Case.