### PR TITLE
Sortcollection 100 percent test coverage

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SortCollection.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SortCollection.cls
@@ -2,11 +2,8 @@
  * Provides a Salesforce Ligntning Flow component for sorting collections.
  * 
  * The following field types are supported and have been tested: 
- *  BOOLEAN, CURRENCY, DATE, DATETIME, DOUBLE, EMAIL, ID, PERCENT, PHONE, 
- *  PICKLIST, REFERENCE, STRING, TIME.
- * The following field types are also supported:
- *  DECIMAL, INTEGER, LONG.
- * 
+ *  BOOLEAN, CURRENCY, DATE, DATETIME, DECIMAL, DOUBLE, EMAIL, ID, INTEGER, 
+ *  LONG, PERCENT, PHONE, PICKLIST, REFERENCE, STRING, TIME.
  * See SortCollectionTest.cls for test coverage of API data types and UI field types.
  */
 global with sharing class SortCollection {
@@ -139,6 +136,7 @@ global with sharing class SortCollection {
      * Field Type Comparable Factory
      * @return A Comparable cooresponding to the fieldType or null if none exists.
      */
+    @TestVisible
     private static Comparable getComparable (String fieldType, Object value) {
         Comparable comp = null;
         switch on fieldType {

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SortCollectionTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SortCollectionTest.cls
@@ -12,33 +12,35 @@ private class SortCollectionTest {
      * Boolean          Checkbox                    Tested. HasOptedOutOfEmail FROM Contact.
      * Double           Currency                    Tested. ExpectedRevenue FROM Campaign.
      * Double           Number                      Tested. Double__c FROM ZTest__c.
-     * Double           Percent                     Tested. ExpectedResponse FROM Campaign
+     * Double           Percent                     Tested. ExpectedResponse FROM Campaign.
      * Date             Date                        Tested. Birthdate FROM Contact.
-     * Datetime         Datetime                    Tested. Datetime__c FROM ZTest__c; CreatedDate FROM Contact.
+     * Datetime         Datetime                    Tested. Datetime__c FROM Contract; CreatedDate FROM Contact.
      *                                              CreatedDate from Contact might not provide much variance in values.
+     * Decimal          ---                         Tested. getComparable and DecimalComparable directly tested. SObject fields not tested.
+     * Integer          ---                         Tested. getComparable and DoubleComparable directly tested. SObject fields not tested.
+     * Long             ---                         Tested. getComparable and DoubleComparable directly tested. SObject fields not tested.
      * String           Email                       Tested. Email FROM Contact.
      * String           Phone                       Tested. Phone FROM Contact.
      * String           Picklist                    Tested. LeadSource FROM Contact. 
      *                                              SortCollection sorts picklists by API Name and not picklist order.
      * String           Text                        Tested. FirstName, LastName, Department FROM Contact.
-     * Time             Time                        Tested. Time__c FROM ZTest__c.
-     * 
-     * ID               Master-detail Relationship  Not tested.
-     * Decimal          ---                         Not tested.
-     * Integer          ---                         Not tested.
-     * Long             ---                         Not tested.
-     * String           Auto Number                 Not tested.
-     * String           Text Area                   Not tested.
-     * String           Long Text Area              Not tested.
-     * String           Multi-select picklist       Not tested.
-     * String           Rich Text Area              Not tested.
-     * String           Data Category Group         Not tested.
-     * String           URL                         Not tested.
+     * Time             Time                        Tested. getComparable and TimeComparable directly tested. SObject fields not tested.
+     * ---              ---                         -----------
+     * ID               Master-detail Relationship  Not tested. However, ID (Lookup) was tested.
+     * String           Auto Number                 Not tested. However, other String UI field types tested.
+     * String           Text Area                   Not tested. However, other String UI field types tested.
+     * String           Long Text Area              Not tested. However, other String UI field types tested.
+     * String           Multi-select picklist       Not tested. However, other String UI field types tested.
+     * String           Rich Text Area              Not tested. However, other String UI field types tested.
+     * String           Data Category Group         Not tested. However, other String UI field types tested.
+     * String           URL                         Not tested. However, other String UI field types tested.
      */
     
     /*
-     * The following SObject must be in your Salesforce environment to maximize
-     * test coverage. If it is not present, some tests will be skipped.
+     * While the test coverage is 100%, not all SObject field types are tested
+     * on actual objects. There commented out tests for testing additional 
+     * fields. To use these tests, the following SObject must be in your 
+     * Salesforce environment:
      * Name: ZTest
      *    * If you use a different name, change CUSTOM_OBJECT_NAME.
      *    * API Name: ZTest__c
@@ -62,7 +64,9 @@ private class SortCollectionTest {
     static final Integer NUM_ACCOUNTS = 11;
     static final Integer NUM_CAMPAIGNS = 13;
     static final Integer NUM_CONTACTS = 23;
+    static final Integer NUM_CONTRACTS = 7;
     static final Integer NUM_CUSTOM_OBJECTS = 17;
+    
 
     static final Boolean[] CHECKBOX_CHOICES = new Boolean[] {null, true, false};
     static final String[] LEAD_SOURCE_CHOICES = new String[] {null, 'Web', 'Phone Inquiry', 'Partner Referral', 'Purchased List', 'Other'};
@@ -132,7 +136,35 @@ private class SortCollectionTest {
             }
         }
         insert testCampaigns;
+        // Make Contracts for DateTime tests
+        List<Contract> testContracts = new List<Contract>();
+        for(Integer i=0; i< NUM_CONTRACTS; i++) {
+            String name = String.fromCharArray(new List<Integer> {aCharCode + Math.mod(i,26)}) + (1 + Math.rint(i/26));
+            if (Math.mod(i,3) == 0) {
+                testContracts.add(new Contract(Name=name,
+                    AccountId = testAccounts[Math.mod(i,NUM_ACCOUNTS)].Id,
+                    ContractTerm = i + 1,
+                    Status = 'Draft'
+                    ));
+            } else {
+                testContracts.add(new Contract(Name=name,
+                    AccountId = testAccounts[Math.mod(i,NUM_ACCOUNTS)].Id,
+                    ContractTerm = i+1,
+                    Status = 'Draft'
+                    ));
+            }
+        }
+        insert testContracts;
+        // Change the ActivatedDates
+        for(Integer i=0; i< NUM_CONTRACTS; i++) {
+            Datetime dt = Datetime.newInstance(2019, 1 + (Math.mod(i, 12)), 1 + Math.mod(i,29), 
+                Math.mod(i,24), Math.mod(i,60), Math.mod(i,60));
+            testContracts[i].Status = 'Activated';
+            testContracts[i].ActivatedDate = dt;
+        }
+        upsert testContracts;
 
+        /*
         // Make Test Objects for field types not covered above
         String customObjectApiName = CUSTOM_OBJECT_API_NAME;
         Schema.SObjectType t = Schema.getGlobalDescribe().get(customObjectApiName);
@@ -143,30 +175,23 @@ private class SortCollectionTest {
             for (Integer i=0; i < NUM_CUSTOM_OBJECTS; i++) {
                 String name = String.fromCharArray(new List<Integer> {aCharCode + Math.mod(i,26)}) + (1 + Math.rint(i/26));
                 Double doub = i + i/1000 + i/100000;
-                Datetime dt = Datetime.newInstance(2000, 1 + (Math.mod(i, 12)), 1 + Math.mod(i,29), 
-                    Math.mod(i,24), Math.mod(i,60), Math.mod(i,60));
+                //Datetime dt = Datetime.newInstance(2000, 1 + (Math.mod(i, 12)), 1 + Math.mod(i,29), 
+                //    Math.mod(i,24), Math.mod(i,60), Math.mod(i,60));
                 SObject so = t.newSObject();
                 so.put('Name',name);
                 if (Math.mod(i,3) != 0) {
                     Time timeVal = Time.newInstance(Math.mod(i,24), Math.mod(i,60), Math.mod(i,60), Math.mod(i,1000)); //HH:mm:ss:S
                     so.put('Time__c', timeVal);
                     so.put('Double__c', doub);
-                    so.put('Datetime__c', dt);
+                    //so.put('Datetime__c', dt);
                 }
                 testSObjects.add(so);
             }
             insert testSObjects;
         }
+        */
     }
 
-    /**************************************************************************
-     * New Stuff field type tests
-     * DECIMAL, INTEGER
-     *************************************************************************/
-   /*  @isTest static void testSortContactAccountIdDesc() {
-        List<SObject> inputCollection = [SELECT Id, LastName, AccountId FROM Contact];
-        testSortDoubleField(inputCollection, 'AccountId:DESC');
-    } */
     /**************************************************************************
      * Checkbox field type tests
      ************************************D*************************************/
@@ -209,6 +234,15 @@ private class SortCollectionTest {
     /**************************************************************************
      * Datetime field type tests
      *************************************************************************/
+    @isTest static void testSortDatetimeContractActivatedDateAsc() {
+        List<SObject> inputCollection = [SELECT Id, ActivatedDate FROM Contract];
+        testSortDatetimeField(inputCollection, 'ActivatedDate:ASC');
+    }
+    @isTest static void testSortDatetimeContractActivatedDateDesc() {
+        List<SObject> inputCollection = [SELECT Id, ActivatedDate FROM Contract];
+        testSortDatetimeField(inputCollection, 'ActivatedDate:DESC');
+    }
+    /* Replaced by testSortDatetimeContact... tests
     @isTest static void testSortCustomObjectDatetimeAsc() {
         System.assert(customSObjectExists(CUSTOM_OBJECT_API_NAME), 
             'MISSING_CUSTOM_SOBJECT - ' + CUSTOM_OBJECT_API_NAME + ' needed for testSortCustomObjectDatetimeAsc().');
@@ -225,6 +259,7 @@ private class SortCollectionTest {
         List<SObject> inputCollection = Database.query(query);
         testSortDatetimeField(inputCollection, 'Datetime__c:DESC');
     }
+    */
 
     // CreatedDates will likely all be all be the same.
     @isTest static void testSortDatetimeContactCreatedDateAsc() {
@@ -281,6 +316,7 @@ private class SortCollectionTest {
     /**************************************************************************
      * Number(x,y) (Double) field type tests.
      *************************************************************************/
+    /* Sufficiently covered by testDoubleCompableIntegerFieldType
     @isTest static void testSortCustomObjectDoubleDesc() {
         System.assert(customSObjectExists(CUSTOM_OBJECT_API_NAME), 
             'MISSING_CUSTOM_SOBJECT - ' + CUSTOM_OBJECT_API_NAME + ' needed for testSortCustomObjectDoubleDesc().');
@@ -289,10 +325,12 @@ private class SortCollectionTest {
         List<SObject> inputCollection = Database.query(query);
         testSortDoubleField(inputCollection, 'Double__c:DESC');
     }
+    */
 
     /**************************************************************************
      * Time field type tests
      *************************************************************************/
+    /* Sufficiently covered by testTimeComparable
     @isTest static void testSortCustomObjectTimeAsc() {
         System.assert(customSObjectExists(CUSTOM_OBJECT_API_NAME), 
             'MISSING_CUSTOM_SOBJECT - ' + CUSTOM_OBJECT_API_NAME + ' needed for testSortCustomObjectTimeAsc().');
@@ -308,6 +346,7 @@ private class SortCollectionTest {
         List<SObject> inputCollection = Database.query(query);
         testSortTimeField(inputCollection, 'Time__c:DESC');
     }
+    */
 
     /**************************************************************************
      * Percentage field type tests
@@ -371,6 +410,142 @@ private class SortCollectionTest {
     @isTest static void testSortStringContactLastNameDesc() {
         List<SObject> inputCollection = [SELECT Id, LastName, FirstName FROM Contact];
         testSortStringField(inputCollection, 'LastName:DESC');
+    }
+
+    /*
+     * Attempting 100% Coverage
+     */
+    @isTest static void testSortableWrapperCompareToUnsupportedType() {
+        
+        List<SObject> inputCollection = [SELECT Id, LastName, FirstName, Department FROM Contact LIMIT 2];
+        System.debug('inputCollection.size() ' + inputCollection.size());
+        Test.startTest();
+        SortCollection.SortableWrapper sw0 = new SortCollection.SortableWrapper(inputCollection[0], 'LastName', 1, 'UnsupportedType');
+        SortCollection.SortableWrapper sw1 = new SortCollection.SortableWrapper(inputCollection[1], 'LastName', 1, 'STRING');
+        //sw0.orig = null;
+        Integer retval = sw0.compareTo(sw1);
+        Test.stopTest();
+
+        System.assertEquals(0,retval);
+    }
+    @isTest static void testBooleanComparable () {
+        Boolean t = true;
+        Boolean f = false;
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,0,1,-1,0,-1,-1,1,1};
+        Test.startTest();
+        Comparable tc = SortCollection.getComparable('BOOLEAN', (Object) t);
+        Comparable fc = SortCollection.getComparable('BOOLEAN', (Object) f);
+        Comparable nc = SortCollection.getComparable('BOOLEAN', null);
+        actuals.add(tc.compareTo(t)); // expect 0, true = true
+        actuals.add(fc.compareTo(f)); // expect 0, false = false
+        actuals.add(tc.compareTo(false)); // expect 1, true > false
+        actuals.add(fc.compareTo(true));  // expect -1, false < true
+        actuals.add(nc.compareTo(null));  // expect 0, null = null
+        actuals.add(nc.compareTo(f));  // expect -1, null < false
+        actuals.add(nc.compareTo(t));  // expect 1-, null < true
+        actuals.add(tc.compareTo(null));  // expect 1, true > null
+        actuals.add(fc.compareTo(null));  // expect 1 false > null
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
+    }
+    @isTest static void testDateimeComparable () {
+        Datetime datetime0 = Datetime.newInstance(2020, 1, 1, 0, 0, 0); //year, month, day, hour, minute, second
+        Datetime datetime1 = Datetime.newInstance(2020, 3, 14, 15, 9, 26); 
+        Datetime datetime2 = Datetime.newInstance(2020, 6, 28, 30, 18,52);
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,1,-1,0,1,-1};
+        Test.startTest();
+        Comparable dt1c = SortCollection.getComparable('DATETIME', (Object) datetime1);
+        Comparable nc = SortCollection.getComparable('DATETIME', null);
+        actuals.add(dt1c.compareTo(datetime1)); // expect 0, 
+        actuals.add(dt1c.compareTo(datetime0)); // expect 1
+        actuals.add(dt1c.compareTo(datetime2)); // expect -1
+        actuals.add(nc.compareTo(null));   // expect 0, null = null
+        actuals.add(dt1c.compareTo(null));  // expect 1, any datetime > null
+        actuals.add(nc.compareTo(datetime1));  // expect -1 null < anydatetime
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
+    }
+    @isTest static void testDecimalComparable () {
+        Decimal value = 3.14159; // Apple
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,1,-1,0,1,-1};
+        Test.startTest();
+        Comparable pi = SortCollection.getComparable('DECIMAL', (Object) value);
+        Comparable n = SortCollection.getComparable('DECIMAL', null);
+        actuals.add(pi.compareTo(value)); // expect 0, pi = pi
+        actuals.add(pi.compareTo(2.71828));   // expect 1, pi > e
+        actuals.add(pi.compareTo(22.4591));  // expect -1, pi < pi^e
+        actuals.add(n.compareTo(null));   // expect 0, null = null
+        actuals.add(pi.compareTo(null));  // expect 1, pi > null
+        actuals.add(n.compareTo(value));  // expect -1 null < pi
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
+    }
+    @isTest static void testDoubleComparableIntegerFieldType () {
+        Integer value = 3;
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,1,-1,0,1,-1};
+        Test.startTest();
+        Comparable pi = SortCollection.getComparable('INTEGER', (Object) value);
+        Comparable n = SortCollection.getComparable('INTEGER', null);
+        actuals.add(pi.compareTo(value)); // expect 0, pi = pi
+        actuals.add(pi.compareTo(2));   // expect 1, pi > e
+        actuals.add(pi.compareTo(22));  // expect -1, pi < pi^e
+        actuals.add(n.compareTo(null));   // expect 0, null = null
+        actuals.add(pi.compareTo(null));  // expect 1, pi > null
+        actuals.add(n.compareTo(value));  // expect -1 null < pi
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
+    }
+    @isTest static void testDoubleComparableLongFieldType () {
+        Long value = 3141592653L;
+        Long evalue  = 2718281828L;
+                     
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,1,-1,0,1,-1};
+        Test.startTest();
+        Comparable pi = SortCollection.getComparable('LONG', (Object) value);
+        Comparable n = SortCollection.getComparable('LONG', null);
+        actuals.add(pi.compareTo(value)); // expect 0, pi = pi
+        actuals.add(pi.compareTo(2));   // expect 1, pi > e
+        actuals.add(pi.compareTo(2*value));  // expect -1, pi < 2*pi
+        actuals.add(n.compareTo(null));   // expect 0, null = null
+        actuals.add(pi.compareTo(null));  // expect 1, pi > null
+        actuals.add(n.compareTo(value));  // expect -1 null < pi
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
+    }
+    @isTest static void testTimeComparable () {
+        Time time0 = Time.newInstance(0, 0, 0, 0); //HH:mm:ss:S
+        Time time1 = Time.newInstance(3, 14, 15, 926); //HH:mm:ss:S
+        Time time2 = Time.newInstance(22, 45, 0, 0); //HH:mm:ss:S
+        List<Integer> actuals = new List<Integer>();
+        List<Integer> expectations = new List<Integer>{0,1,-1,0,1,-1};
+        Test.startTest();
+        Comparable t1 = SortCollection.getComparable('TIME', (Object) time1);
+        Comparable n = SortCollection.getComparable('TIME', null);
+        actuals.add(t1.compareTo(time1)); // expect 0, 3:14:15:926 = 3:14:15:000
+        actuals.add(t1.compareTo(time0)); // expect 1, 3:14:15:926 > 00:00:00:000
+        actuals.add(t1.compareTo(time2)); // expect -1, 3:14:15:926 < 22:45:00:000
+        actuals.add(n.compareTo(null));   // expect 0, null = null
+        actuals.add(t1.compareTo(null));  // expect 1, 3:14:15:926 > null
+        actuals.add(n.compareTo(time1));  // expect -1 null < 3:14:15:926
+        Test.stopTest();
+        for (Integer i = 0; i < actuals.size(); i++) {
+            System.assertEquals(expectations[i], actuals[i], 'Comparison #' + i);
+        }
     }
 
     /**************************************************************************


### PR DESCRIPTION
1. Added @TestVisible annotation SortCollection's getComparable () 
2. Added Datetime test on Contract object
3. Added additional field type tests with getComparable () now test visible
4. Commented out test setup and tests using custom Sobject - no longer needed due to item 3.