### PR TITLE
Dual list box sort

### DIFF
--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.html
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.html
@@ -5,6 +5,7 @@
                                    all-options-string-format={allOptionsStringFormat}
                                    use-which-object-key-for-data={useWhichObjectKeyForData}
                                    use-which-object-key-for-label={useWhichObjectKeyForLabel}
+                                   use-which-object-key-for-sort={useWhichObjectKeyForSort}
                                    label={label}
                                    source-label={sourceLabel}
                                    field-level-help={fieldLevelHelp}

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js
@@ -21,6 +21,7 @@ export default class dualListBoxFSC extends LightningElement {
     @api requiredOptions;
     @api useWhichObjectKeyForData = defaults.valueField;
     @api useWhichObjectKeyForLabel = defaults.labelField;
+    @api useWhichObjectKeyForSort;
     @api useObjectValueAsOutput = false;
 
     _allOptionsStringFormat;

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js-meta.xml
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js-meta.xml
@@ -22,6 +22,7 @@
             <property name="useObjectValueAsOutput" type="Boolean" role="inputOnly"> </property>
             <property name="useWhichObjectKeyForData" type="String" role="inputOnly"> </property>
             <property name="useWhichObjectKeyForLabel" type="String" role="inputOnly"> </property>
+            <property name="useWhichObjectKeyForSort" type="String" role="inputOnly"> </property>
             <property name="allOptionsFieldDescriptorList" type="apex://FieldDescriptor[]" role="inputOnly"> </property>
             <property name="allOptionsCSV" type="String" role="inputOnly"> </property>
             <property name="allOptionsStringCollection" type="String[]" role="inputOnly"> </property>

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js-meta.xml
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBox2/dualListBox2.js-meta.xml
@@ -9,29 +9,28 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen" configurationEditor="c-dual-list-box-c-p-e" category="Input">
-            <property name="label" type="String" role="inputOnly"> </property>
-            <property name="sourceLabel" type="String" role="inputOnly"> </property>
-            <property name="fieldLevelHelp" type="String" role="inputOnly"> </property>
-            <property name="selectedLabel" type="String" role="inputOnly"> </property>
-            <property name="min" type="Integer" role="inputOnly"> </property>
-            <property name="max" type="Integer" role="inputOnly"> </property>
-            <property name="disableReordering" type="Boolean" role="inputOnly"> </property>
-            <property name="size" type="Integer" role="inputOnly"> </property>
-            <property name="required" type="Boolean" role="inputOnly"> </property>
-            <property name="requiredOptions" type="String" role="inputOnly"> </property>
-            <property name="useObjectValueAsOutput" type="Boolean" role="inputOnly"> </property>
-            <property name="useWhichObjectKeyForData" type="String" role="inputOnly"> </property>
-            <property name="useWhichObjectKeyForLabel" type="String" role="inputOnly"> </property>
-            <property name="useWhichObjectKeyForSort" type="String" role="inputOnly"> </property>
-            <property name="allOptionsFieldDescriptorList" type="apex://FieldDescriptor[]" role="inputOnly"> </property>
-            <property name="allOptionsCSV" type="String" role="inputOnly"> </property>
-            <property name="allOptionsStringCollection" type="String[]" role="inputOnly"> </property>
-            <property name="allOptionsStringCollectionLabels" type="String[]" role="inputOnly"> </property>
-            <property name="allOptionsStringFormat" type="String" role="inputOnly"> </property>
-            <property name="selectedOptionsFieldDescriptorList" type="apex://FieldDescriptor[]"> </property>
-            <property name="selectedOptionsCSV" type="String"> </property>
-            <property name="selectedOptionsStringList" type="String[]"> </property>
-
+            <property name="label" type="String" role="inputOnly"/>
+            <property name="sourceLabel" type="String" role="inputOnly"/>
+            <property name="fieldLevelHelp" type="String" role="inputOnly"/>
+            <property name="selectedLabel" type="String" role="inputOnly"/>
+            <property name="min" type="Integer" role="inputOnly"/>
+            <property name="max" type="Integer" role="inputOnly"/>
+            <property name="disableReordering" type="Boolean" role="inputOnly"/>
+            <property name="size" type="Integer" role="inputOnly"/>
+            <property name="required" type="Boolean" role="inputOnly"/>
+            <property name="requiredOptions" type="String" role="inputOnly"/>
+            <property name="useObjectValueAsOutput" type="Boolean" role="inputOnly"/>
+            <property name="useWhichObjectKeyForData" type="String" role="inputOnly"/>
+            <property name="useWhichObjectKeyForLabel" type="String" role="inputOnly"/>
+            <property name="useWhichObjectKeyForSort" type="String" role="inputOnly"/>
+            <property name="allOptionsFieldDescriptorList" type="apex://FieldDescriptor[]" role="inputOnly"/>
+            <property name="allOptionsCSV" type="String" role="inputOnly"/>
+            <property name="allOptionsStringCollection" type="String[]" role="inputOnly"/>
+            <property name="allOptionsStringCollectionLabels" type="String[]" role="inputOnly"/>
+            <property name="allOptionsStringFormat" type="String" role="inputOnly"/>
+            <property name="selectedOptionsFieldDescriptorList" type="apex://FieldDescriptor[]"/>
+            <property name="selectedOptionsCSV" type="String"/>
+            <property name="selectedOptionsStringList" type="String[]"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBoxCPE/dualListBoxCPE.html
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBoxCPE/dualListBoxCPE.html
@@ -115,6 +115,13 @@
                     value={inputValues.useWhichObjectKeyForData.value}
                     onblur={handleValueChange}
             ></lightning-input>
+            <lightning-input
+                type="text"
+                label={inputValues.useWhichObjectKeyForSort.label}
+                name="select_useWhichObjectKeyForSort"
+                value={inputValues.useWhichObjectKeyForSort.value}
+                onblur={handleValueChange}
+            ></lightning-input>
         </template>
     </div>
     <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Labels</div>

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBoxCPE/dualListBoxCPE.js
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/dualListBoxCPE/dualListBoxCPE.js
@@ -37,6 +37,12 @@ export default class DualListBoxCpe extends LightningElement {
             isCollection: false,
             label: 'Use Which Object Key For Label'
         },
+        useWhichObjectKeyForSort: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: 'Use Which Object Key For Sort'
+        },
         useObjectValueAsOutput: {value: null, valueDataType: null, isCollection: false, label: 'Select Field'},
         allOptionsFieldDescriptorList: {
             value: null,

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js
@@ -56,8 +56,12 @@ export default class dualListBox extends LightningElement {
     set allOptions(value) {
         if (!this.isError) {
             this._optionsOriginal = value;
-            let formattedOptions = this.formatOptionsSet(value, this.allOptionsStringFormat);
-            this._options = this.sortOptionsSet(formattedOptions, this.useWhichObjectKeyForSort);
+            if (this.useWhichObjectKeyForSort) {
+                let formattedOptions = this.formatOptionsSet(value, this.allOptionsStringFormat);
+                this._options = this.sortOptionsSet(formattedOptions, this.useWhichObjectKeyForSort);
+            } else {
+                this._options = this.formatOptionsSet(value, this.allOptionsStringFormat);
+            }
         }
     }
 

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js
@@ -21,6 +21,7 @@ export default class dualListBox extends LightningElement {
     @api allOptionsStringFormat = defaults.csv;//csv;list;object
     @api useWhichObjectKeyForData = defaults.valueField;
     @api useWhichObjectKeyForLabel = defaults.labelField;
+    @api useWhichObjectKeyForSort;
     @api useObjectValueAsOutput = false; //used with csv or list
     @track _options; //always json{label,value}
     @track _optionsOriginal; //stores original values
@@ -55,7 +56,8 @@ export default class dualListBox extends LightningElement {
     set allOptions(value) {
         if (!this.isError) {
             this._optionsOriginal = value;
-            this._options = this.formatOptionsSet(value, this.allOptionsStringFormat);
+            let formattedOptions = this.formatOptionsSet(value, this.allOptionsStringFormat);
+            this._options = this.sortOptionsSet(formattedOptions, this.useWhichObjectKeyForSort);
         }
     }
 
@@ -73,6 +75,19 @@ export default class dualListBox extends LightningElement {
         // if (this.useObjectValueAsOutput && this.selectedValuesStringFormat === defaults.originalObject) {
         //     return defaults.canNotUseValuesForOutput;
         // }
+    }
+
+    sortOptionsSet(value, sortField) {
+        if (!value) {
+            return;
+        }
+        if (!sortField) {
+            return value;
+        }
+        let fieldValue = row => row[sortField] || '';
+        return [...value.sort(
+            (a,b)=>(a=fieldValue(a).toUpperCase(),b=fieldValue(b).toUpperCase(),((a>b)-(b>a)))
+        )];        
     }
 
     formatValuesSet(value, optionType) {

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js-meta.xml
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js-meta.xml
@@ -23,6 +23,7 @@
             <property name="selectedValuesStringFormat" type="String" > </property>
             <property name="useWhichObjectKeyForData" type="String" default="value"> </property>
             <property name="useWhichObjectKeyForLabel" type="String" default="label"> </property>
+            <property name="useWhichObjectKeyForSort" type="String"> </property>
             <property name="useObjectValueAsOutput" type="Boolean"> </property>
             <property name="allOptions" type="String"> </property>
         </targetConfig>

--- a/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js-meta.xml
+++ b/flow_screen_components/dualListBoxFSC/force-app/main/default/lwc/extendedBaseDualListBox/extendedBaseDualListBox.js-meta.xml
@@ -9,23 +9,23 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__RecordPage">
-            <property name="label" type="String"> </property>
-            <property name="sourceLabel" type="String" > </property>
-            <property name="fieldLevelHelp" type="String" > </property>
-            <property name="selectedLabel" type="String"> </property>
-            <property name="selectedOptions" type="String"> </property>
-            <property name="min" type="Integer"> </property>
-            <property name="max" type="Integer"> </property>
-            <property name="disableReordering" type="Boolean"> </property>
-            <property name="size" type="Integer"> </property>
-            <property name="required" type="Boolean"> </property>
-            <property name="requiredOptions" type="String"> </property>
-            <property name="selectedValuesStringFormat" type="String" > </property>
-            <property name="useWhichObjectKeyForData" type="String" default="value"> </property>
-            <property name="useWhichObjectKeyForLabel" type="String" default="label"> </property>
-            <property name="useWhichObjectKeyForSort" type="String"> </property>
-            <property name="useObjectValueAsOutput" type="Boolean"> </property>
-            <property name="allOptions" type="String"> </property>
+            <property name="label" type="String"/>
+            <property name="sourceLabel" type="String"/>
+            <property name="fieldLevelHelp" type="String"/>
+            <property name="selectedLabel" type="String"/>
+            <property name="selectedOptions" type="String"/>
+            <property name="min" type="Integer"/>
+            <property name="max" type="Integer"/>
+            <property name="disableReordering" type="Boolean"/>
+            <property name="size" type="Integer"/>
+            <property name="required" type="Boolean"/>
+            <property name="requiredOptions" type="String"/>
+            <property name="selectedValuesStringFormat" type="String"/>
+            <property name="useWhichObjectKeyForData" type="String" default="value"/>
+            <property name="useWhichObjectKeyForLabel" type="String" default="label"/>
+            <property name="useWhichObjectKeyForSort" type="String"/>
+            <property name="useObjectValueAsOutput" type="Boolean"/>
+            <property name="allOptions" type="String"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
This updates dualListBoxFSC to support sorting of the GetFieldDescriptions dataset.  The admin can specify which keyfield to sort on.