### PR TITLE
ExecuteSOQL Bulkification and getFormattedValue Fix

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls
@@ -1,11 +1,15 @@
 public without sharing class ExecuteSOQL {
     private static Set<String> DATE_LITERAL_FORMATS = new Set<String>{'YESTERDAY','TODAY','TOMORROW','LAST_WEEK','THIS_WEEK','NEXT_WEEK','LAST_MONTH','THIS_MONTH','NEXT_MONTH','LAST_90_DAYS','NEXT_90_DAYS','LAST_N_DAYS','NEXT_N_DAYS','NEXT_N_WEEKS','LAST_N_WEEKS','NEXT_N_MONTHS','LAST_N_MONTHS','THIS_QUARTER','LAST_QUARTER','NEXT_QUARTER','NEXT_N_QUARTERS','LAST_N_QUARTERS','THIS_YEAR','LAST_YEAR','NEXT_YEAR','NEXT_N_YEARS','LAST_N_YEARS','THIS_FISCAL_QUARTER','LAST_FISCAL_QUARTER','NEXT_FISCAL_QUARTER','NEXT_N_FISCAL_QUARTERS','LAST_N_FISCAL_QUARTERS','THIS_FISCAL_YEAR','LAST_FISCAL_YEAR','NEXT_FISCAL_YEAR','NEXT_N_FISCAL_YEARS','LAST_N_FISCAL_YEARS'};
-    class ExecuteSOQLException extends Exception {}
-    @InvocableMethod(label='Execute SOQL Query' description='Executes an SOQL query and returns a list of sObjects of the specified type' category='Util')
+    public class ExecuteSOQLException extends Exception {}
+    // Legacy entry point
     public static List <Results> getEligibleProducts(List<Requests> requestList) {
-        Results results = new Results();
+        return execute(requestList);
+    }
+    @InvocableMethod(label='Execute SOQL Query' description='Executes an SOQL query and returns a list of sObjects of the specified type' category='Util')
+    public static List <Results> execute(List<Requests> requestList) {
         List<Results> responseWrapper = new List<Results>();
         for(Requests curRequest : requestList) {
+            Results results = new Results();
             String soqlQuery = curRequest.soqlQuery;
             soqlQuery = replaceWithFormattedValues(soqlQuery);
             List<SObject> queryResult = Database.query(soqlQuery);
@@ -102,6 +106,7 @@ public without sharing class ExecuteSOQL {
         }
         return query;
     }
+    @TestVisible
     private static String getFormattedValue(String fieldValue, String fieldType) {		
         if (fieldType == 'DATETIME' || fieldType == 'DATE') {
             //Datetime is already formatted
@@ -124,7 +129,7 @@ public without sharing class ExecuteSOQL {
             if (isDate) {
                 fieldValue = fieldValue.replaceAll(', ', '/');
                 fieldValue = fieldValue.replaceAll('/ ', '/');
-                fieldValue += ' 12:00 am';
+                fieldValue += ', 12:00 am';
             }
             return Datetime.parse(fieldValue).format('yyyy-MM-dd\'T\'HH:mm:ss\'Z\'');
         }

--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQLTest.cls
@@ -1,16 +1,16 @@
 @isTest
 public class ExecuteSOQLTest {
-    @isTest
-    public static void testExecuteSOQLDateTime() {
+    @isTest 
+    public static void testExecuteEnglishUpperCasePM() {
         Account acc = new Account(Name = 'Test Account');
         insert acc;
 
         //Not formatted DateTime
         ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
-        requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 04/12/2020 03:24 PM';
+        requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 04/12/2020, 03:24 PM';
 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{
                 requests
         });
         Test.stopTest();
@@ -18,7 +18,7 @@ public class ExecuteSOQLTest {
     }
     
     @isTest
-    private static void testExecuteSOQLShortDate() {
+    private static void testExecuteSOQLMonthDayCommaYear() {
         Account acc = new Account(Name = 'Test Account');
         insert acc;
 
@@ -27,7 +27,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id From Account Where CreatedDate >= April 12, 2020';
 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{
                 requests
         });
         Test.stopTest();
@@ -45,7 +45,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 2020-04-12T15:24:00Z';
 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{
                 requests
         });
         Test.stopTest();
@@ -63,7 +63,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id From Account Where CreatedDate = LAST_n_DAYS:14';
 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{
                 requests
         });
         Test.stopTest();
@@ -79,7 +79,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' LIMIT 2';
                 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{requests});
         Test.stopTest();
         
         System.assertEquals(2, results[0].sObjects.size());  
@@ -94,7 +94,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id From Account Where Name != \'TEST\' AND Id = \'' + searchAccount.Id + '\'';
                 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{requests});
         Test.stopTest();
         
         System.assertEquals(1, results[0].sObjects.size());  
@@ -109,7 +109,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id,Name From Account Order By Name';
                 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{requests});
         Test.stopTest();
         
         System.assertEquals(true, results[0].sObjects.size() == 3);
@@ -131,7 +131,7 @@ public class ExecuteSOQLTest {
         requests.soqlQuery = 'Select Id, AccountId, Account.Name From Contact Where AccountId in (SELECT Id from Account WHERE Name in (\'Test1\', \'Test2\', \'Test3\')) ';
 
         Test.startTest();
-        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{requests});
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.execute(new List<ExecuteSOQL.Requests>{requests});
         Test.stopTest();
 
         System.assertEquals(1, results[0].sObjects.size());
@@ -140,5 +140,89 @@ public class ExecuteSOQLTest {
         System.assertEquals(ct.Id, returnedContact.Id);
         System.assertEquals(act.Id, returnedContact.AccountId);
         System.assertEquals('Test1', returnedContact.Account.Name);
+    }
+    
+    @isTest
+    private static void testGetFieldTypesUnknownSObjectType() {
+        String sObjectTypeName = 'theObjectThatMustNotBeNamed';
+        String msg = '[ExecuteSOQLException Not Thrown for Unknown sObject Type]';
+        Test.startTest();
+        try {
+        	Map<String, String> results = ExecuteSOQL.getFieldTypes(sObjectTypeName, new List<String>());
+        } catch (ExecuteSOQL.ExecuteSOQLException e) {
+            msg = e.getMessage();
+        }
+        Test.stopTest();
+        System.assertEquals('Unable to get sObject Type for name: '+ sObjectTypeName, msg);
+    }
+
+    @isTest
+    private static void testReplaceWithFormattedValuesWithBadQueryString() {
+        String soqlQuery = 'DOES NOT COMPUTE WHERE SELECT FROM ';
+        String msg = '[ExecuteSOQLException Not Thrown for Bad Query String]';
+        Test.startTest();
+        try {
+            String result = ExecuteSOQL.replaceWithFormattedValues(soqlQuery);
+        } catch (ExecuteSOQL.ExecuteSOQLException e) {
+            msg = e.getMessage();
+        }
+        Test.stopTest();
+        System.assertEquals('Unable to parse query string: ' + soqlQuery, msg);
+    }
+
+    @isTest
+    private static void testGetFormattedValueWithInteger() {
+        String fieldvalue = '1';
+        String fieldType = 'INTEGER';
+        Test.startTest();
+        String actualFieldvalue = ExecuteSOQL.getFormattedValue(fieldValue, fieldType);
+        Test.stopTest();
+        System.assertEquals(actualFieldvalue, fieldValue);
+    }
+
+    @isTest
+    public static void testBulkification() {
+        final Integer NUM_ACCOUNTS = 11;
+        List<Account> accounts = new List<Account>();
+        for (Integer i = 1; i <= NUM_ACCOUNTS; i++) {
+            accounts.add(new Account(Name = 'Test ' + String.valueOf(i)));
+        }
+        insert accounts;
+
+        List<ExecuteSOQL.Requests> requestsList = new List<ExecuteSOQL.Requests>();
+        ExecuteSOQL.Requests requests;
+        for (Integer i=1; i <= NUM_ACCOUNTS; i++) {
+            requests = new ExecuteSOQL.Requests();
+            requests.soqlQuery = 'Select Id From Account Where Name LIKE \'Test _%\' LIMIT ' + String.valueOf(i);
+            requestsList.add(requests);
+        }
+        System.debug('testBulkification: requestsList.size() ' + requestsList.size());
+        Test.startTest();
+        List<ExecuteSOQL.Results> resultsList = ExecuteSOQL.execute(requestsList);
+        Test.stopTest();
+        System.debug('testBulkification: requestsList.size() ' + requestsList.size() +', resultsList.size() ' + resultsList.size());
+        System.assertEquals(requestsList.size(), resultsList.size(), 'Results list size');
+        for (Integer i=0; i < resultsList.size(); i++) {
+            ExecuteSOQL.Results results =resultsList[i];
+            List<SObject> sObjects = results.sObjects;
+            System.debug('testBulkification: sObjects.size() ' + sObjects.size() +', expected ' + (i+1));
+            System.assertEquals(i+1, sObjects.size(), 'Returned SObjects size');
+        }
+    }
+
+    @isTest
+    public static void testLegacyEntryPoint() {
+        Account acc = new Account(Name = 'Test Account');
+        insert acc;
+        
+        ExecuteSOQL.Requests requests = new ExecuteSOQL.Requests();
+        requests.soqlQuery = 'Select Id From Account Where CreatedDate >= 04/12/2020, 03:24 PM';
+
+        Test.startTest();
+        List<ExecuteSOQL.Results> results = ExecuteSOQL.getEligibleProducts(new List<ExecuteSOQL.Requests>{
+                requests
+        });
+        Test.stopTest();
+        System.assertEquals(acc.Id, results[0].sObjects[0].Id);
     }
 }


### PR DESCRIPTION
1. Fixed bulkification bug - moved location of `String soqlQuery = curRequest.soqlQuery;` 
2. getFormattedValue - adding missing comma in `fieldValue += ', 12:00 am';`
3. Increased testing to 100% code coverage
4. Renamed invocable method to `execute` from `getEligibleProducts` and added `getEligibleProducts` to support any legacy users.