### PR TITLE
Fixed regex to not strip __ from field names

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/GenerateCollectionReport.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/GenerateCollectionReport.cls
@@ -28,7 +28,7 @@ global with sharing class GenerateCollectionReport {
             hideHeader = curRequest.hideHeader != null ? curRequest.hideHeader :  false;
             if (inputCollection != null && !inputCollection.isEmpty() && shownFields != null) {
                 reportString += 'Collection Type: ' + inputCollection[0].getSObjectType().getDescribe().getName() + '\n\n';
-                List<String> shownFieldsArray = shownFields.replaceAll('[^a-zA-Z0-9\\,]', '').split(',');
+                List<String> shownFieldsArray = shownFields.replaceAll('[^a-zA-Z0-9\\,\\_]', '').split(',');
                 System.debug('first value in shownFieldsArray is: ' + shownFieldsArray[0]);
                 //System.debug('second value in shownFieldsArray is: ' + shownFieldsArray[1]);
                 switch on displayMode {


### PR DESCRIPTION
Noticed the field name was getting truncated if it had __c in it so I found the issue in the regex that cleans up the field names