### PR TITLE
new fsc_flowCheckbox

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowBanner/fsc_flowBanner.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowBanner/fsc_flowBanner.html
@@ -1,3 +1,25 @@
+<!-- 
+    
+Lightning Web Component for Flow Custom Property Editors:     fsc_flowBanner
+
+This component allows the developer to display a Header/Banner in a Custom Property Editor
+
+    It provides a way to create sections and add separation between different functional areas 
+    of a Custom Property Editor LWC.  The component also supports a link to informational or 
+    help text for the section.
+
+    Find complete instructions at https://unofficialsf.com/banner-component-for-custom-property-editors/
+
+CREATED BY:         Eric Smith
+
+VERSION:            1.0.0
+
+RELEASE NOTES:      
+
+11/28/20 -          Eric Smith -    Version 1.0.0
+
+-->
+
 <template>
     <!-- =============== Flow Banner =============== -->
     <div style={bannerStyle} class={bannerMargin}>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.html
@@ -1,0 +1,38 @@
+<!-- 
+    
+Lightning Web Component for Flow Custom Property Editors:     fsc_flowCheckbox
+
+This component allows the developer to display a Checkbox in a Custom Property Editor
+
+    This component avoids the issues with a CPE checkbox not being persistent unless it is selected more than once.  
+    It also support the ability to give a boolean attribute a default value of True.
+
+    Find complete instructions at https://unofficialsf.com/checkbox-component-for-custom-property-editors/
+
+CREATED BY:         Eric Smith
+
+VERSION:            1.0.0
+
+RELEASE NOTES:      
+
+02/08/21 -          Eric Smith -    Version 1.0.0
+
+-->
+
+<template>
+    <div class="slds-form-element">
+        <div class="slds-form-element__control">
+            <lightning-input
+                class={cbClass}
+                type="checkbox" 
+                label={label}
+                name={name}
+                disabled={disabled}
+                checked={isChecked}
+                field-level-help={fieldLevelHelp}
+                onblur={handleCheckboxChange}
+                onchange={handleCheckboxChange}
+            ></lightning-input>
+        </div>
+    </div>
+</template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.js
@@ -1,0 +1,31 @@
+import { LightningElement, api } from 'lwc';
+
+const CB_TRUE = 'CB_TRUE';
+const CB_FALSE = 'CB_FALSE';
+
+export default class FlowCheckbox extends LightningElement {
+    @api label;
+    @api name;
+    @api checked;
+    @api fieldLevelHelp;
+    @api disabled;
+
+    @api
+    get isChecked() {
+        return (this.checked == CB_TRUE) ? true : false;
+    }
+
+    cbClass = 'slds-p-top_xxx-small';
+
+    handleCheckboxChange(event) {
+        this.dispatchEvent(new CustomEvent('checkboxchanged', {
+            // bubbles: true
+            detail: {
+                id: event.target.name,
+                newValue: event.target.checked,
+                newValueDataType: 'Boolean',
+                newStringValue: event.target.checked ? CB_TRUE : CB_FALSE
+            }
+        }));
+    }
+}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCheckbox/fsc_flowCheckbox.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>50.0</apiVersion>
+    <isExposed>false</isExposed>
+</LightningComponentBundle>


### PR DESCRIPTION
New component for FlowScreenComponentsBasePack.

This is a Checkbox component for CPEs that provides a workaround to the inconsistent behavior with checkboxes in CPEs.  It also provides a way to default a checkbox attribute to True.

USF draft writeup: https://unofficialsf.com/?p=21892&preview=true

Standard behavior bug explanation: https://quip.com/03wkAa9Kpacl/Reproduce-CPE-Checkbox-Bug