### PR TITLE
datatable picklist highlight fix

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/comboboxColumnType/comboboxColumnType.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/comboboxColumnType/comboboxColumnType.js
@@ -41,6 +41,6 @@ export default class ComboboxColumnType extends LightningElement {
         this.dispatchEvent(customEvent)
 
         //set isChanged so that cell is highlighted
-        this.cellClass = 'isChanged';
+        //this.cellClass = 'isChanged'; removed. highlighting controlled by manipulating fieldValues on the datatable
     }
 }

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1191,9 +1191,9 @@ export default class Datatable extends LightningElement {
         this.mydata = [...data];            // Reset the current table values
         if (!this.suppressBottomBar) {
             this.columns = [...this.columns];   // Force clearing of the edit highlights
+            //clear draftValues. this is required for custom column types that need to specifically write into draftValues
+            this.template.querySelector('c-custom-lightning-datatable').draftValues = [];
         }
-        //clear draftValues. this is required for custom column types that need to specifically write into draftValues
-        this.template.querySelector('c-custom-lightning-datatable').draftValues = [];
     }
 
     cancelChanges(event) {

--- a/flow_screen_components/datatable/force-app/main/default/staticresources/customLightningDatatableStyles.css
+++ b/flow_screen_components/datatable/force-app/main/default/staticresources/customLightningDatatableStyles.css
@@ -15,6 +15,10 @@
 c-custom-lightning-datatable lightning-primitive-cell-factory .slds-hyphenate {
     width: 100%;
 }
+/* ensures that custom column cells remain higlighted on hover when edited */
+.slds-scope .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited {
+    background-color: rgb(250, 255, 189);
+}
 
 /********************************/
 /**** c-combobox-column-type ****/
@@ -24,14 +28,15 @@ c-combobox-column-type .slds-dropdown {
     max-height: 180px;
 }
 /* highlight combobox if value is changed*/
-c-combobox-column-type .isChanged input[lightning-basecombobox_basecombobox],
+/* removed. highlighting is now controlled by manipulating fieldValues*/
+/*c-combobox-column-type .isChanged input[lightning-basecombobox_basecombobox],
 c-combobox-column-type .isChanged input[readonly][role=combobox],
 c-combobox-column-type .isChanged input:focus,
 .slds-scope c-combobox-column-type .isChanged input[lightning-basecombobox_basecombobox],
 .slds-scope c-combobox-column-type .isChanged input[readonly][role=combobox],
 .slds-scope c-combobox-column-type .isChanged input:focus {
     background-color: rgb(250, 255, 189);
-}
+} */
 /* Remove position:absolute on the dropdown icon so that it doesn't appear on top of column action dropdown*/
 c-combobox-column-type lightning-base-combobox .slds-input-has-icon lightning-icon.slds-input__icon{
     top: 0;

--- a/flow_screen_components/datatable/force-app/main/default/staticresources/customLightningDatatableStyles.css
+++ b/flow_screen_components/datatable/force-app/main/default/staticresources/customLightningDatatableStyles.css
@@ -16,7 +16,8 @@ c-custom-lightning-datatable lightning-primitive-cell-factory .slds-hyphenate {
     width: 100%;
 }
 /* ensures that custom column cells remain higlighted on hover when edited */
-.slds-scope .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited {
+.slds-scope .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited,
+.slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited {
     background-color: rgb(250, 255, 189);
 }
 


### PR DESCRIPTION
Updated the behaviour of datatable picklist highlight when cell is edited. This will now resemble standard behaviour, where the box is highlighted but the dropdown isn't. The box highlight is controlled by salesforce by manipulating the fieldValues of the datatable.