### PR TITLE
Remove_Sort_from_Loop

### DIFF
--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerController.cls
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerController.cls
@@ -34,10 +34,10 @@ global with sharing class FieldPickerController {
                 }
             }
 
-            result.sort();
-
         }
 
+        result.sort();      // Eric Smith 12/31/20 - Moved sort outside of for loop
+        
         return result;
 
     }


### PR DESCRIPTION
The FieldPickerController.cls in the FlowActionsBasePack had a Sort inside of a For Loop and it was causing an "Apex CPU time limit exceeded" error for some users.