### PR TITLE
Update FlexCard to support more than account object

### DIFF
--- a/flow_screen_components/flexcards/force-app/main/default/lwc/flexcardFlow/flexcardFlow.js
+++ b/flow_screen_components/flexcards/force-app/main/default/lwc/flexcardFlow/flexcardFlow.js
@@ -12,12 +12,13 @@ export default class FlexcardFlow extends LightningElement {
     @api icon;
     @api cardSize = 300;
     @api avatarField;
+    @api objectAPIName;
     @track fieldHTML='';
     @track recordLayoutData={};
     @track objectInfo;
     curRecord;
 
-     @wire(getObjectInfo, { objectApiName: 'Account' })
+     @wire(getObjectInfo, { objectApiName: '$objectAPIName' })
     recordInfo({ data, error }) {
         if (data) {
             this.objectInfo = data;

--- a/flow_screen_components/flexcards/force-app/main/default/lwc/flexcardFlow/flexcardFlow.js-meta.xml
+++ b/flow_screen_components/flexcards/force-app/main/default/lwc/flexcardFlow/flexcardFlow.js-meta.xml
@@ -11,6 +11,7 @@
             <property name="selectedLabel" label="Selected Label" type="String" role="outputOnly" description="The selected Label (V1.3+)"/>
             <property name="icon" label="Icon" type="String" description="Icon name for example standard:account"/>
             <propertyType name="T" extends="SObject" label="Flexcard Object API Name" description="Specify the API Name of the SObject to use in the Flexcard"/>
+            <property name="objectAPIName" label="Object API Name" type="String" role="inputOnly" require="true" description="The SObject API Name used to query fields and values" />
             <property name="records" label="Card Data Record Collection" type="{T[]}" role="inputOnly" description="Record Collection variable containing the records to display in the flexcard."/>
             <property name="visibleFieldNames" label="Visible Field Names" type="String" default="Id" required="true" description="Show which fields?"/>
             <property name="visibleFlowNames" label="Visible Flow Names" type="String" description="Show which flow?"/>


### PR DESCRIPTION
I added an inputOnly property to provide the object API Name for the js objectInfo wire I couldn't figure out how to get it from the "T" propertytype wasn't sure if that's possible or not. 