### PR TITLE
sendBetterEmail - All relevant Collections (String and Object) now accessible for selection in CPE

### DIFF
--- a/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmail.cls
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmail.cls
@@ -1,7 +1,7 @@
 /**
 * @File Name			: SendBetterEmail.cls
  * @Description			: Uses Spring/Summer '20 EmailTemplate Object + ContentVersion with multi-lingual
- * @Credits				: Alex Edelstein, Jeremiah Dohn, etal
+ * @OriginalAuthor		: Alex Edelstein, etal
  * @Group				: unofficialSF
  * @Last Modified By	: Jack D. Pond
  * @Last Modified On	: 08-12-2020

--- a/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmail.cls
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmail.cls
@@ -4,7 +4,7 @@
  * @Credits				: Alex Edelstein, Jeremiah Dohn, etal
  * @Group				: unofficialSF
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 08-11-2020
+ * @Last Modified On	: 08-12-2020
  * @License				: LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * @Modification Log	: 
  * 
@@ -120,7 +120,7 @@ public without sharing class SendBetterEmail {
 						if (curRequest.whatIds != null && curRequest.whatIds.size() > 0 ){
 							if (curRequest.whatIds.size() == curRequest.targetObjectIds.size()){
 								try {
-									mmail.setTargetObjectIds(curRequest.whatIds);
+									mmail.setWhatIds(curRequest.whatIds);
 								} catch (Exception e){
 									thisResponse.errors = e.getMessage();
 								}

--- a/flow_action_components/SendBetterEmail/force-app/main/default/lwc/addNewMembers/addNewMembers.js-meta.xml
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/lwc/addNewMembers/addNewMembers.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="addNewMembers">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>

--- a/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailCPE/sendBetterEmailCPE.js
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailCPE/sendBetterEmailCPE.js
@@ -5,7 +5,7 @@
  * @Credits				: From quickChoiceCPE,Andrii Kraiev and sentRichEmailCPE,Alex Edelstein etal.
  * @Group				: 
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 08-11-2020
+ * @Last Modified On	: 08-12-2020
  * @Modification Log	: 
  * Ver		Date		Author				Modification
  * 1.33.2	6/29/2020	Jack D. Pond		Initial Version
@@ -40,6 +40,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 		flowDataTypeString: 'String',
 		stringVariablesOption: 'String Variables (or type an address)',
 		stringDataType: 'String',
+		stringCollectionVariablesOption: 'String Collection',
 		referenceDataType: 'reference',
 		nullValue: ''
 	}
@@ -66,36 +67,22 @@ export default class SendBetterEmailCPE extends LightningElement {
 		saveAsActivity: {value: null, dataType: null, isCollection: false, label: 'Save Email as Activity on Recipient Record(s)?'},
 		saveAsTask: {value: null, dataType: null, isCollection: false, label: 'Save Email as Task on recipient related record(s)?'},
 		recordId: {value: null, valueDataType: null, isCollection: false, label: 'Related Record Id (for template merge fields and/or recording Email as a task)'},
-		SendTOthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendTOthisOneEmailAddress'},
-		SendTOthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendTOthisStringCollectionOfEmailAddresses'},
-		SendTOtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfContacts'},
-		SendTOtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfUsers'},
-		SendTOtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfLeads'},
-		SendCCthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendCCthisOneEmailAddress'},
-		SendCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendCCthisStringCollectionOfEmailAddresses'},
-		SendCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfContacts'},
-		SendCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfUsers'},
-		SendCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfLeads'},
-		SendBCCthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCthisOneEmailAddress'},
-		SendBCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCthisStringCollectionOfEmailAddresses'},
-		SendBCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfContacts'},
-		SendBCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfUsers'},
-		SendBCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfLeads'},
+		SendTOthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendTOthisOneEmailAddress'},
+		SendTOthisStringCollectionOfEmailAddresses: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOthisStringCollectionOfEmailAddresses'},
+		SendTOtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfContacts'},
+		SendTOtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfUsers'},
+		SendTOtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfLeads'},
+		SendCCthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendCCthisOneEmailAddress'},
+		SendCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: true, label: 'SendCCthisStringCollectionOfEmailAddresses'},
+		SendCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfContacts'},
+		SendCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfUsers'},
+		SendCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfLeads'},
+		SendBCCthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendBCCthisOneEmailAddress'},
+		SendBCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCthisStringCollectionOfEmailAddresses'},
+		SendBCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfContacts'},
+		SendBCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfUsers'},
+		SendBCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfLeads'},
 		contentDocumentAttachments: {value: null, valueDataType: null, isCollection: false, label: 'Attach which Content Document Links?'}
-/*
-		allowNoneToBeChosen: {value: null, valueDataType: null, isCollection: false, label: 'Add a \'None\' choice'},
-		required: {value: null, valueDataType: null, isCollection: false, label: 'Required'},
-		masterLabel: {value: null, valueDataType: null, isCollection: false, label: 'Master Label'},
-		value: {value: null, valueDataType: null, isCollection: false, label: 'Value (Default or Existing)'},
-		style_width: {value: null, valueDataType: null, isCollection: false, label: 'Width (Pixels)'},
-		numberOfColumns: {value: null, valueDataType: null, isCollection: false, label: 'Number of Columns'},
-		includeIcons: {value: null, valueDataType: null, isCollection: false, label: 'Show Icons'},
-		choiceIcons: {value: null, valueDataType: null, isCollection: true, label: 'Choice Icons [Card Icons]'},
-		iconSize: {value: null, valueDataType: null, isCollection: false, label: 'Icon Size'},
-		objectName: {value: null, valueDataType: null, isCollection: false, label: 'Select Object'},
-		fieldName: {value: null, valueDataType: null, isCollection: false, label: 'Select Field'},
-		recordTypeId: {value: null, valueDataType: null, isCollection: false, label: 'Filter on Record Type ID:'},
-*/
 	};
 
 	bodyOptions = [
@@ -153,8 +140,8 @@ export default class SendBetterEmailCPE extends LightningElement {
 			'User': 'SendTOtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendTOtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendTOtheEmailAddressesFromThisCollectionOfLeads',
-			'String': 'SendTOthisStringCollectionOfEmailAddresses',
-			'String Variables (or type an address)': 'SendTOthisOneEmailAddress'
+			'String Collection': 'SendTOthisStringCollectionOfEmailAddresses',
+			'String Variable (or type an address)': 'SendTOthisOneEmailAddress'
 		}
 	}, {
 		baseLabel: 'CC',
@@ -165,7 +152,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 			'User': 'SendCCtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendCCtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendCCtheEmailAddressesFromThisCollectionOfLeads',
-			'String': 'SendCCthisStringCollectionOfEmailAddresses',
+			'String Collection': 'SendCCthisStringCollectionOfEmailAddresses',
 			'String Variables (or type an address)': 'SendCCthisOneEmailAddress'
 		}
 	}, {
@@ -177,7 +164,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 			'User': 'SendBCCtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendBCCtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendBCCtheEmailAddressesFromThisCollectionOfLeads',
-			'String': 'SendBCCthisStringCollectionOfEmailAddresses',
+			'String Collection': 'SendBCCthisStringCollectionOfEmailAddresses',
 			'String Variables (or type an address)': 'SendBCCthisOneEmailAddress'
 		}
 	}];
