### PR TITLE
Revert "Quick Choice InstantNavigation Mode"

### DIFF
--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceCpe/fbc_quickChoiceCpe.html
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceCpe/fbc_quickChoiceCpe.html
@@ -24,13 +24,6 @@
                     checked={inputValues.includeIcons.value}
                     onchange={handleValueChange}
             ></lightning-input>
-        <lightning-input
-                name="select_navOnSelect"
-                type="checkbox"
-                label={inputValues.navOnSelect.label}
-                checked={inputValues.navOnSelect.value}
-                 onchange={handleValueChange}
-        ></lightning-input>
         <!-- </template> -->
         <!-- <template if:true={inputValues.includeIcons.value}> -->
             <c-fbc_flow-combobox

--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceCpe/fbc_quickChoiceCpe.js
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceCpe/fbc_quickChoiceCpe.js
@@ -15,7 +15,6 @@ export default class QuickChoiceCpe extends LightningElement {
         style_width: {value: null, valueDataType: null, isCollection: false, label: 'Width (Pixels)'},
         numberOfColumns: {value: null, valueDataType: null, isCollection: false, label: 'Number of Columns'},
         includeIcons: {value: null, valueDataType: null, isCollection: false, label: 'Show Icons'},
-        navOnSelect: {value: false, valueDataType: null, isCollection: false, label: 'InstantNavigation Mode'},
         choiceIcons: {value: null, valueDataType: null, isCollection: true, label: 'Choice Icons [Card Icons]'},
         iconSize: {value: null, valueDataType: null, isCollection: false, label: 'Icon Size'},
         objectName: {value: null, valueDataType: null, isCollection: false, label: 'Select Object'},
@@ -98,10 +97,6 @@ export default class QuickChoiceCpe extends LightningElement {
         return this.inputValues.inputMode.value === this.settings.inputModeDualCollection;
     }
 
-    get isNavOnSelect() {
-        return this.inputValues.inputMode.value === this.settings.navOnSelect;
-    }
-    
     get isDatasourceSingleOrDualCollection() {
         return this.inputValues.inputMode.value === this.settings.inputModeSingleCollection || this.inputValues.inputMode.value === this.settings.inputModeDualCollection;
     }

--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceFSC/fbc_quickChoiceFSC.js
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceFSC/fbc_quickChoiceFSC.js
@@ -1,5 +1,5 @@
 import {LightningElement, api, track, wire} from "lwc";
-import {FlowAttributeChangeEvent, FlowNavigationNextEvent} from "lightning/flowSupport";
+import {FlowAttributeChangeEvent} from "lightning/flowSupport";
 import {getPicklistValues} from "lightning/uiObjectInfoApi";
 import Quickchoice_Images from '@salesforce/resourceUrl/fbc_Quickchoice_Images';	//Static Resource containing images for Visual Cards
 
@@ -7,9 +7,6 @@ import Quickchoice_Images from '@salesforce/resourceUrl/fbc_Quickchoice_Images';
 /* eslint-disable no-console */
 
 export default class QuickChoiceFSC extends LightningElement {
-
-    @api
-    availableActions = [];
 
     @api masterLabel;
     @api choiceLabels;
@@ -30,7 +27,6 @@ export default class QuickChoiceFSC extends LightningElement {
     @api choiceIcons;
     @api includeIcons;
     @api iconSize;
-    @api navOnSelect;
 
     //-------------For displayMode = Picklist or Radio
     @api style_width = 320;
@@ -305,10 +301,7 @@ export default class QuickChoiceFSC extends LightningElement {
         this.selectedValue = (this.showVisual) ? event.target.value : event.detail.value;
         console.log("selected value is: " + this.selectedValue);
         this.dispatchFlowAttributeChangedEvent('value', this.selectedValue);
-        if (this.navOnSelect && this.availableActions.find(action => action === 'NEXT')) {
-            const navigateNextEvent = new FlowNavigationNextEvent();
-            this.dispatchEvent(navigateNextEvent);
-        }
+
     }
 
     setSelectedLabel() {

--- a/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceFSC/fbc_quickChoiceFSC.js-meta.xml
+++ b/flow_process_components/FlowBaseComponents/force-app/main/default/lwc/fbc_quickChoiceFSC/fbc_quickChoiceFSC.js-meta.xml
@@ -16,7 +16,6 @@
             <property name="choiceLabels" label="Choice Labels (String Collection)" type="String[]" description="The labels of your choices"/>
             <property name="choiceIcons" label="Card Mode - Choice Icons (String Collection)" type="String[]" description="Icon names or image names"/>
             <property name="includeIcons" label="Card Mode - Include Icons in Display Box?" type="Boolean" description="Display the provided icons in the visual card when set to True"/>
-            <property name="navOnSelect" label="Button Mode" type="Boolean" role="inputonly" description="Navigate to next flow element on card selection"/>
             <property name="iconSize" label="Card Mode - Icon Size" type="String" description="Options include x-small, small, medium, or large. This value defaults to medium."/>
             <property name="numberOfColumns" label="Card Mode - Number of Display Box Columns (1 or 2)" type="String" description="1 or blank (default) for a single column or 2 for dual columns"/>
             <property name="inputMode" label="Input Mode" type="String" description="“Single String Collection”, “Dual String Collections”, “Picklist Field”, or ” Visual Text Box ” are currently supported"/>


### PR DESCRIPTION
Reverts alexed1/LightningFlowComponents#507

stand by...i'm pulling all the 'fbc_' prefixes out of flow base components because we're switching to managed packages. let me get that done first.