### PR TITLE
Now shows a pen icon before picklist is editable

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.html
@@ -1,11 +1,25 @@
 <!-- Combobox Column Type -->
 <template>
+    <!-- slds-hide is used instead of template if, as it allows us to focus on the combobox when edit icon is clicked -->
     <lightning-combobox
-    class={cellClass}
-    name="combobox"
-    variant="label-hidden"
-    value={value}
-    options={options}
-    onchange={handleChange}
-    dropdown-alignment="auto"></lightning-combobox>
+        name="combobox"
+        class="slds-p-vertical_xx-small slds-p-horizontal_x-small slds-hide"
+        variant="label-hidden"
+        value={value}
+        options={options}
+        onchange={handleChange}
+        dropdown-alignment="auto"
+        onblur= {focusout}
+    ></lightning-combobox>
+
+    <template if:false={editMode}>
+        <div class="combobox-view__min-height cell__is-editable slds-grid slds-p-vertical_xx-small slds-p-horizontal_x-small slds-var-m-around_xxx-small">
+            <div class="slds-col_bump-right slds-align-middle slds-truncate">
+                {value}
+            </div>
+            <div class="slds-align-middle">
+                <lightning-button-icon icon-name="utility:edit" size="medium" variant="bare" class="cell-icon__edit" onclick={editCombobox}></lightning-button-icon>
+            </div>
+        </div>
+    </template>
 </template>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.js
@@ -7,7 +7,7 @@ export default class ers_comboboxColumnType extends LightningElement {
     @api keyFieldValue;
     @api picklistValues;
     @api value;
-    cellClass;
+    editMode = false;
 
     get options() {
         let _options = [];
@@ -40,7 +40,26 @@ export default class ers_comboboxColumnType extends LightningElement {
         });
         this.dispatchEvent(customEvent)
 
-        //set isChanged so that cell is highlighted
-        //this.cellClass = 'isChanged'; removed. highlighting controlled by manipulating fieldValues on the datatable
+        this.toggleEditMode();
+        //remove combobox and remove focus
+        this.template.querySelector("lightning-combobox").classList.add("slds-hide");
+        this.template.querySelector("lightning-combobox").blur();
+    }
+    editCombobox(){
+        this.toggleEditMode();
+        //show the combobox & focus on it
+        this.template.querySelector("lightning-combobox").classList.remove("slds-hide");
+        this.template.querySelector("lightning-combobox").focus();
+    }
+
+    toggleEditMode() {
+        this.editMode = !this.editMode;
+    }
+    //remove combobox when not focused
+    focusout() {
+        if(this.editMode) {
+            this.toggleEditMode();
+            this.template.querySelector("lightning-combobox").classList.add("slds-hide");
+        }
     }
 }

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_comboboxColumnType.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_comboboxColumnType.html
@@ -13,6 +13,8 @@
 
     <!-- readonly -->
     <template if:false={typeAttributes.editable}>
-        {value}
+        <div class="slds-p-vertical_xx-small slds-p-horizontal_x-small">
+            {value}
+        </div>
     </template>
 </template>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_customLightningDatatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_customLightningDatatable.js
@@ -29,7 +29,7 @@ export default class ers_customLightningDatatable extends LightningDatatable {
         },
         combobox: {
             template: ers_comboboxColumnType,
-            standardCellLayout: true,
+            standardCellLayout: false,
             typeAttributes: ['editable', 'fieldName', 'keyField', 'keyFieldValue', 'picklistValues']
         }
     }

--- a/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
+++ b/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
@@ -16,11 +16,20 @@ c-ers_custom-lightning-datatable lightning-primitive-cell-factory .slds-hyphenat
     width: 100%;
 }
 /* ensures that custom column cells remain higlighted on hover when edited */
-.slds-scope .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited,
-.slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited {
+.slds-scope c-ers_custom-lightning-datatable .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited,
+c-ers_custom-lightning-datatable  .slds-table:not(.slds-no-row-hover) tbody tr:hover>td.slds-is-edited {
     background-color: rgb(250, 255, 189);
 }
-
+/* show edit pen when td is hovered */
+.slds-scope c-ers_custom-lightning-datatable  .slds-table:not(.slds-no-row-hover) tbody td:hover lightning-button-icon.cell-icon__edit .slds-button_icon,
+c-ers_custom-lightning-datatable .slds-table:not(.slds-no-row-hover) tbody td:hover lightning-button-icon.cell-icon__edit .slds-button_icon {
+    visibility: visible;
+}
+/* show white background on hover if cell is editable */
+.slds-scope c-ers_custom-lightning-datatable  .slds-table:not(.slds-no-row-hover) tbody td:hover:not(.slds-is-edited) .cell__is-editable,
+c-ers_custom-lightning-datatable  .slds-table:not(.slds-no-row-hover) tbody td:hover:not(.slds-is-edited) .cell__is-editable {
+    background-color: white;
+}
 /********************************/
 /**** c-ers_combobox-column-type ****/
 /********************************/
@@ -28,16 +37,6 @@ c-ers_custom-lightning-datatable lightning-primitive-cell-factory .slds-hyphenat
 c-ers_combobox-column-type .slds-dropdown {
     max-height: 180px;
 }
-/* highlight combobox if value is changed*/
-/* removed. highlighting is now controlled by manipulating fieldValues*/
-/*c-ers_combobox-column-type .isChanged input[lightning-basecombobox_basecombobox],
-c-ers_combobox-column-type .isChanged input[readonly][role=combobox],
-c-ers_combobox-column-type .isChanged input:focus,
-.slds-scope c-ers_combobox-column-type .isChanged input[lightning-basecombobox_basecombobox],
-.slds-scope c-ers_combobox-column-type .isChanged input[readonly][role=combobox],
-.slds-scope c-ers_combobox-column-type .isChanged input:focus {
-    background-color: rgb(250, 255, 189);
-} */
 /* Remove position:absolute on the dropdown icon so that it doesn't appear on top of column action dropdown*/
 c-ers_combobox-column-type lightning-base-combobox .slds-input-has-icon lightning-icon.slds-input__icon{
     top: 0;
@@ -49,4 +48,15 @@ c-ers_combobox-column-type lightning-base-combobox .slds-input-has-icon lightnin
     margin-top: 0.1rem;
     position: static;
     padding-right: 1.3rem;
+}
+
+/********************************/
+/******** custom classes ********/
+/********************************/
+.combobox-view__min-height {
+    min-height: 36px;
+}
+.cell-icon__edit {
+    opacity: 0.5;
+    visibility: hidden;
 }


### PR DESCRIPTION
- Mimics the behaviour of other editable cells, where a pen icon is displayed when hovered
- when the pen icon is clicked, only then the picklist is editable
- selecting a new picklist value will revert the cell back to view mode
- clicking away from the picklist will revert the cell back to view mode