### PR TITLE
stored comma-delimited string into list var

### DIFF
--- a/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
+++ b/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
@@ -11,14 +11,14 @@ public with sharing class GetLayoutFields {
         for (Requests req : requestList) {
             String layoutName = req.layoutName;
             String objectName = req.objectName;
-            String excludeFields = requestList[0].excludeFields;
+            String excludeFields = req.excludeFields;
             String layoutFieldsCSV = '';
 
             layoutName = objectName + '-' + layoutName;
             List<Metadata.Metadata> layouts = 
                 Metadata.Operations.retrieve(Metadata.MetadataType.Layout, 
                                             new List<String> {layoutName});
-                                            
+
             List<String> lstExcludeFields = excludeFields.split(',');
 
             Metadata.Layout layoutMd = (Metadata.Layout)layouts.get(0);

--- a/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
+++ b/flow_action_components/GetLayoutFields/force-app/main/default/classes/GetLayoutFields.cls
@@ -18,14 +18,17 @@ public with sharing class GetLayoutFields {
             List<Metadata.Metadata> layouts = 
                 Metadata.Operations.retrieve(Metadata.MetadataType.Layout, 
                                             new List<String> {layoutName});
+                                            
+            List<String> lstExcludeFields = excludeFields.split(',');
 
             Metadata.Layout layoutMd = (Metadata.Layout)layouts.get(0);
-
+            
+            
             for (Metadata.LayoutSection section : layoutMd.layoutSections) {
                 for (Metadata.LayoutColumn column : section.layoutColumns) {
                     if (column.layoutItems != null) {
                         for (Metadata.LayoutItem item : column.layoutItems) {
-                            if(!excludeFields.contains(item.field)){
+                            if(!lstExcludeFields.contains(item.field)){
                                 layoutFieldsCSV = layoutFieldsCSV + ',' +item.field;
                             }
                         }
@@ -52,7 +55,7 @@ public with sharing class GetLayoutFields {
         public String objectName;
 
         @InvocableVariable 
-        global String excludeFields;
+        public String excludeFields;
 
     }
 
@@ -64,5 +67,4 @@ public with sharing class GetLayoutFields {
 
     }
 }
-
 


### PR DESCRIPTION
instead of searching if the single string of fields separated by a comma contains each field on the layout, the inputted string of comma separated field names is stored in a string List and the list is searched.

for example, previously a user input of "Account_Status__c" would exclude the standard "Status" field since the input string contains Status. Now the contains checks if the list contains an "Account_Status__c" as one of its list members.