@@ -253,24 +240,43 @@ export default class SendBetterEmailCPE extends LightningElement {
 							data: [],
 							valueFieldName: valueFieldName,
 							labelFieldName: labelFieldName
-						};
+						}
 						outputTypes[curLookUp.object].data.push(curLookUp);
 					}
 				}
 			}
 		});
-		let stringVariables = flowContext.variables.filter(curValue => {
-			return curValue.dataType === 'String' && !curValue.isCollection
+		allowedTypes.forEach(curType => {
+			if (curType === 'String'){
+				let allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === curType && curValue.isCollection
+				});
+				this.addToOutputTypes(outputTypes,allVariables,this.settings.stringCollectionVariablesOption,false);
+				allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === curType && !curValue.isCollection
+				});
+				this.addToOutputTypes(outputTypes,allVariables,this.settings.stringVariablesOption,false);
+			} else {
+				let allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === "SObject" && curValue.objectType === curType
+				});
+				this.addToOutputTypes(outputTypes,allVariables,curType,true);
+			}
 		});
-
-		if (stringVariables && stringVariables.length) {
-			outputTypes[this.settings.stringVariablesOption] = {
-				data: stringVariables,
-				valueFieldName: 'name',
-				labelFieldName: 'name'
-			};
-		}
 		this.convertedFlowContext = outputTypes;
