### PR TITLE
Add padding to layout items for readability

### DIFF
--- a/flow_screen_components/recordDetailFSC/force-app/main/default/lwc/recordDetailFlowScreenComponent/recordDetailFlowScreenComponent.html
+++ b/flow_screen_components/recordDetailFSC/force-app/main/default/lwc/recordDetailFlowScreenComponent/recordDetailFlowScreenComponent.html
@@ -32,7 +32,7 @@ Lightning Web Component for Flow Screens:       recordDetailFlowScreenComponent
                                 object-api-name={objectApiName}>
                             <lightning-layout multiple-rows="true">
                                 <template for:each={fieldData} for:item="field">
-                                    <lightning-layout-item key={field.fieldName} size={elementSize}>
+                                    <lightning-layout-item class="slds-p-horizontal_medium" key={field.fieldName} size={elementSize}>
                                         <div class="underline">
                                             <lightning-output-field if:false={field.isError} field-name={field.fieldName}>
                                             </lightning-output-field>
@@ -55,7 +55,7 @@ Lightning Web Component for Flow Screens:       recordDetailFlowScreenComponent
                         >
                             <lightning-layout multiple-rows="true">
                                 <template for:each={fieldData} for:item="field">
-                                    <lightning-layout-item key={field.fieldName} size={elementSize}>
+                                    <lightning-layout-item  class="slds-p-horizontal_medium" key={field.fieldName} size={elementSize}>
                                         <template if:false={field.isError} >
                                             <lightning-output-field if:true={field.isOutput} field-name={field.fieldName}>
                                             </lightning-output-field>


### PR DESCRIPTION
Given the spacing between the field label and the actual input element, screens become difficult to use especially when there are many fields presented to the user. This is especially problematic with the two-column layout, as the input elements of fields from column 1 are adjacent to the labels of column 2.
This change simply adds padding to the layout items so that fields are a bit more distinguishable from each other. It's a small quality of life improvement, but makes a big difference.