### PR TITLE
Icon picker update + CPE

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
@@ -102,37 +102,37 @@ Updates:    Added an option to hide the Actions Icons
                             title="Select one of the tabs to the right to pick an Icon Type">
                         </lightning-tab>
                         <template if:false={excludeStandardIcons}>
-                        <lightning-tab label="Standard Icons" icon-name="standard:case"
-                            title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
-                            <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
-                                    table-data={standardIcons} columns={columns} max-row-selection="1"
-                                    onrowselection={iconSelected} table-style={tableStyle}>
-                                </c-fsc_searchable-data-table>
-                            </div>
-                        </lightning-tab>
+                            <lightning-tab label="Standard Icons" icon-name="standard:case"
+                                title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
+                                <div style={tabHeight}>
+                                    <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                        table-data={standardIcons} columns={columns} max-row-selection="1"
+                                        onrowselection={iconSelected} table-style={tableStyle}>
+                                    </c-fsc_searchable-data-table>
+                                </div>
+                            </lightning-tab>
                         </template>
                         <template if:false={excludeUtilityIcons}>
-                        <lightning-tab label="Utility Icons" icon-name="utility:einstein"
-                            title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
-                            <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
-                                    table-data={utilityIcons} columns={columns} max-row-selection="1"
-                                    onrowselection={iconSelected} table-style={tableStyle}>
-                                </c-fsc_searchable-data-table>
-                            </div>
-                        </lightning-tab>
+                            <lightning-tab label="Utility Icons" icon-name="utility:einstein"
+                                title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
+                                <div style={tabHeight}>
+                                    <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                        table-data={utilityIcons} columns={columns} max-row-selection="1"
+                                        onrowselection={iconSelected} table-style={tableStyle}>
+                                    </c-fsc_searchable-data-table>
+                                </div>
+                            </lightning-tab>
                         </template>
                         <template if:false={excludeCustomIcons}>
-                        <lightning-tab label="Custom Icons" icon-name="custom:custom61"
-                            title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
-                            <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
-                                    table-data={customIcons} columns={columns} max-row-selection="1"
-                                    onrowselection={iconSelected} table-style={tableStyle}>
-                                </c-fsc_searchable-data-table>
-                            </div>
-                        </lightning-tab>
+                            <lightning-tab label="Custom Icons" icon-name="custom:custom61"
+                                title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
+                                <div style={tabHeight}>
+                                    <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                        table-data={customIcons} columns={columns} max-row-selection="1"
+                                        onrowselection={iconSelected} table-style={tableStyle}>
+                                    </c-fsc_searchable-data-table>
+                                </div>
+                            </lightning-tab>
                         </template>
                         <template if:false={excludeActionIcons}>
                             <lightning-tab label="Action Icons" icon-name="action:flow"
@@ -183,10 +183,12 @@ Updates:    Added an option to hide the Actions Icons
                                             <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
                                                 role="option">
                                                 <span class="slds-media__figure slds-listbox__option-icon">
-                                                    <lightning-icon icon-name={icon.iconName} size="small"></lightning-icon>
+                                                    <lightning-icon icon-name={icon.iconName} size="small">
+                                                    </lightning-icon>
                                                 </span>
                                                 <span class="slds-media__body">
-                                                    <span class="slds-truncate" title={icon.iconName}>{icon.iconName}</span>
+                                                    <span class="slds-truncate"
+                                                        title={icon.iconName}>{icon.iconName}</span>
                                                 </span>
                                             </div>
                                         </li>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
@@ -231,6 +231,10 @@ Updates:    Added an option to hide the Actions Icons
                     </div>
                 </div>
             </template>
+
+            <template if:true={invalidMode}>
+                <div class="slds-text-color_error">Icon Selector error: a valid display mode has not been entered. Choose 'accordion', 'tab', or 'combobox'.</div>
+            </template>
         </div>
     </div>
 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
@@ -45,7 +45,7 @@ Updates:    Added an option to hide the Actions Icons
                         </lightning-tab>
                         <lightning-tab label="Open" title="Click here to open the Icon Picker">
                             <lightning-accordion allow-multiple-sections-open active-section-name={activeSections}>
-                                <template if:false={excludeStandardIcons}>
+                                <template if:false={hideStandardIcons}>
                                     <lightning-accordion-section name="S" label="Standard Icons"
                                         title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                                         <div style={tabHeight}>
@@ -56,7 +56,7 @@ Updates:    Added an option to hide the Actions Icons
                                         </div>
                                     </lightning-accordion-section>
                                 </template>
-                                <template if:false={excludeUtilityIcons}>
+                                <template if:false={hideUtilityIcons}>
                                     <lightning-accordion-section name="U" label="Utility Icons"
                                         title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
                                         <div style={tabHeight}>
@@ -67,7 +67,7 @@ Updates:    Added an option to hide the Actions Icons
                                         </div>
                                     </lightning-accordion-section>
                                 </template>
