### PR TITLE
bugFix: use fsc_toast-message component instead of fbc

### DIFF
--- a/flow_screen_components/recordDetailFSC/force-app/main/default/lwc/recordDetailFlowScreenComponent/recordDetailFlowScreenComponent.html
+++ b/flow_screen_components/recordDetailFSC/force-app/main/default/lwc/recordDetailFlowScreenComponent/recordDetailFlowScreenComponent.html
@@ -112,8 +112,8 @@ Lightning Web Component for Flow Screens:       recordDetailFlowScreenComponent
                 </template>
             </div>
         </template>
-        <div class="fbc_toast-message">
-            <c-fbc_toast-message></c-fbc_toast-message>
+        <div class="fsc_toast-message">
+            <c-fsc_toast-message></c-fsc_toast-message>
         </div>
     </div>
 </template>


### PR DESCRIPTION
bugFix: mismatch where the child component on html page is <c-fsc_toast-message>, but in JS showToast(), querySelector is configured to select ('c-**fbc**_toast-message').

Fixed JS querySelector to select 'c-**fsc**_toast-message'