### PR TITLE
Update SObjectDeepClone.cls

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
@@ -194,7 +194,8 @@ public with sharing class SObjectDeepClone {
         if (fMap != null) {
             for (Schema.SObjectField ft : fMap.values()) { // loop through all field tokens (ft)
                 Schema.DescribeFieldResult fd = ft.getDescribe(); // describe each field (fd)
-                if (fd.isCreateable()) { // field is creatable
+                // *** Added Not Unique - Eric Smith - 3/6/21
+                if (fd.isCreateable() && !fd.isUnique()) { // field is creatable
                     selectFields.add(fd.getName());
                 }
             }


### PR DESCRIPTION
Trying to create a clone of a related record when one of the fields is required to be unique will cause this action to fail.