-                                <template if:false={excludeCustomIcons}>
+                                <template if:false={hideCustomIcons}>
                                     <lightning-accordion-section name="C" label="Custom Icons"
                                         title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                                         <div style={tabHeight}>
@@ -78,7 +78,7 @@ Updates:    Added an option to hide the Actions Icons
                                         </div>
                                     </lightning-accordion-section>
                                 </template>
-                                <template if:false={excludeActionIcons}>
+                                <template if:false={hideActionIcons}>
                                     <lightning-accordion-section name="A" label="Action Icons"
                                         title="Action icons are for use with quick actions on touch-screen devices">
                                         <div style={tabHeight}>
@@ -101,7 +101,7 @@ Updates:    Added an option to hide the Actions Icons
                         <lightning-tab style={tabStyle} label="SELECT TYPE"
                             title="Select one of the tabs to the right to pick an Icon Type">
                         </lightning-tab>
-                        <template if:false={excludeStandardIcons}>
+                        <template if:false={hideStandardIcons}>
                             <lightning-tab label="Standard Icons" icon-name="standard:case"
                                 title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                                 <div style={tabHeight}>
@@ -112,7 +112,7 @@ Updates:    Added an option to hide the Actions Icons
                                 </div>
                             </lightning-tab>
                         </template>
-                        <template if:false={excludeUtilityIcons}>
+                        <template if:false={hideUtilityIcons}>
                             <lightning-tab label="Utility Icons" icon-name="utility:einstein"
                                 title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
                                 <div style={tabHeight}>
@@ -123,7 +123,7 @@ Updates:    Added an option to hide the Actions Icons
                                 </div>
                             </lightning-tab>
                         </template>
-                        <template if:false={excludeCustomIcons}>
+                        <template if:false={hideCustomIcons}>
                             <lightning-tab label="Custom Icons" icon-name="custom:custom61"
                                 title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                                 <div style={tabHeight}>
@@ -134,7 +134,7 @@ Updates:    Added an option to hide the Actions Icons
                                 </div>
                             </lightning-tab>
                         </template>
-                        <template if:false={excludeActionIcons}>
+                        <template if:false={hideActionIcons}>
                             <lightning-tab label="Action Icons" icon-name="action:flow"
                                 title="Action icons are for use with quick actions on touch-screen devices">
                                 <div style={tabHeight}>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
@@ -39,42 +39,52 @@ Updates:    Added an option to hide the Actions Icons
         <div class="slds-form-element__control">
 
             <template if:true={accordionMode}>
-                <label class="slds-form-element__label" style="width: 100%;">Icon Picker
+                <label class="slds-form-element__label" style="width: 100%;">{label}
                     <lightning-tabset>
-                        <lightning-tab style={tabStyle}
-                            label="Close"
-                            title="Click here to close the Icon Picker">
+                        <lightning-tab style={tabStyle} label="Close" title="Click here to close the Icon Picker">
                         </lightning-tab>
-                        <lightning-tab
-                            label="Open" 
-                            title="Click here to open the Icon Picker">
+                        <lightning-tab label="Open" title="Click here to open the Icon Picker">
                             <lightning-accordion allow-multiple-sections-open active-section-name={activeSections}>
-                                <lightning-accordion-section name="S" label="Standard Icons" title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
-                                    <div style={tabHeight}>
-                                        <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={standardIcons}
-                                            columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}> 
-                                        </c-fsc_searchable-data-table>
-                                    </div>
-                                </lightning-accordion-section>
-                                <lightning-accordion-section name="U" label="Utility Icons" title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
-                                    <div style={tabHeight}>
-                                        <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={utilityIcons}
-                                            columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}> 
-                                        </c-fsc_searchable-data-table>
-                                    </div>
-                                </lightning-accordion-section>
-                                <lightning-accordion-section name="C" label="Custom Icons" title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
-                                    <div style={tabHeight}>
-                                        <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={customIcons}
-                                            columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}> 
-                                        </c-fsc_searchable-data-table>
-                                    </div>
-                                </lightning-accordion-section>
-                                <template if:false={hideActionIcons}>
-                                    <lightning-accordion-section name="A" label="Action Icons" title="Action icons are for use with quick actions on touch-screen devices">
+                                <template if:false={excludeStandardIcons}>
+                                    <lightning-accordion-section name="S" label="Standard Icons"
+                                        title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                                         <div style={tabHeight}>
-                                            <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={actionIcons}
-                                                columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}> 
+                                            <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                                table-data={standardIcons} columns={columns} max-row-selection="1"
+                                                onrowselection={iconSelected} table-style={tableStyle}>
+                                            </c-fsc_searchable-data-table>
+                                        </div>
+                                    </lightning-accordion-section>
+                                </template>
+                                <template if:false={excludeUtilityIcons}>
+                                    <lightning-accordion-section name="U" label="Utility Icons"
+                                        title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
+                                        <div style={tabHeight}>
+                                            <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                                table-data={utilityIcons} columns={columns} max-row-selection="1"
+                                                onrowselection={iconSelected} table-style={tableStyle}>
+                                            </c-fsc_searchable-data-table>
+                                        </div>
+                                    </lightning-accordion-section>
+                                </template>
+                                <template if:false={excludeCustomIcons}>
+                                    <lightning-accordion-section name="C" label="Custom Icons"
+                                        title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
+                                        <div style={tabHeight}>
+                                            <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                                table-data={customIcons} columns={columns} max-row-selection="1"
+                                                onrowselection={iconSelected} table-style={tableStyle}>
+                                            </c-fsc_searchable-data-table>
+                                        </div>
+                                    </lightning-accordion-section>
+                                </template>
+                                <template if:false={excludeActionIcons}>
+                                    <lightning-accordion-section name="A" label="Action Icons"
+                                        title="Action icons are for use with quick actions on touch-screen devices">
+                                        <div style={tabHeight}>
+                                            <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                                table-data={actionIcons} columns={columns} max-row-selection="1"
+                                                onrowselection={iconSelected} table-style={tableStyle}>
                                             </c-fsc_searchable-data-table>
                                         </div>
                                     </lightning-accordion-section>
