### PR TITLE
Fix failing test setup for orgs with email change verification disabled.

### DIFF
--- a/flow_process_components/FlowBaseComponents/force-app/main/default/classes/fbc_SearchUtilsTest.cls
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/classes/fbc_SearchUtilsTest.cls
@@ -9,7 +9,7 @@ private class fbc_SearchUtilsTest {
     @testSetup
     static void setup() {
         List<Profile> adminProfile = [SELECT Id FROM Profile WHERE Name = 'System Administrator'];
-        User testUser = new User(Alias = 'test1', Email = 'testuser1@testorg.com', EmailEncodingKey = 'UTF-8', LastName = TEST_RECORD_NAME, LanguageLocaleKey = 'en_US', LocaleSidKey = 'en_US', ProfileId = adminProfile[0].Id, TimeZoneSidKey = 'America/Los_Angeles', UserName = TEST_RECORD_NAME);
+        User testUser = new User(Alias = 'test1', Email = 'testuser1@example.com', EmailEncodingKey = 'UTF-8', LastName = TEST_RECORD_NAME, LanguageLocaleKey = 'en_US', LocaleSidKey = 'en_US', ProfileId = adminProfile[0].Id, TimeZoneSidKey = 'America/Los_Angeles', UserName = TEST_RECORD_NAME);
         insert testUser;
         Group userGroup = new Group(Name = TEST_RECORD_NAME, type = 'Queue');
         insert userGroup;


### PR DESCRIPTION
When an org has Email Change Verification **disabled**, a user's email address can only be in the whitelisted domains or example.com.  fbc_SearchUtilsTest.setup() currently fails in these orgs as 'testorg.com' is not in the domain whitelist.

Changes:
Changed the email address for the test user from 'testuser1@testorg.com' to 'testuser1@example.com' in fbc_SearchUtilsTest.setup()