+	}
+	addToOutputTypes(outputTypes,theseVariables,variablesOption,isSObject) {
+		let retVal = null;
+		if (theseVariables && theseVariables.length) {
+			if (!(variablesOption in outputTypes)) {
+				outputTypes[variablesOption] = {
+					data: [],
+					valueFieldName: 'name',
+					labelFieldName: 'name'
+				}
+			}
+			outputTypes[variablesOption].data.push(...theseVariables);
+		}
 	}
 
 	doCleanRoleManager(baseLabel, newValueObjectType) {

--- a/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailCPE/sendBetterEmailCPE.js
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailCPE/sendBetterEmailCPE.js
@@ -5,26 +5,12 @@
  * @Credits				: From quickChoiceCPE,Andrii Kraiev and sentRichEmailCPE,Alex Edelstein etal.
  * @Group				: 
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 08-12-2020
+ * @Last Modified On	: 08-13-2020
  * @Modification Log	: 
  * Ver		Date		Author				Modification
  * 1.33.2	6/29/2020	Jack D. Pond		Initial Version
 **/
 import {api, track, LightningElement} from 'lwc';
-
-/*	MassEmail
-
-	saveAsTask
-	setBccSender(bcc)
-	setDescription(description)
-	setReplyTo(replyAddress)
-	setSaveAsActivity(saveAsActivity)
-	setSenderDisplayName(displayName)
-	setTargetObjectIds(targetObjectIds)
-	setTemplateID(templateId)
-	setUseSignature(useSignature)
-	setWhatIds(whatIds)
-*/
 
 export default class SendBetterEmailCPE extends LightningElement {
 	_builderContext;
@@ -38,9 +24,9 @@ export default class SendBetterEmailCPE extends LightningElement {
 		singleEmailOption: 'singleEmail',
 		massEmailOption: 'massEmail',
 		flowDataTypeString: 'String',
+		stringCollectionVariablesOption: 'String Collection',
 		stringVariablesOption: 'String Variables (or type an address)',
 		stringDataType: 'String',
-		stringCollectionVariablesOption: 'String Collection',
 		referenceDataType: 'reference',
 		nullValue: ''
 	}
@@ -67,21 +53,21 @@ export default class SendBetterEmailCPE extends LightningElement {
 		saveAsActivity: {value: null, dataType: null, isCollection: false, label: 'Save Email as Activity on Recipient Record(s)?'},
 		saveAsTask: {value: null, dataType: null, isCollection: false, label: 'Save Email as Task on recipient related record(s)?'},
 		recordId: {value: null, valueDataType: null, isCollection: false, label: 'Related Record Id (for template merge fields and/or recording Email as a task)'},
-		SendTOthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendTOthisOneEmailAddress'},
-		SendTOthisStringCollectionOfEmailAddresses: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOthisStringCollectionOfEmailAddresses'},
-		SendTOtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfContacts'},
-		SendTOtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfUsers'},
-		SendTOtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendTOtheEmailAddressesFromThisCollectionOfLeads'},
-		SendCCthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendCCthisOneEmailAddress'},
-		SendCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: true, label: 'SendCCthisStringCollectionOfEmailAddresses'},
-		SendCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfContacts'},
-		SendCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfUsers'},
-		SendCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendCCtheEmailAddressesFromThisCollectionOfLeads'},
-		SendBCCthisOneEmailAddress: {value: null, valueDataType: "String", isCollection: false, label: 'SendBCCthisOneEmailAddress'},
-		SendBCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCthisStringCollectionOfEmailAddresses'},
-		SendBCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfContacts'},
-		SendBCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfUsers'},
-		SendBCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: "String", isCollection: true, label: 'SendBCCtheEmailAddressesFromThisCollectionOfLeads'},
+		SendTOthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendTOthisOneEmailAddress'},
+		SendTOthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendTOthisStringCollectionOfEmailAddresses'},
+		SendTOtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfContacts'},
+		SendTOtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfUsers'},
+		SendTOtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendTOtheEmailAddressesFromThisCollectionOfLeads'},
+		SendCCthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendCCthisOneEmailAddress'},
+		SendCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendCCthisStringCollectionOfEmailAddresses'},
+		SendCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfContacts'},
+		SendCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfUsers'},
+		SendCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendCCtheEmailAddressesFromThisCollectionOfLeads'},
+		SendBCCthisOneEmailAddress: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCthisOneEmailAddress'},
+		SendBCCthisStringCollectionOfEmailAddresses: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCthisStringCollectionOfEmailAddresses'},
+		SendBCCtheEmailAddressesFromThisCollectionOfContacts: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfContacts'},
+		SendBCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfUsers'},
+		SendBCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfLeads'},
 		contentDocumentAttachments: {value: null, valueDataType: null, isCollection: false, label: 'Attach which Content Document Links?'}
 	};
 
