### PR TITLE
Use all picklist values when user has no read access to SObject

### DIFF
--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -43,8 +43,8 @@ https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 3.2.2 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xJdQAI)   
-[Version 3.2.2 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xJdQAI)
+[Version 3.2.3 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xJnQAI)   
+[Version 3.2.3 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xJnQAI)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -63,7 +63,12 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes
  
-## 06/11/21 -  Eric Smith -    Version 3.2.2 
+## 06/13/21 -  Eric Smith -    Version 3.2.3 
+**Updates:** 
+-   When the running User doesn't have Read access to the Datatable's SObject, Record Type Id for Picklist Values is ignored
+    and all picklist values will be available when editing a picklist field
+ 
+ ## 06/11/21 -  Eric Smith -    Version 3.2.2 
 **Updates:** 
 -   Editable picklist fields now show a pencil icon when editable (Same behavior as all other field edits) 
 -   Icon Pickers in the CPE and Configure Column Wizard have been updated to the latest version 

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -67,6 +67,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 **Updates:** 
 -   When the running User doesn't have Read access to the Datatable's SObject, Record Type Id for Picklist Values is ignored
     and all picklist values will be available when editing a picklist field
+-   Fields that are Read Only to the running User can still be edited when the Flow is running in System Mode
  
  ## 06/11/21 -  Eric Smith -    Version 3.2.2 
 **Updates:** 

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
@@ -15,6 +15,8 @@
  *              use the recordId values in the lookup fields get the values
  *              of the Name fields in the corresponding records. Return the
  *              records that now include both the Id and Name for each lookup.
+ *   
+ * 06/13/21 -   Eric Smith -    Version 3.2.3   Return all Picklist values when the running user doesn't have Read access to table's SObject
  * 
  * 06/10/21 -   Eric Smith -    Version 3.2.2   Saved list of Date fields for time-zone offset processing
  * 
@@ -72,12 +74,12 @@ public with sharing class ers_DatatableController {
         List<String> lookupFieldList;
         Map<String, Map<Id, SObject>> dataMap;
         Map<String, String> objNameFieldMap;
-        // Map<String, Map<String,String>> picklistFieldMap;   // Field API Name, <Picklist Value, Picklist Label>
+        Map<String, Map<String,String>> picklistFieldMap;   // Field API Name, <Picklist Value, Picklist Label>
         List<String> percentFieldList;
         List<String> noEditFieldList;
         list<String> timeFieldList;
         list<String> dateFieldList;
-        // list<String> picklistFieldList;
+        list<String> picklistFieldList;
         List<String> currencyFieldList;
         List<String> numberFieldList;
         String objectName;
@@ -120,7 +122,7 @@ public with sharing class ers_DatatableController {
             curRR.noEditFieldList = emptyList;
             curRR.timeFieldList = emptyList;
             curRR.dateFieldList = emptyList;
-            // curRR.picklistFieldList = emptyList;
+            curRR.picklistFieldList = emptyList;
             curRR.currencyFieldList = emptyList;
             curRR.numberFieldList = emptyList;
             curRR.rowData = records;
@@ -156,10 +158,10 @@ public with sharing class ers_DatatableController {
         List<String> noEditFields = new List<String>();
         List<String> timeFields = new List<String>();
         List<String> dateFields = new List<String>();
-        // List<String> picklistFields = new List<String>();
+        List<String> picklistFields = new List<String>();
         List<String> currencyFields = new List<String>();
         List<String> numberFields = new List<String>();
-        // Map<String, Map<String, String>> picklistFieldLabels = new Map<String, Map<String, String>>();
+        Map<String, Map<String, String>> picklistFieldLabels = new Map<String, Map<String, String>>();
         String objectLinkField = getNameUniqueField(objName);   // Name (link) Field for the Datatable SObject
         System.debug('*** OBJ/LINK' + objname + '/' + objectLinkField);
 
@@ -186,7 +188,8 @@ public with sharing class ers_DatatableController {
                 + '", "length" : "' + dfr.getLength() 
                 + '"}';
 
-            if (!dfr.isUpdateable() || dfr.isCalculated()) noEditFields.add(fieldName);  // Check for Read Only and Formula fields
+            // if (!dfr.isUpdateable() || dfr.isCalculated()) noEditFields.add(fieldName);  // Check for Read Only and Formula fields
+            if (dfr.isCalculated()) noEditFields.add(fieldName);  // Check for Formula fields
 
             switch on dfr.getType().name() {
                 when 'REFERENCE' {
@@ -221,15 +224,15 @@ public with sharing class ers_DatatableController {
                     dateFields.add(fieldName);
                 }
                 when 'PICKLIST', 'MULTIPICKLIST' {
-                    // picklistFields.add(dfr.getName());
+                    picklistFields.add(dfr.getName());
                     // if (!noEditFields.contains(fieldName)) {
                     //     noEditFields.add(fieldName);
                     // }
-                    // Map<String, String> valueLabelPair = new Map<String, String>();
-                    // for(Schema.PicklistEntry ple : dfr.getPicklistValues()) {
-                    //     valueLabelPair.put(ple.getValue(), ple.getLabel());
-                    // }
-                    // picklistFieldLabels.put(dfr.getName(), valueLabelPair);
+                    Map<String, String> valueLabelPair = new Map<String, String>();
+                    for(Schema.PicklistEntry ple : dfr.getPicklistValues()) {
+                        valueLabelPair.put(ple.getValue(), ple.getLabel());
+                    }
+                    picklistFieldLabels.put(dfr.getName(), valueLabelPair);
                 }
                 when else {
                 }
@@ -244,8 +247,8 @@ public with sharing class ers_DatatableController {
         curRR.noEditFieldList = noEditFields;
         curRR.timeFieldList = timeFields;
         curRR.dateFieldList = dateFields;
-        // curRR.picklistFieldList = picklistFields;
-        // curRR.picklistFieldMap = picklistFieldLabels;
+        curRR.picklistFieldList = picklistFields;
+        curRR.picklistFieldMap = picklistFieldLabels;
         curRR.objectLinkField = objectLinkField;
         curRR.currencyFieldList = currencyFields;
         curRR.numberFieldList = numberFields;

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -20,7 +20,7 @@ if (baseURL.includes('--c.visualforce.')) {     // Running in Flow Builder
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '3.2.2',   // Current Source Code Version #
+        VERSION_NUMBER : '3.2.3',   // Current Source Code Version #
         MAXROWCOUNT : 1000,         // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,             // Used to round off the column widths during Config Mode to nearest value
         MYDOMAIN : myDomain,        // Used for building links for lookup fields

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -19,7 +19,7 @@
     ],
     "namespace": "",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "51.0",
+    "sourceApiVersion": "52.0",
     "packageAliases": {
         "datatable": "0Ho5G000000XZNaSAO",
         "FlowActionsBasePack": "04t4W000002vXUCQA2",
@@ -47,6 +47,7 @@
         "datatable@3.2.1-0": "04t5G0000047xH8QAI",
         "FlowActionsBasePack@2.20.0-0": "04t4W00000308ACQAY",
         "FlowScreenComponentsBasePack@2.3.5-0": "04t5G0000047xJOQAY",
-        "datatable@3.2.2-0": "04t5G0000047xJdQAI"
+        "datatable@3.2.2-0": "04t5G0000047xJdQAI",
+        "datatable@3.2.3-0": "04t5G0000047xJnQAI"
     }
 }


### PR DESCRIPTION
When the running User doesn't have Read access to the Datatable's SObject, Record Type Id for Picklist Values is ignored
and all picklist values will be available when editing a picklist field