### PR TITLE
support for String.Split, Strings.Join, Strings.Unique

### DIFF
--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringSplit.cls
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringSplit.cls
@@ -1,0 +1,39 @@
+global class StringSplit {
+  @InvocableMethod(
+    label='Splits a string in an array of strings'
+    description='Given a string and a delimiter, will split the string into a collection of strings'
+    category='String Helpers'
+  )
+  global static List<List<String>> stringSplit(List<StringSplitParams> params) {
+    List<String[]> results = new List<String[]>();
+    for (StringSplitParams p : params) {
+      if (p.str == null) {
+        results.add(new List<String>{});
+        continue;
+      }
+      if (p.delim == null) {
+        results.add(new List<String>{ p.str });
+        continue;
+      }
+
+      results.add(p.str.split(p.delim));
+    }
+    return results;
+  }
+
+  global class StringSplitParams {
+    @InvocableVariable(
+      label='String'
+      description='The string to split'
+      required=false
+    )
+    global String str;
+
+    @InvocableVariable(
+      label='Delimiter'
+      description='The delimiter to split on'
+      required=false
+    )
+    global String delim;
+  }
+}

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringSplit.cls-meta.xml
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringSplit.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsJoin.cls
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsJoin.cls
@@ -1,0 +1,30 @@
+global class StringsJoin {
+  @InvocableMethod(
+    label='Join Strings'
+    description='Joins a list of strings with optional delimiter'
+    category='String Helper'
+  )
+  global static List<String> join(List<StringJoinParams> parm) {
+    List<String> results = new List<String>();
+    for (StringJoinParams p : parm) {
+      results.add(String.join(p.arr, p.delim));
+    }
+    return results;
+  }
+
+  global class StringJoinParams {
+    @InvocableVariable(
+      label='String Collection'
+      description='The list of strings to join'
+      required=false
+    )
+    global String[] arr;
+
+    @InvocableVariable(
+      label='Delimiter'
+      description='The delimiter to join with'
+      required=false
+    )
+    global String delim;
+  }
+}

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsJoin.cls-meta.xml
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsJoin.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsTests.cls
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsTests.cls
@@ -1,0 +1,38 @@
+@isTest
+public class StringsTests {
+  @isTest
+  private static void testSplit() {
+    StringSplit.StringSplitParams p = new StringSplit.StringSplitParams();
+    p.str = '1;2;3';
+    p.delim = ';';
+    List<String[]> result = StringSplit.stringSplit(
+      new List<StringSplit.StringSplitParams>{ p }
+    );
+    System.assertEquals(1, result.size());
+    System.assertEquals(3, result[0].size());
+    System.assertEquals('1', result[0][0]);
+  }
+
+  @isTest
+  private static void testJoin() {
+    StringsJoin.StringJoinParams p = new StringsJoin.StringJoinParams();
+    p.arr = new List<String>{ '1', '2', '3' };
+    p.delim = ',';
+    String[] result = StringsJoin.join(
+      new List<StringsJoin.StringJoinParams>{ p }
+    );
+    System.assertEquals(1, result.size());
+    System.assertEquals('1,2,3', result[0]);
+  }
+
+  @isTest
+  private static void testUnique() {
+    StringsUnique.StringUniqueParam p = new StringsUnique.StringUniqueParam();
+    p.arr = new List<String>{ '1', '1', '2', '3', '2' };
+    List<String[]> result = StringsUnique.unique(
+      new List<StringsUnique.StringUniqueParam>{ p }
+    );
+    System.assertEquals(1, result.size());
+    System.assertEquals(3, result[0].size());
+  }
+}

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsTests.cls-meta.xml
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsUnique.cls
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsUnique.cls
@@ -1,0 +1,43 @@
+global class StringsUnique {
+  @InvocableMethod(
+    label='Unique Strings'
+    description='Returns only unique Strings'
+    category='String Helper'
+  )
+  global static List<String[]> unique(List<StringUniqueParam> parm) {
+    List<String[]> results = new List<String[]>();
+    for (StringUniqueParam p : parm) {
+      Set<String> pValues = new Set<String>();
+      List<String> res = new List<String>();
+
+      for (String s : p.arr) {
+        String comp = p.ignoreCase != null && p.ignoreCase
+          ? s.toLowerCase()
+          : s;
+        if (!pValues.contains(comp)) {
+          res.add((s));
+        }
+        pValues.add(comp);
+      }
+      results.add(res);
+    }
+    return results;
+  }
+
+  global class StringUniqueParam {
+    @InvocableVariable(
+      label='String Collection'
+      description='The list of strings to join'
+      required=false
+    )
+    global String[] arr;
+
+    // TODO
+    @InvocableVariable(
+      label='Ignore Case'
+      description='Ignore string casing (case in-sensitive).'
+      required=false
+    )
+    global Boolean ignoreCase;
+  }
+}

--- a/flow_action_components/StringChangers/force-app/main/default/classes/StringsUnique.cls-meta.xml
+++ b/flow_action_components/StringChangers/force-app/main/default/classes/StringsUnique.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>48.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
I started writing something similar, and then I found this project (glad I did because it does a bunch of what I was going to do plus TON more.  Nice work!!!!)

Anyways, I had a couple invocable that I didn't see in here (incoming via this PR and one other).

- `String.Join`
- `String.split`: I've found this really nice as it's a easy way to init collects of strings
- `String.unique`: filters a collection of string, removing duplicates 

I wasn't sure the best place to put them, so let me know if I need to move these or create a new folder.  Also, I can split out the tests to individual files

If you don't think they are a valuable addition, no worries!