### PR TITLE
Added dedupe back in

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/DedupeRecordCollection.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/DedupeRecordCollection.cls
@@ -1,0 +1,49 @@
+global with sharing class DedupeRecordCollection {
+
+    @InvocableMethod
+    global static List<FlowResponse> dedupe(List<FlowRequest> requests) {
+        List<FlowResponse> flowResponses = new List<FlowResponse>();
+        for (FlowRequest request : requests) {
+            FlowResponse flowResponse = new FlowResponse();
+            flowResponse.outputRecordCollection = getUniqueSObjectCollection(request);
+            flowResponses.add(flowResponse);
+        }
+        return flowResponses;
+    }
+
+    private static List<SObject> getUniqueSObjectCollection(FlowRequest request) {
+        Map<String, SObject> sobjectMap = new Map<String, SObject>();
+        for (SObject record : request.inputRecordCollection) {
+            try {
+                String fieldValue = String.valueOf(record.get(request.fieldToDedupeOn));
+                if(!sobjectMap.containsKey(fieldValue)) {
+                    sobjectMap.put(fieldValue, record);
+                }
+            } catch(SObjectException e) {
+                System.debug(e.getMessage());
+            }
+        }
+        return sobjectMap.values();
+    }
+
+    global class FlowRequest {
+
+        @InvocableVariable(required=true)
+        global List<SObject> inputRecordCollection;
+        
+        @InvocableVariable(required=true)
+        global String fieldToDedupeOn;
+        
+    }
+
+    global class FlowResponse {
+
+        public FlowResponse() {
+            outputRecordCollection = new List<SObject>();
+        }
+
+        @InvocableVariable
+        global List<SObject> outputRecordCollection;
+
+    }
+}

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/DedupeRecordCollection.cls-meta.xml
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/DedupeRecordCollection.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
@alexed1 
Please rebuild Collection Processors with the addition of the dedupe component.  It was previously removed when it was thought incorrectly that Find Common and Uncommon would provide the same functionality.

I will update the documentation.