@@ -85,51 +95,46 @@ Updates:    Added an option to hide the Actions Icons
                 </label>
             </template>
 
-            <template if:false={accordionMode}>
-                <label class="slds-form-element__label" style="width: 100%;">Icon Picker
+            <template if:true={tabMode}>
+                <label class="slds-form-element__label" style="width: 100%;">{label}
                     <lightning-tabset>
-                        <lightning-tab style={tabStyle}
-                            label="SELECT TYPE"
+                        <lightning-tab style={tabStyle} label="SELECT TYPE"
                             title="Select one of the 4 tabs to the right to pick an Icon Type">
                         </lightning-tab>
-                        <lightning-tab
-                            label="Standard Icons" 
-                            icon-name="standard:case"
+                        <lightning-tab label="Standard Icons" icon-name="standard:case"
                             title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                             <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={standardIcons}
-                                    columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}> 
+                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                    table-data={standardIcons} columns={columns} max-row-selection="1"
+                                    onrowselection={iconSelected} table-style={tableStyle}>
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
-                        <lightning-tab 
-                            label="Utility Icons" 
-                            icon-name="utility:einstein"
+                        <lightning-tab label="Utility Icons" icon-name="utility:einstein"
                             title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
                             <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={utilityIcons}
-                                    columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}>
+                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                    table-data={utilityIcons} columns={columns} max-row-selection="1"
+                                    onrowselection={iconSelected} table-style={tableStyle}>
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
-                        <lightning-tab 
-                            label="Custom Icons" 
-                            icon-name="custom:custom61"
+                        <lightning-tab label="Custom Icons" icon-name="custom:custom61"
                             title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                             <div style={tabHeight}>
-                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={customIcons}
-                                    columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}>
+                                <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                    table-data={customIcons} columns={columns} max-row-selection="1"
+                                    onrowselection={iconSelected} table-style={tableStyle}>
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
                         <template if:false={hideActionIcons}>
-                            <lightning-tab 
-                                label="Action Icons" 
-                                icon-name="action:flow"
+                            <lightning-tab label="Action Icons" icon-name="action:flow"
                                 title="Action icons are for use with quick actions on touch-screen devices">
                                 <div style={tabHeight}>
-                                    <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id" table-data={actionIcons}
-                                        columns={columns} max-row-selection="1" onrowselection={iconSelected} table-style={tableStyle}>
+                                    <c-fsc_searchable-data-table search-placeholder="Search ..." key-field="id"
+                                        table-data={actionIcons} columns={columns} max-row-selection="1"
+                                        onrowselection={iconSelected} table-style={tableStyle}>
                                     </c-fsc_searchable-data-table>
                                 </div>
                             </lightning-tab>
@@ -138,6 +143,86 @@ Updates:    Added an option to hide the Actions Icons
                 </label>
             </template>
 
