### PR TITLE
Fix {} Characters

### DIFF
--- a/flow_process_components/FlowBaseComponents/force-app/main/default/classes/fbc_RetrieveMetadata.cls
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/classes/fbc_RetrieveMetadata.cls
@@ -29,6 +29,10 @@
  **/
 
  /**
+ * Eric Smith - 9/3/20
+ * 
+ * 		Escaped {} characters in the Extracted File String so it could be processed in a Flow
+ * 
  * Eric Smith - August 2020
  * 
  *      Extract a single metadata file from the Zip file returned by the Retrieve
@@ -40,7 +44,7 @@
 
 public  with sharing class fbc_RetrieveMetadata 
 {
-	private static final Integer METADATA_API_VERSION = 48;
+	private static final Integer METADATA_API_VERSION = 49;
 
 	public static List<SelectOption> MetaDataTypes {get; set;}
 	public static String MetaDataType {get; set;}		
@@ -166,9 +170,14 @@ RetrieveResult retrieveResult = metadataConnection.checkRetrieveStatus(response.
         //currently only set up to handle a single file
         Blob fileData = curZippex.getFile(filenamesList[0]);
         System.debug ('filename: ' + filenamesList[0]);
-        System.debug ('filedata: [' + fileData.toString() + ']');
+		System.debug ('filedata: [' + fileData.toString() + ']');
 
-        return fileData.toString();
+		// Escape {} characters so the String can be processed in a Flow
+		String escFileData = fileData.toString();
+		escFileData = escFileData.replace('{', '&lbrace;');
+		escFileData = escFileData.replace('}', '&rbrace;');
+		
+		return escFileData;
 
     }
 

--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_transferMetadata/fbc_transferMetadata.js
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_transferMetadata/fbc_transferMetadata.js
@@ -1,4 +1,5 @@
 /**
+ * 09/03/20     Eric Smith      Unescaped {} characters in the Metadata String in case it was passed in that way from a Flow
  * 
  * 08/21/20     Eric Smith      Added Extracted and Escaped Metadata Strings to the Output Attributes
  * 
@@ -82,7 +83,13 @@ export default class TransferMetadata extends LightningElement {
         // this.modifiedName = this.metadataName + '_Converted';
         this.modifiedName = this.metadataName;
         console.log('this.metadataName is: ' + this.modifiedName);
-        fbc_deployMetadata({ metadataText : this.metadataString, metadataName : this.modifiedName, testLevel: null, objectType : this.objectType,  })
+
+        // Special Processing to unescape characters passed by the Import/Export Flows flow
+        let documentContent = this.metadataString;
+        documentContent = documentContent.replaceAll('&lbrace;', '{');
+        documentContent = documentContent.replaceAll('&rbrace;', '}');
+
+        fbc_deployMetadata({ metadataText : documentContent, metadataName : this.modifiedName, testLevel: null, objectType : this.objectType,  })        
         .then(result => {
             console.log('result of deployment request is: ' + result);
             console.log('successfully sent async deployment request');

--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_transferMetadata/fbc_transferMetadata.js
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_transferMetadata/fbc_transferMetadata.js
@@ -84,7 +84,7 @@ export default class TransferMetadata extends LightningElement {
         this.modifiedName = this.metadataName;
         console.log('this.metadataName is: ' + this.modifiedName);
 
-        // Special Processing to unescape characters passed by the Import/Export Flows flow
+        // Special Processing to unescape characters that could be passed in by a flow
         let documentContent = this.metadataString;
         documentContent = documentContent.replaceAll('&lbrace;', '{');
         documentContent = documentContent.replaceAll('&rbrace;', '}');


### PR DESCRIPTION
Escape and unescape the { and } characters when passing metadata strings to and from a flow