@@ -141,7 +127,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 			'Contact': 'SendTOtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendTOtheEmailAddressesFromThisCollectionOfLeads',
 			'String Collection': 'SendTOthisStringCollectionOfEmailAddresses',
-			'String Variable (or type an address)': 'SendTOthisOneEmailAddress'
+			'String Variables (or type an address)': 'SendTOthisOneEmailAddress'
 		}
 	}, {
 		baseLabel: 'CC',
@@ -164,7 +150,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 			'User': 'SendBCCtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendBCCtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendBCCtheEmailAddressesFromThisCollectionOfLeads',
-			'String Collection': 'SendBCCthisStringCollectionOfEmailAddresses',
+			'String': 'SendBCCthisStringCollectionOfEmailAddresses',
 			'String Variables (or type an address)': 'SendBCCthisOneEmailAddress'
 		}
 	}];
@@ -240,12 +226,17 @@ export default class SendBetterEmailCPE extends LightningElement {
 							data: [],
 							valueFieldName: valueFieldName,
 							labelFieldName: labelFieldName
-						}
+						};
 						outputTypes[curLookUp.object].data.push(curLookUp);
 					}
 				}
 			}
 		});
+		let stringVariables = flowContext.variables.filter(curValue => {
+			return curValue.dataType === 'String' && curValue.isCollection
+		});
+
+
 		allowedTypes.forEach(curType => {
 			if (curType === 'String'){
 				let allVariables = flowContext.variables.filter(curValue => {
@@ -258,7 +249,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 				this.addToOutputTypes(outputTypes,allVariables,this.settings.stringVariablesOption,false);
 			} else {
 				let allVariables = flowContext.variables.filter(curValue => {
-					return curValue.dataType === "SObject" && curValue.objectType === curType
+					return curValue.dataType === 'SObject' && curValue.objectType === curType
 				});
 				this.addToOutputTypes(outputTypes,allVariables,curType,true);
 			}
@@ -294,7 +285,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 		if (valuesToCleanUp.length) {
 			valuesToCleanUp.forEach(valueToCleanUp => {
 				if (valueToCleanUp && valueToCleanUp.value) {
-					this.dispatchFlowValueChangeEvent(valueToCleanUp.name, this.settings.nullValue, this.settings.stringDataType);
+					this.dispatchFlowValueChangeEvent(valueToCleanUp.name, this.settings.nullValue, this.settings.stringCollectionVariablesOption);
 				}
 			});
 		}
@@ -324,6 +315,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 				newValueDataType: newValueDataType
 			}
 		});
+
 		this.dispatchEvent(valueChangedEvent);
 	}
 
@@ -340,7 +332,7 @@ export default class SendBetterEmailCPE extends LightningElement {
 		let curAttributeName = event.target.name ? event.target.name : null;
 		this.inputValues.emailMessageType.value = event.detail.value;
 		this.isMassEmail = this.inputValues.emailMessageType.value === this.settings.massEmailOption;
-		this.dispatchFlowValueChangeEvent(curAttributeName, event.detail.value, "String");
+		this.dispatchFlowValueChangeEvent(curAttributeName, event.detail.value, 'String');
 		//		this.doClearBodyOptions();
 	}
 