-        </div>    
+            <template if:true={comboboxMode}>
+                <label class="slds-form-element__label">{label}</label>
+                <div class="slds-form-element__control slds-input-has-icon slds-input-has-icon_right">
+                    <div class="slds-combobox_container">
+                        <div class="slds-combobox slds-dropdown-trigger slds-dropdown-trigger_click" role="combobox">
+                            <div class="slds-combobox__form-element slds-input-has-icon slds-input-has-icon_right"
+                                role="none">
+                                <button
+                                    class="slds-icon slds-input__icon slds-theme_default slds-p-right_small slds-p-bottom_small">
+                                    <lightning-icon size="x-small" icon-name={searchboxIcon}
+                                        onmousedown={handleSearchboxIconClick}></lightning-icon>
+                                </button>
+                                <template if:true={iconName}>
+                                    <span class="slds-icon_container slds-combobox__input-entity-icon">
+                                        <lightning-icon
+                                            class="slds-icon slds-icon_small slds-input__icon_left searchboxIcon"
+                                            icon-name={iconName}></lightning-icon>
+                                    </span>
+                                </template>
+                                <input type="text" placeholder="Type to search"
+                                    class="slds-input slds-combobox__input comboboxInput" onfocus={handleSearchFocus}
+                                    onkeyup={handleSearchChange} onchange={handleSearchChange}
+                                    onblur={handleSearchBlur} />
+                            </div>
+
+                            <div class="slds-dropdown slds-dropdown_length-with-icon-7 slds-dropdown_fluid"
+                                role="listbox" onmousedown={handleDropdownClick}>
+                                <ul class="slds-listbox slds-listbox_vertical" role="presentation">
+                                    <template for:each={displayedIcons} for:item="icon">
+                                        <li role="presentation" class="slds-listbox__item" key={icon.iconName}
+                                            data-icon={icon.iconName} onmousedown={handleIconSelect}>
+                                            <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                                role="option">
+                                                <span class="slds-media__figure slds-listbox__option-icon">
+                                                    <lightning-icon icon-name={icon.iconName} size="small"></lightning-icon>
+                                                </span>
+                                                <span class="slds-media__body">
+                                                    <span class="slds-truncate" title={icon.iconName}>{icon.iconName}</span>
+                                                </span>
+                                            </div>
+                                        </li>
+                                    </template>
+
+                                    <!-- If the number of icons that match the current search term is greater than the amount of results currently set to be displayed  -->
+                                    <template if:true={resultsExceedMax}>
+                                        <li role="presentation"
+                                            class="slds-listbox__item slds-border_top slds-theme_default"
+                                            onclick={loadMore}>
+                                            <!-- <span class="slds-truncate slds-align_absolute-center slds-p-around_xx-small slds-text-link_reset"></span> -->
+
+                                            <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                                role="option">
+                                                <!-- <span class="slds-media__figure slds-listbox__option-icon">
+                                                    <lightning-icon icon-name={icon.iconName} size="small"></lightning-icon>
+                                                </span> -->
+                                                <span class="slds-media__body">
+                                                    <span class="slds-truncate">{loadMoreString}</span>
+                                                </span>
+                                            </div>
+
+                                        </li>
+                                    </template>
+
+                                    <!-- If no matches were found, let the user know -->
+                                    <template if:false={displayedIcons.length}>
+                                        <li role="presentation" class="slds-listbox__item">
+                                            <div class="slds-media slds-listbox__option slds-listbox__option_plain slds-media_small"
+                                                role="option">
+                                                <span class="slds-media__body">
+                                                    <span class="slds-truncate">{noMatchesFoundString}</span>
+                                                </span>
+                                            </div>
+                                        </li>
+                                    </template>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </template>
+        </div>
     </div>
 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.html
@@ -99,8 +99,9 @@ Updates:    Added an option to hide the Actions Icons
                 <label class="slds-form-element__label" style="width: 100%;">{label}
                     <lightning-tabset>
                         <lightning-tab style={tabStyle} label="SELECT TYPE"
-                            title="Select one of the 4 tabs to the right to pick an Icon Type">
+                            title="Select one of the tabs to the right to pick an Icon Type">
                         </lightning-tab>
+                        <template if:false={excludeStandardIcons}>
                         <lightning-tab label="Standard Icons" icon-name="standard:case"
                             title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                             <div style={tabHeight}>
@@ -110,6 +111,8 @@ Updates:    Added an option to hide the Actions Icons
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
+                        </template>
+                        <template if:false={excludeUtilityIcons}>
                         <lightning-tab label="Utility Icons" icon-name="utility:einstein"
                             title="Utility icons are simple, single-color glyphs that identify labels and actions across form factors">
                             <div style={tabHeight}>
@@ -119,6 +122,8 @@ Updates:    Added an option to hide the Actions Icons
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
+                        </template>
+                        <template if:false={excludeCustomIcons}>
                         <lightning-tab label="Custom Icons" icon-name="custom:custom61"
                             title="Standard and Custom Object icons represent Salesforce entities and objects (Account, Case, etc.)">
                             <div style={tabHeight}>
@@ -128,7 +133,8 @@ Updates:    Added an option to hide the Actions Icons
                                 </c-fsc_searchable-data-table>
                             </div>
                         </lightning-tab>
-                        <template if:false={hideActionIcons}>
+                        </template>
+                        <template if:false={excludeActionIcons}>
                             <lightning-tab label="Action Icons" icon-name="action:flow"
                                 title="Action icons are for use with quick actions on touch-screen devices">
                                 <div style={tabHeight}>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
