### PR TITLE
Fix error in card selection when no Master Label

### DIFF
--- a/flow_screen_components/quickChoiceCPE/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.html
+++ b/flow_screen_components/quickChoiceCPE/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.html
@@ -17,6 +17,9 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+9/14/20 -   Eric Smith -    Version 2.3 
+                            Fixed visual card selection when no Master Label is provided  
+  
 8/27/20 -   Eric Smith -    Version 2.2
                             Added an option to sort the Picklist labels
 
@@ -57,7 +60,7 @@ Additional components packaged with this LWC:
             <div class={gridClass} style={gridStyle}>
                 <template for:each={items} for:item="item">
                     <div key={item.name} class={columnClass}>
-                        <input type="radio" id={item.name} value={item.name} name={masterLabel} data-id={item.name} onclick={handleChange} />
+                        <input type="radio" id={item.name} value={item.name} name={radioGroup} data-id={item.name} onclick={handleChange} />
                         <label for={item.name}>
 
                             <!-- Display Visual Card Pickers with Icons-->
@@ -108,7 +111,7 @@ Additional components packaged with this LWC:
         <template if:true={showRadio}>
             <div style={inputStyle}>
                 <lightning-radio-group 
-                    name={masterLabel} 
+                    name={radioGroup} 
                     label={masterLabel} 
                     value={selectedValue}
                     options={options}

--- a/flow_screen_components/quickChoiceCPE/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js
+++ b/flow_screen_components/quickChoiceCPE/force-app/main/default/lwc/quickChoiceFSC/quickChoiceFSC.js
@@ -87,6 +87,14 @@ export default class QuickChoiceFSC extends LightningElement {
         this._allLabels = value;
     }
 
+    @api get radioGroup() {
+        return "RG-" + this.masterLabel + "_RG";
+    }
+
+    set radioGroup(value) {
+        this.radioGroup = value;
+    }
+    
     //possibility master record type only works if there aren't other record types?
     @wire(getPicklistValues, {
         recordTypeId: "$recordTypeId",


### PR DESCRIPTION
Visual cards did not act like a radio group when no Master Label was provided.  Master Label can now be empty and the selection will work as expected.