### PR TITLE
Fixed string typecaste not working for decimals

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/GenerateCollectionReport.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/GenerateCollectionReport.cls
@@ -61,7 +61,7 @@ global with sharing class GenerateCollectionReport {
                 fieldValue = '';
             } else {
                 if (record != null){
-                    fieldValue = (String)record.get(fieldName);
+                    fieldValue = String.valueOf(record.get(fieldName));
                     if (fieldValue == null) fieldValue = '';
                 } else fieldValue = fieldName;
                 


### PR DESCRIPTION
For some reason (String)record.get(fieldname)) was not working so I tried using the valueOf method in String and it no longer broke. Related to this comment as well: https://unofficialsf.com/convert-record-data-into-tables-for-email-automation-with-generate-collection-report/#comment-1565