@@ -357,10 +349,10 @@ export default class SendBetterEmailCPE extends LightningElement {
 			let curAttributeValue = event.target.type === 'checkbox' ? event.target.checked : event.detail.value;
 			let curAttributeType;
 			switch (event.target.type) {
-				case "checkbox":
+				case 'checkbox':
 					curAttributeType = 'Boolean';
 					break;
-				case "number":
+				case 'number':
 					curAttributeType = 'Number';
 					break;
 				default:
@@ -378,8 +370,8 @@ export default class SendBetterEmailCPE extends LightningElement {
 			let attributeToChange = curRecipient.typeMap[event.detail.newValueObjectType];
 			let newLabel = event.detail.newValue ? curRecipient.baseLabel + ' (' + event.detail.newValue + ')' : curRecipient.baseLabel;
 			curRecipient.label = newLabel;
-			if (event.detail.newValueType === this.settings.stringDataType) {
-				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? event.detail.newValue : this.settings.nullValue, this.settings.stringDataType);
+			if (event.detail.newValueType === this.settings.stringCollectionVariablesOption) {
+				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? event.detail.newValue : this.settings.nullValue, this.settings.stringCollectionVariablesOption);
 			} else {
 				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? '{!' + event.detail.newValue + '}' : this.settings.nullValue, this.settings.referenceDataType);
 			}

--- a/flow_action_components/SendBetterEmail/sfdx-project.json
+++ b/flow_action_components/SendBetterEmail/sfdx-project.json
@@ -2,33 +2,6 @@
     "packageDirectories": [
         {
             "path": "force-app",
-            "default": false,
-            "package": "SendBetterEmailPrA",
-            "versionName": "ver 0.1",
-            "versionNumber": "0.1.0.NEXT"
-        },
-        {
-            "path": "force-app",
-            "package": "sendBetterEmail(Without Examples)",
-            "versionName": "ver 1.33.01",
-            "versionNumber": "1.33.01.NEXT",
-            "default": false
-        },
-        {
-            "path": "force-app",
-            "package": "sendBetterEmail",
-            "versionName": "ver 1.33.03",
-            "versionNumber": "1.33.03.NEXT",
-            "definitionFile": "config/project-scratch-def.json",
-            "dependencies": [
-                {
-                    "package": "FlowBaseComponents@1.2.3-0"
-                }
-            ],
-            "default": false
-        },
-        {
-            "path": "force-app",
             "package": "sendBetterEmail",
             "versionName": "ver 2.0.0",
             "versionNumber": "2.0.0.NEXT",
@@ -45,18 +18,9 @@
     "sourceApiVersion": "49.0",
     "packageAliases": {
         "FLowBaseComponents": "033f4000000AoiCAAS",
-        "SendBetterEmailPrA": "0HoB0000000CavEKAS",
-        "SendBetterEmailPrA@0.1.0-1": "04tB0000000OE9cIAG",
-        "SendBetterEmailPrA@0.1.0-2": "04tB0000000ORBxIAO",
-        "sendBetterEmail": "0Ho3h000000Gmb2CAC",
-        "sendBetterEmail(No Tests)": "0Ho3h000000GmbCCAS",
-        "sendBetterEmail(Without Examples)": "0Ho3h0000008OTFCA2",
-        "sendBetterEmail@1.33.1-0": "04t3h000002Ne4QAAS",
-        "sendBetterEmail(Without Examples)@1.33.1-0": "04t3h000002Ne4kAAC",
+        "sendBetterEmail": "0Ho3h000000XZEsCAO",
         "FlowBaseComponents@1.2.3-0": "04tf4000004Pu2iAAC",
-        "sendBetterEmail@1.33.2-0": "04t3h0000045qdMAAQ",
-        "sendBetterEmail@1.33.2-2": "04t3h0000045qdRAAQ",
-        "sendBetterEmail@1.33.2-3": "04t3h0000045qeeAAA",
-        "sendBetterEmail@1.33.3-0": "04t3h0000045qf3AAA"
+        "sendBetterEmail(Without Examples)@1.33.1-0": "04t3h000002Ne4kAAC",
+        "sendBetterEmail@0.0.0-0": "04t3h0000045qmeAAA"
     }
 }

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/classes/SendHTMLEmail.cls
@@ -4,7 +4,7 @@
  * @Credits				: Authored by Alex Edelstein, etal
  * @Group				: unofficialSF
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 08-11-2020
+ * @Last Modified On	: 08-12-2020
  * @License				: LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * @Modification Log	: 
  * 
@@ -120,7 +120,7 @@ public without sharing class SendHTMLEmail {
 						if (curRequest.whatIds != null && curRequest.whatIds.size() > 0 ){
 							if (curRequest.whatIds.size() == curRequest.targetObjectIds.size()){
 								try {
-									mmail.setTargetObjectIds(curRequest.whatIds);
+									mmail.setWhatIds(curRequest.whatIds);
 								} catch (Exception e){
 									thisResponse.errors = e.getMessage();
 								}

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/lwc/addNewMembers/addNewMembers.js-meta.xml
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/lwc/addNewMembers/addNewMembers.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="addNewMembers">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>49.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__AppPage</target>

--- a/flow_action_components/SendHTMLEmail/force-app/main/default/lwc/sendHTMLEmailCPE/sendHTMLEmailCPE.js
+++ b/flow_action_components/SendHTMLEmail/force-app/main/default/lwc/sendHTMLEmailCPE/sendHTMLEmailCPE.js
@@ -5,26 +5,12 @@
  * @Credits				: From quickChoiceCPE,Andrii Kraiev and sentRichEmailCPE,Alex Edelstein etal.
  * @Group				: 
  * @Last Modified By	: Jack D. Pond
- * @Last Modified On	: 08-11-2020
+ * @Last Modified On	: 08-13-2020
  * @Modification Log	: 
  * Ver		Date		Author				Modification
  * 1.33.2	6/29/2020	Jack D. Pond		Initial Version
 **/
 import {api, track, LightningElement} from 'lwc';
-
-/*	MassEmail
-
-	saveAsTask
-	setBccSender(bcc)
-	setDescription(description)
-	setReplyTo(replyAddress)
-	setSaveAsActivity(saveAsActivity)
-	setSenderDisplayName(displayName)
-	setTargetObjectIds(targetObjectIds)
-	setTemplateID(templateId)
-	setUseSignature(useSignature)
-	setWhatIds(whatIds)
-*/
 
 export default class SendHTMLEmailCPE extends LightningElement {
 	_builderContext;
@@ -38,6 +24,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 		singleEmailOption: 'singleEmail',
 		massEmailOption: 'massEmail',
 		flowDataTypeString: 'String',
+		stringCollectionVariablesOption: 'String Collection',
 		stringVariablesOption: 'String Variables (or type an address)',
 		stringDataType: 'String',
 		referenceDataType: 'reference',
@@ -82,20 +69,6 @@ export default class SendHTMLEmailCPE extends LightningElement {
 		SendBCCtheEmailAddressesFromThisCollectionOfUsers: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfUsers'},
 		SendBCCtheEmailAddressesFromThisCollectionOfLeads: {value: null, valueDataType: null, isCollection: false, label: 'SendBCCtheEmailAddressesFromThisCollectionOfLeads'},
 		contentDocumentAttachments: {value: null, valueDataType: null, isCollection: false, label: 'Attach which Content Document Links?'}
-/*
-		allowNoneToBeChosen: {value: null, valueDataType: null, isCollection: false, label: 'Add a \'None\' choice'},
-		required: {value: null, valueDataType: null, isCollection: false, label: 'Required'},
-		masterLabel: {value: null, valueDataType: null, isCollection: false, label: 'Master Label'},
-		value: {value: null, valueDataType: null, isCollection: false, label: 'Value (Default or Existing)'},
-		style_width: {value: null, valueDataType: null, isCollection: false, label: 'Width (Pixels)'},
-		numberOfColumns: {value: null, valueDataType: null, isCollection: false, label: 'Number of Columns'},
-		includeIcons: {value: null, valueDataType: null, isCollection: false, label: 'Show Icons'},
-		choiceIcons: {value: null, valueDataType: null, isCollection: true, label: 'Choice Icons [Card Icons]'},
-		iconSize: {value: null, valueDataType: null, isCollection: false, label: 'Icon Size'},
-		objectName: {value: null, valueDataType: null, isCollection: false, label: 'Select Object'},
-		fieldName: {value: null, valueDataType: null, isCollection: false, label: 'Select Field'},
-		recordTypeId: {value: null, valueDataType: null, isCollection: false, label: 'Filter on Record Type ID:'},
-*/
 	};
 
 	bodyOptions = [
@@ -153,7 +126,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 			'User': 'SendTOtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendTOtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendTOtheEmailAddressesFromThisCollectionOfLeads',
-			'String': 'SendTOthisStringCollectionOfEmailAddresses',
+			'String Collection': 'SendTOthisStringCollectionOfEmailAddresses',
 			'String Variables (or type an address)': 'SendTOthisOneEmailAddress'
 		}
 	}, {
@@ -165,7 +138,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 			'User': 'SendCCtheEmailAddressesFromThisCollectionOfUsers',
 			'Contact': 'SendCCtheEmailAddressesFromThisCollectionOfContacts',
 			'Lead': 'SendCCtheEmailAddressesFromThisCollectionOfLeads',
-			'String': 'SendCCthisStringCollectionOfEmailAddresses',
+			'String Collection': 'SendCCthisStringCollectionOfEmailAddresses',
 			'String Variables (or type an address)': 'SendCCthisOneEmailAddress'
 		}
 	}, {
@@ -260,17 +233,41 @@ export default class SendHTMLEmailCPE extends LightningElement {
 			}
 		});
 		let stringVariables = flowContext.variables.filter(curValue => {
-			return curValue.dataType === 'String' && !curValue.isCollection
+			return curValue.dataType === 'String' && curValue.isCollection
 		});
 
-		if (stringVariables && stringVariables.length) {
-			outputTypes[this.settings.stringVariablesOption] = {
-				data: stringVariables,
-				valueFieldName: 'name',
-				labelFieldName: 'name'
-			};
-		}
+
+		allowedTypes.forEach(curType => {
+			if (curType === 'String'){
+				let allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === curType && curValue.isCollection
+				});
+				this.addToOutputTypes(outputTypes,allVariables,this.settings.stringCollectionVariablesOption,false);
+				allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === curType && !curValue.isCollection
+				});
+				this.addToOutputTypes(outputTypes,allVariables,this.settings.stringVariablesOption,false);
+			} else {
+				let allVariables = flowContext.variables.filter(curValue => {
+					return curValue.dataType === 'SObject' && curValue.objectType === curType
+				});
+				this.addToOutputTypes(outputTypes,allVariables,curType,true);
+			}
+		});
 		this.convertedFlowContext = outputTypes;
