### PR TITLE
Packaging update + turned of object create in test

### DIFF
--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmailTest.cls
@@ -5,7 +5,7 @@
  * @Author				: Jack D. Pond
  * @Group				: unofficialSF
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 07-11-2020
+ * @Last Modified On	: 08-07-2020
  * @Modification Log	: 
  * @License				: LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * Ver		Date		Author					Modification
@@ -49,7 +49,7 @@ public with sharing class SendHTMLEmailTest {
     Inversely, not doing these tests can cause code coverage % failures.  For pre-deployment testing purposes, TEST_WITH_CREATED_RECORDS should be set to true,
     but for version release, should be set to false.
 **/
-    private Static Final Boolean TEST_WITH_CREATED_RECORDS = true;
+    private Static Final Boolean TEST_WITH_CREATED_RECORDS = false;
 //
     private Static Final String TEMPLATE_NAME = 'xxxyyy Test Email Template yyyxxx';
     private Static Final String TEMPLATE_DEVNAME = 'xxxyyy_Test_Email_Template_yyyxxx';

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -19,6 +19,7 @@
             "package": "sendHTMLEmail",
             "versionName": "ver 1.33.02",
             "versionNumber": "1.33.02.NEXT",
+            "definitionFile": "config/project-scratch-def.json",
             "dependencies": [
                 {
                     "package": "FlowBaseComponents@1.2.3-0"
@@ -42,6 +43,7 @@
         "sendHTMLEmail(Without Examples)@1.33.1-0": "04t3h000002Ne4kAAC",
         "FlowBaseComponents@1.2.3-0": "04tf4000004Pu2iAAC",
         "sendHTMLEmail@1.33.2-0": "04t3h0000045qdMAAQ",
-        "sendHTMLEmail@1.33.2-2": "04t3h0000045qdRAAQ"
+        "sendHTMLEmail@1.33.2-2": "04t3h0000045qdRAAQ",
+        "sendHTMLEmail@1.33.2-3": "04t3h0000045qeeAAA"
     }
 }

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -17,8 +17,8 @@
         {
             "path": "force-app",
             "package": "sendHTMLEmail",
-            "versionName": "ver 1.33.02",
-            "versionNumber": "1.33.02.NEXT",
+            "versionName": "ver 1.33.03",
+            "versionNumber": "1.33.03.NEXT",
             "definitionFile": "config/project-scratch-def.json",
             "dependencies": [
                 {
@@ -44,6 +44,7 @@
         "FlowBaseComponents@1.2.3-0": "04tf4000004Pu2iAAC",
         "sendHTMLEmail@1.33.2-0": "04t3h0000045qdMAAQ",
         "sendHTMLEmail@1.33.2-2": "04t3h0000045qdRAAQ",
-        "sendHTMLEmail@1.33.2-3": "04t3h0000045qeeAAA"
+        "sendHTMLEmail@1.33.2-3": "04t3h0000045qeeAAA",
+        "sendHTMLEmail@1.33.3-0": "04t3h0000045qf3AAA"
     }
 }


### PR DESCRIPTION
SendHTMLEmailTest has an option to more thoroughly test by creating records.   When enabled, coverage =93% when disabled, 83%.  Creating these records may cause a failure on upload if the installing org has created custom required fields, so should not be included in the distribution.

This release turns off the record create in the test classes and adds more sophisticated package creation definition.
`    private Static Final Boolean TEST_WITH_CREATED_RECORDS = false;
`

The r[elated package installation]( https://login.salesforce.com/packaging/installPackage.apexp?p0=04t3h0000045qf3AAA) (for sendHTMLEmail).

The minimum dependent install for [Flow Based Components](https://unofficialsf-psitex-dev-ed.lightning.force.com/packagingSetupUI/ipLanding.app?apvId=04tf4000004Pu2iAAC).