### PR TITLE
Ignore Account Duplicate Rules

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
@@ -413,7 +413,11 @@ public with sharing class ListActionsTest {
             returnList.add(new Account(Name = TEST_RECORD_NAME + i, Website = '' + i));
         }
         if (doInsert) {
-            insert returnList;
+            //insert returnList without triggering duplicate rules
+            Database.DMLOptions dml = new Database.DMLOptions(); 
+            dml.DuplicateRuleHeader.AllowSave = true; 
+            List<Database.SaveResult> sr = Database.insert(returnList, dml);
+
         }
 
         return returnList;

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
@@ -63,7 +63,10 @@ public with sharing class SObjectDeepClone {
                 clone.Id = null;
             }
             markAsCloned(clone);
-            insert clone;
+            
+            //insert clone without triggering duplicate rules            
+            Database.DMLOptions dml = new Database.DMLOptions(); 
+            dml.DuplicateRuleHeader.AllowSave = true; Database.SaveResult sr = Database.insert(clone, dml);
 
             clonedChildrenPerTypeMap = new Map<String, List<SObject>>();
             for (String relationshipName : this.relationshipMap.keySet()) {


### PR DESCRIPTION
Modifications so that tests will pass when Account duplicate rules are active in the org.