@@ -994,6 +994,8 @@ export default class ObjectIconSelector extends LightningElement {
     get tabMode() { return this.mode === MODES.TAB; }
     get accordionMode() { return this.mode === MODES.ACCORDION; }
     get comboboxMode() { return this.mode === MODES.COMBOBOX; }
+    get invalidMode() { return !this.tabMode && !this.accordionMode && !this.comboboxMode; }
+
     get displayedIcons() {
         return this.filteredIcons.slice(0, this.currentMaxResults);
     }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
@@ -930,7 +930,7 @@ export default class ObjectIconSelector extends LightningElement {
 
     @api mode;
     @api label = 'Pick an Icon';
-    // @api iconName = null;
+
     @api
     get iconName() {
         return this._iconName || null;
@@ -955,10 +955,9 @@ export default class ObjectIconSelector extends LightningElement {
                 this.template.querySelector('.comboboxInput').removeAttribute('readonly');
                 this.template.querySelector('.comboboxInput').value = null;
             }
-            //this.dispatchEvent(new CustomEvent('selecticon', { detail: iconName }));
-            const iconSelectedEvent = new CustomEvent('iconselection', { detail: iconName });
-            this.dispatchEvent(iconSelectedEvent);    
         }
+        const iconSelectedEvent = new CustomEvent('iconselection', { detail: iconName });
+        this.dispatchEvent(iconSelectedEvent);    
     }
     _iconName;
     @track icons = [];
@@ -996,7 +995,6 @@ export default class ObjectIconSelector extends LightningElement {
     get accordionMode() { return this.mode === MODES.ACCORDION; }
     get comboboxMode() { return this.mode === MODES.COMBOBOX; }
     get displayedIcons() {
-        // console.log(this.filteredIcons.slice(0, this.currentMaxResults));
         return this.filteredIcons.slice(0, this.currentMaxResults);
     }
 
@@ -1006,7 +1004,7 @@ export default class ObjectIconSelector extends LightningElement {
         }      
         let icons = [];
         for (let icon of this.icons) {
-            if (!this.searchText || icon.iconName.toLowerCase().includes(this.searchText)) {
+            if (icon.iconName.toLowerCase().includes(this.searchText)) {
                 icons.push(icon);
             }
         }
@@ -1029,6 +1027,7 @@ export default class ObjectIconSelector extends LightningElement {
         if (!this.excludeStandardIcons) this.icons.push(...this.standardIcons);
         if (!this.excludeCustomIcons) this.icons.push(...this.customIcons);
         if (!this.excludeUtilityIcons) this.icons.push(...this.utilityIcons);
+        // Action icons display weirdly in the combobox so I'm leaving them out for now
         //if (!this.excludeActionIcons) this.icons.push(...this.actionIcons);
     }
 
@@ -1044,8 +1043,9 @@ export default class ObjectIconSelector extends LightningElement {
     iconSelected(event){
         const selRow = event.detail.selectedRows[0];
         this.iconName=selRow.iconName;
-        const iconSelectedEvent = new CustomEvent('iconselection', { detail: this.iconName });
-        this.dispatchEvent(iconSelectedEvent);
+        // Moving the dispatch to iconName setter
+        // const iconSelectedEvent = new CustomEvent('iconselection', { detail: this.iconName });
+        // this.dispatchEvent(iconSelectedEvent);
     }
 
 
@@ -1068,11 +1068,11 @@ export default class ObjectIconSelector extends LightningElement {
     }
 
     focusSearchbox() {
-        this.template.querySelector('input').focus();
+        this.template.querySelector('.comboboxInput').focus();
     }
 
     blurSearchbox() {
-        this.template.querySelector('input').blur();
+        this.template.querySelector('.comboboxInput').blur();
     }
 
     clearSearchbox() {
@@ -1112,8 +1112,6 @@ export default class ObjectIconSelector extends LightningElement {
     }
 
     handleSearchboxIconClick(event) {
-        //if (this.iconName || this.searchText) {
-            console.log('in searchboxicon click '+ event.currentTarget.iconName);
         if (event.currentTarget.iconName == SEARCHBOX_ICONS.CLEAR) {
             this.clearSearchbox();
         } else {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js
@@ -897,6 +897,8 @@ const UTILITY_ICONS = [
     { 'iconName': 'utility:zoomout', 'id': 'utility:zoomout' }
 ]
 
+const ICON_CATEGORIES = [ 'standard', 'custom', 'utility', 'action'];
+
 const MODES = {
     ACCORDION: 'accordion',
     TAB: 'tab',
@@ -930,6 +932,22 @@ export default class ObjectIconSelector extends LightningElement {
     @api hideCustomIcons;
     @api hideUtilityIcons;
     @api hideActionIcons;
+    
+    @api 
+    get iconCategories() {
+        return this._iconCategories;
+    }
+    set iconCategories(iconCategories) {
+        this._iconCategories = iconCategories;
+        console.log('incoming iconCategories: '+ JSON.stringify(iconCategories));
+        for (let category of ICON_CATEGORIES) {
+            let hideProperty = 'hide' + category.charAt(0).toUpperCase() + category.slice(1) +'Icons';
+            console.log('hideproperty = '+ hideProperty, this[hideProperty]);
+            this[hideProperty] = !iconCategories.includes(category);
+            console.log('new value: '+ this[hideProperty]);
+        }
+        
+    }
 
     @api mode;
     @api label = 'Pick an Icon';
@@ -1026,6 +1044,8 @@ export default class ObjectIconSelector extends LightningElement {
         if (!this.hideUtilityIcons) this.icons.push(...this.utilityIcons);
         // Action icons display weirdly in the combobox so I'm leaving them out for now
         //if (!this.hideActionIcons) this.icons.push(...this.actionIcons);
+
+        console.log(this.iconCategories);
     }
 
     renderedCallback() {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -9,13 +9,16 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
-            <property name="mode" label="Display Mode" type="String" description="Enter 'tab', 'accordion', or 'combobox'" required="true" role="inputOnly"/>
-            <property name="excludeStandardIcons" label="Exclude Standard icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="excludeCustomIcons" label="Exclude Custom icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="excludeUtilityIcons" label="Exclude Utility icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="excludeActionIcons" label="Exclude Action icons" type="Boolean" default="false" role="inputOnly"/>
-            <property name="label" label="Label" type="String" role="inputOnly"/>
+            <property name="mode" label="Display Mode" type="String" description="Enter 'tab', 'accordion', or 'combobox'" role="inputOnly"/>
+            <property name="hideStandardIcons" label="Hide Standard icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="hideCustomIcons" label="Hide Custom icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="hideUtilityIcons" label="Hide Utility icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="hideActionIcons" label="Hide Action icons" type="Boolean" default="false" description="Note: Action icons are not available in combobox mode" role="inputOnly"/>
+            <property name="label" label="Label" type="String" default="Pick an Icon" required="true" role="inputOnly"/>
             <property name="iconName" type="String" role="outputOnly"/>
+
+            <!-- Legacy properties -->
+            <property name="accordionMode" label="zzz(legacy) Accordion Mode" description="This is a legacy property included for backwards compatibility and is not recommended for future use. Use the new 'mode' property instead." type="boolean" role="inputOnly"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -8,14 +8,15 @@
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
-        <targetConfig targets="lightning__FlowScreen">
+        <targetConfig targets="lightning__FlowScreen" configurationEditor="c-fsc_pick-icon-cpe">
             <property name="mode" label="Display Mode" type="String" description="Enter 'tab', 'accordion', or 'combobox'" role="inputOnly"/>
             <property name="hideStandardIcons" label="Hide Standard icons" type="Boolean" default="false" role="inputOnly"/>
             <property name="hideCustomIcons" label="Hide Custom icons" type="Boolean" default="false" role="inputOnly"/>
             <property name="hideUtilityIcons" label="Hide Utility icons" type="Boolean" default="false" role="inputOnly"/>
             <property name="hideActionIcons" label="Hide Action icons" type="Boolean" default="false" description="Note: Action icons are not available in combobox mode" role="inputOnly"/>
-            <property name="label" label="Label" type="String" default="Pick an Icon" required="true" role="inputOnly"/>
-            <property name="iconName" type="String" role="outputOnly"/>
+            <property name="label" label="Label" type="String" default="Pick an Icon" role="inputOnly"/>
+            <property name="iconName" label="Icon Name" type="String"/>
+            <property name="iconCategories" type="String" role="inputOnly"/>
 
             <!-- Legacy properties -->
             <property name="accordionMode" label="zzz(legacy) Accordion Mode" description="This is a legacy property included for backwards compatibility and is not recommended for future use. Use the new 'mode' property instead." type="boolean" role="inputOnly"/>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIcon/fsc_pickIcon.js-meta.xml
@@ -9,8 +9,12 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
-            <property name="accordionMode" type="Boolean" default="false" role="inputOnly"/>
-            <property name="hideActionIcons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="mode" label="Display Mode" type="String" description="Enter 'tab', 'accordion', or 'combobox'" required="true" role="inputOnly"/>
+            <property name="excludeStandardIcons" label="Exclude Standard icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="excludeCustomIcons" label="Exclude Custom icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="excludeUtilityIcons" label="Exclude Utility icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="excludeActionIcons" label="Exclude Action icons" type="Boolean" default="false" role="inputOnly"/>
+            <property name="label" label="Label" type="String" role="inputOnly"/>
             <property name="iconName" type="String" role="outputOnly"/>
         </targetConfig>
     </targetConfigs>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.html
@@ -1,0 +1,17 @@
+<template>
+    <div class="padding">
+        <lightning-input name="label" label={inputValues.label.label} value={inputValues.label.value}
+            onchange={handleInputChange}></lightning-input>
+
+        <div class="slds-p-top_small">
+            <c-toggle-input name="mode" label={inputValues.mode.label} options={displayModeOptions}
+                value={inputValues.mode.value} ontogglechange={handleToggleChange} class="modeToggle" required></c-toggle-input>
+        </div>
+        <div class="slds-p-top_small">
+            <c-toggle-input name="iconCategories" label={inputValues.iconCategories.label} options={iconCategoryOptions}
+                help-text="Note: Action icons are not available in combobox mode" values={iconCategories}
+                ontogglechange={handleToggleChange} class="slds-m-vertical_medium" multiselect required>
+            </c-toggle-input>
+        </div>
+    </div>
+</template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js
@@ -1,0 +1,134 @@
+import { LightningElement, track, api } from 'lwc';
+const ICON_CATEGORY_OPTIONS = [
+    { label: 'Standard', value: 'standard', default: true },
+    { label: 'Custom', value: 'custom', default: true },
+    { label: 'Utility', value: 'utility', default: true },
+    { label: 'Action', value: 'action', default: false }
+];
+
+const DISPLAY_MODE_OPTIONS = [
+    { label: 'Combobox', value: 'combobox' },
+    { label: 'Accordion', value: 'accordion' },
+    { label: 'Tab', value: 'tab' }
+];
+
+const DATA_TYPE = {
+    STRING: 'String',
+    BOOLEAN: 'Boolean',
+    NUMBER: 'Number',
+}
+
+const DEFAULT_LABEL = 'Pick an Icon';
+const MODE_REQUIRED_ERROR = 'A display mode is required, please select one of the modes.';
+
+export default class Fsc_pickIconCpe extends LightningElement {
+
+    @api builderContext;
+
+    @api
+    get inputVariables() {
+        return this._values;
+    }
+    set inputVariables(value) {
+        this._values = value;
+
+        this.initializeValues();
+    }
+    _values;
+
+    @track inputValues = {
+        mode: { value: null, valueDataType: null, isCollection: false, label: 'Mode' },
+        // iconCategories: this.inputValue('Available Icon Categories', false, this.defaultCategories.join()),
+        iconCategories: { value: null, valueDataType: null, isCollection: false, label: 'Available Icon Categories' },
+        label: { value: DEFAULT_LABEL, valueDataType: null, isCollection: false, label: 'Label' },
+        iconName: { value: null, valueDataType: null, isCollection: false, label: 'Icon Name' }
+    };
+    
+    @track iconCategories = ['standard', 'custom', 'utility'];
+
+    initializeValues() {
+        // console.log('in initializeValues');
+        console.log('loading initializevalues, '+ JSON.stringify(this._values));
+        if (this._values && this._values.length) {
+            this._values.forEach(curInputParam => {
+                if (curInputParam.name && this.inputValues[curInputParam.name]) {
+                    let inputValue = this.inputValues[curInputParam.name];
+                    console.log('in initializeValues: ' + JSON.stringify(curInputParam));
+                    if (curInputParam.name == 'iconCategories') {
+                        this.iconCategories = curInputParam.value.split(',');
+                    } else {
+                        inputValue.value = curInputParam.value;
+                    }                    
+                    inputValue.valueDataType = curInputParam.valueDataType;
+                }
+            });
+        }
+    }
+
+    dispatchFlowValueChangeEvent(id, newValue, newValueDataType) {
+        const valueChangedEvent = new CustomEvent('configuration_editor_input_value_changed', {
+            bubbles: true,
+            cancelable: false,
+            composed: true,
+            detail: {
+                name: id,
+                newValue: newValue ? newValue : null,
+                newValueDataType: newValueDataType
+            }
+        });
+        this.dispatchEvent(valueChangedEvent);
+        console.log('dispatched flow change event, detail: ' + JSON.stringify(valueChangedEvent.detail));
+    }
+
+    inputValue(label, isCollection, defaultValue) {
+        return { value: undefined, valueDataType: null, isCollection: isCollection, label: label, defaultValue: defaultValue };
+    }
+
+    /* COMPONENT */
+
+    @track iconCategoryOptions = ICON_CATEGORY_OPTIONS;
+    displayModeOptions = DISPLAY_MODE_OPTIONS;
+
+    get defaultCategories() {
+        let defaults = [];
+        for (let category of ICON_CATEGORY_OPTIONS) {
+            if (category.default) {
+                defaults.push(category.value);
+            }
+        };
+        console.log(defaults);
+        return defaults;
+    }
+
+    handleToggleChange(event) {
+        let name = event.currentTarget.name;
+        if (name) {
+            // let value = event.currentTarget.multiselect ? event.detail.values.join() : event.detail.value;
+            let value = event.detail.values.join();
+            if (value)
+                this.template.querySelector('.modeToggle').errorMessage = null;
+            console.log('in toggle change for '+ name +', dispatching value = '+ value);
+            this.dispatchFlowValueChangeEvent(name, value, DATA_TYPE.STRING);
+        }
+    }
+
+    handleInputChange(event) {
+        let name = event.currentTarget.name;
+        if (name) {
+            let value = event.detail.value;
+            this.dispatchFlowValueChangeEvent(name, value, DATA_TYPE.STRING);
+        }
+    }
+
+    @api validate() {
+        const validity = [];
+        if (!this.inputValues.mode.value) {
+            this.template.querySelector('.modeToggle').errorMessage = MODE_REQUIRED_ERROR;
+            validity.push({
+                key: 'Display Mode Required',
+                errorString: MODE_REQUIRED_ERROR,
+            });
+        }
+        return validity;
+    }
+}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickIconCpe/fsc_pickIconCpe.js-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>51.0</apiVersion>
+    <isExposed>true</isExposed>
+</LightningComponentBundle>

--- a/flow_screen_components/flowButtonBar/force-app/main/default/lwc/toggleInput/toggleInput.html
+++ b/flow_screen_components/flowButtonBar/force-app/main/default/lwc/toggleInput/toggleInput.html
@@ -1,11 +1,28 @@
 <template>
     <div>
-        <span class="slds-text-title">{label}</span>
-        <template if:true={helpText}>
-            <lightning-helptext class="slds-p-horizontal_x-small" content={helpText}>
-            </lightning-helptext>
+        <div class="slds-text-title slds-grid slds-grid_vertical-align-center slds-p-vertical_xxx-small">
+            <span>
+                <template if:true={required}>
+                    <span class="slds-text-color_error slds-p-horizontal_xxx-small">*</span>
+                </template>
+                {label}
+            </span>
+            <template if:true={helpText}>
+                <lightning-helptext class="slds-p-horizontal_x-small" content={helpText}>
+                </lightning-helptext>
+            </template>
+        </div>
+
+
+        <lightning-button-group>
+            <template for:each={options} for:item="option">
+                <lightning-button label={option.label} value={option.value} key={option.value}
+                    onclick={handleToggleClick}></lightning-button>
+            </template>
+        </lightning-button-group>
+
+        <template if:true={errorMessage}>
+            <div class="slds-text-color_error">{errorMessage}</div>
         </template>
-        <lightning-radio-group label={label} type="button" options={options} value={value} onchange={handleToggleChange}
-            variant="label-hidden"></lightning-radio-group>
     </div>
 </template>

--- a/flow_screen_components/flowButtonBar/force-app/main/default/lwc/toggleInput/toggleInput.js
+++ b/flow_screen_components/flowButtonBar/force-app/main/default/lwc/toggleInput/toggleInput.js
@@ -1,12 +1,79 @@
 import { LightningElement, api } from 'lwc';
 
+const VARIANTS = {
+    UNSELECTED: 'neutral',
+    SELECTED: 'brand'
+}
+
 export default class ToggleInput extends LightningElement {
     @api label;
     @api options;
-    @api value;    
     @api helpText;
-    
+    @api multiselect;
+    @api required;
+    @api errorMessage;
 
+    @api 
+    get values() {
+        return this._values;
+    }
+    set values(values) {
+        this._values = values ? [...values] : []; // using spread operator to create a shallow clone of the array for mutability
+        if (this.rendered) {
+            this.updateToggle();
+        }
+    }
+    _values;
+
+    @api
+    get value() {
+        return this.values[0] || null;
+    }
+    set value(value) {
+        this.values = [value];
+    }
+    
+    rendered;
+    renderedCallback() {
+        if (this.rendered) return;
+        this.rendered = true;
+
+        this.updateToggle();
+    }
+
+    handleToggleClick(event) {
+        let clickedValue = event.target.value;
+        let curIndex = this.values.findIndex(value => value === clickedValue);
+        if (curIndex >= 0) {
+            if (!this.required || this.values.length > 1)
+                this.values.splice(curIndex, 1);
+        } else {
+            if (this.multiselect) {
+                this.values.push(clickedValue);
+            } else {
+                this.value = clickedValue;
+            }
+        }
+        this.dispatchEvent(new CustomEvent('togglechange', { 
+            detail: { 
+                value: this.value,
+                values: this.values
+            }
+        }));
+        this.updateToggle();
+    }
+
+    updateToggle() {
+        for (let button of this.template.querySelectorAll('lightning-button')) {
+            if (this.values.includes(button.value)) {
+                button.variant = VARIANTS.SELECTED;
+            } else {
+                button.variant = VARIANTS.UNSELECTED;
+            }
+        }
+    }
+
+    /* No longer used
     handleToggleChange(event) {
         this.dispatchEvent(new CustomEvent('togglechange', { 
             detail: { 
@@ -14,4 +81,5 @@ export default class ToggleInput extends LightningElement {
             }
         }));
     }
+    */
 }


### PR DESCRIPTION
@alexed1 @ericrsmith35 I think I've come up with something that works and is hopefully an improvement. I added a CPE ([screenshot](https://i.imgur.com/SxCvWqp.png)), which allows behind-the-scenes support for legacy properties while providing a simpler UI.

The CPE makes heavy use of my toggleInput component, which I've rebuilt significantly to allow for multi-select and a few other niceties (BUT, I made sure to make it backwards-compatible—fool me once...). This also makes it really easy to set hideActionIcons to default to false; I'm not married to that, but for my 2¢ that makes sense.