+	}
+	addToOutputTypes(outputTypes,theseVariables,variablesOption,isSObject) {
+		let retVal = null;
+		if (theseVariables && theseVariables.length) {
+			if (!(variablesOption in outputTypes)) {
+				outputTypes[variablesOption] = {
+					data: [],
+					valueFieldName: 'name',
+					labelFieldName: 'name'
+				}
+			}
+			outputTypes[variablesOption].data.push(...theseVariables);
+		}
 	}
 
 	doCleanRoleManager(baseLabel, newValueObjectType) {
@@ -288,7 +285,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 		if (valuesToCleanUp.length) {
 			valuesToCleanUp.forEach(valueToCleanUp => {
 				if (valueToCleanUp && valueToCleanUp.value) {
-					this.dispatchFlowValueChangeEvent(valueToCleanUp.name, this.settings.nullValue, this.settings.stringDataType);
+					this.dispatchFlowValueChangeEvent(valueToCleanUp.name, this.settings.nullValue, this.settings.stringCollectionVariablesOption);
 				}
 			});
 		}
@@ -318,6 +315,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 				newValueDataType: newValueDataType
 			}
 		});
+
 		this.dispatchEvent(valueChangedEvent);
 	}
 
@@ -334,7 +332,7 @@ export default class SendHTMLEmailCPE extends LightningElement {
 		let curAttributeName = event.target.name ? event.target.name : null;
 		this.inputValues.emailMessageType.value = event.detail.value;
 		this.isMassEmail = this.inputValues.emailMessageType.value === this.settings.massEmailOption;
-		this.dispatchFlowValueChangeEvent(curAttributeName, event.detail.value, "String");
+		this.dispatchFlowValueChangeEvent(curAttributeName, event.detail.value, 'String');
 		//		this.doClearBodyOptions();
 	}
 
@@ -351,10 +349,10 @@ export default class SendHTMLEmailCPE extends LightningElement {
 			let curAttributeValue = event.target.type === 'checkbox' ? event.target.checked : event.detail.value;
 			let curAttributeType;
 			switch (event.target.type) {
-				case "checkbox":
+				case 'checkbox':
 					curAttributeType = 'Boolean';
 					break;
-				case "number":
+				case 'number':
 					curAttributeType = 'Number';
 					break;
 				default:
@@ -372,8 +370,8 @@ export default class SendHTMLEmailCPE extends LightningElement {
 			let attributeToChange = curRecipient.typeMap[event.detail.newValueObjectType];
 			let newLabel = event.detail.newValue ? curRecipient.baseLabel + ' (' + event.detail.newValue + ')' : curRecipient.baseLabel;
 			curRecipient.label = newLabel;
-			if (event.detail.newValueType === this.settings.stringDataType) {
-				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? event.detail.newValue : this.settings.nullValue, this.settings.stringDataType);
+			if (event.detail.newValueType === this.settings.stringCollectionVariablesOption) {
+				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? event.detail.newValue : this.settings.nullValue, this.settings.stringCollectionVariablesOption);
 			} else {
 				this.dispatchFlowValueChangeEvent(attributeToChange, event.detail.newValue ? '{!' + event.detail.newValue + '}' : this.settings.nullValue, this.settings.referenceDataType);
 			}

--- a/flow_action_components/SendHTMLEmail/sfdx-project.json
+++ b/flow_action_components/SendHTMLEmail/sfdx-project.json
@@ -2,33 +2,6 @@
     "packageDirectories": [
         {
             "path": "force-app",
-            "default": false,
-            "package": "SendHTMLEmailPrA",
-            "versionName": "ver 0.1",
-            "versionNumber": "0.1.0.NEXT"
-        },
-        {
-            "path": "force-app",
-            "package": "sendHTMLEmail(Without Examples)",
-            "versionName": "ver 1.33.01",
-            "versionNumber": "1.33.01.NEXT",
-            "default": false
-        },
-        {
-            "path": "force-app",
-            "package": "sendHTMLEmail",
-            "versionName": "ver 1.33.03",
-            "versionNumber": "1.33.03.NEXT",
-            "definitionFile": "config/project-scratch-def.json",
-            "dependencies": [
-                {
-                    "package": "FlowBaseComponents@1.2.3-0"
-                }
-            ],
-            "default": false
-        },
-        {
-            "path": "force-app",
             "package": "sendHTMLEmail",
             "versionName": "ver 2.0.0",
             "versionNumber": "2.0.0.NEXT",
@@ -45,18 +18,10 @@
     "sourceApiVersion": "49.0",
     "packageAliases": {
         "FLowBaseComponents": "033f4000000AoiCAAS",
-        "SendHTMLEmailPrA": "0HoB0000000CavEKAS",
-        "SendHTMLEmailPrA@0.1.0-1": "04tB0000000OE9cIAG",
-        "SendHTMLEmailPrA@0.1.0-2": "04tB0000000ORBxIAO",
         "sendHTMLEmail": "0Ho3h000000Gmb2CAC",
         "sendHTMLEmail(No Tests)": "0Ho3h000000GmbCCAS",
         "sendHTMLEmail(Without Examples)": "0Ho3h0000008OTFCA2",
-        "sendHTMLEmail@1.33.1-0": "04t3h000002Ne4QAAS",
-        "sendHTMLEmail(Without Examples)@1.33.1-0": "04t3h000002Ne4kAAC",
         "FlowBaseComponents@1.2.3-0": "04tf4000004Pu2iAAC",
-        "sendHTMLEmail@1.33.2-0": "04t3h0000045qdMAAQ",
-        "sendHTMLEmail@1.33.2-2": "04t3h0000045qdRAAQ",
-        "sendHTMLEmail@1.33.2-3": "04t3h0000045qeeAAA",
-        "sendHTMLEmail@1.33.3-0": "04t3h0000045qf3AAA"
+        "sendHTMLEmail@2.0.0-0": "04t3h0000045qiMAAQ"
     }
 }


### PR DESCRIPTION
Code was only looking in "lookups" in flows.  Should have also been looking in variables - for both objects (record collections) and strings (string collections).

Also fixed but that was associating tasks with targetId instead of WhatId

Next Steps:

1. Modify the documentation for renaming and update the 6 flow example videos(after your preliminary review) (JDP)
2. Create the sendBetterEmail Version 2.0.0.0 unmanaged package (AE)

Subsequent steps:

- Refactor code for quality and maintainability
- Introduce validations into CPE instead of action class
- Introduce flow-level bulkification (allow multiple request "bags" to be created using mdt record). Not sure if this one is needed