### PR TITLE
Updated GetPicklistValues to be batchable

### DIFF
--- a/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValues.cls
+++ b/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValues.cls
@@ -3,56 +3,59 @@
 
 public with sharing class GetPicklistValues {
   
-    @InvocableMethod
-    public static List <Results> getPicklistVals(List<Requests> requestList) {
-        System.debug('entering getPicklistVals');
-        String objectName = requestList[0].objectName;
-        String fieldName = requestList[0].fieldName;
-        System.debug('object and field are  :' + objectName + 'and ' + fieldName );
+  @InvocableMethod(label='Get Picklist Values' description='Batchable version of GetPicklistValues')
+  public static List <Results> getPicklistVals(List<Requests> requestList) {
+      System.debug('entering getPicklistVals');
+      
+      List<Results> responseWrapper= new List<Results>();
+      
+      for (Requests request : requestList){
+          
+          String objectName = request.objectName;
+          String fieldName = request.fieldName;
+          System.debug('object and field are  :' + objectName + 'and ' + fieldName );
+  
+          SObjectType objectType = ((SObject) Type.forName(objectName).newInstance())
+                                    .getSObjectType();  //courtesy of cropredy and sfdcfox https://salesforce.stackexchange.com/a/250041/24822
+  
+          //General code below courtesy of sfdcmonkey http://sfdcmonkey.com/2016/12/05/how-to-fetch-picklist-value-from-sobject-and-set-in-uiinputselect/
+  
+          // Describe the SObject using its object type.
+          Schema.DescribeSObjectResult objDescribe = objectType.getDescribe();
+          // Get a map of fields for the SObject
+          map < String, Schema.SObjectField > fieldMap = objDescribe.fields.getMap();
+          // Get the list of picklist values for this field.
+          list < Schema.PicklistEntry > values =
+          fieldMap.get(fieldName).getDescribe().getPickListValues();
+  
+          List<String> picklistStringVals = new List<String>();
+  
+          //assemble the values into a List of strings
+          for (Schema.PicklistEntry a: values) {
+              picklistStringVals.add(a.getValue());
+          }
+          
+          Results response = new Results();
+          response.picklistValues = picklistStringVals;
+          responseWrapper.add(response);
+      }
 
-        SObjectType objectType = ((SObject) Type.forName(objectName).newInstance())
-                                  .getSObjectType();  //courtesy of cropredy and sfdcfox https://salesforce.stackexchange.com/a/250041/24822
+      return responseWrapper;
+  
+  }
 
-        //General code below courtesy of sfdcmonkey http://sfdcmonkey.com/2016/12/05/how-to-fetch-picklist-value-from-sobject-and-set-in-uiinputselect/
+  public class Requests {
+    @InvocableVariable(required=true)
+    public String objectName;
 
-        // Describe the SObject using its object type.
-        Schema.DescribeSObjectResult objDescribe = objectType.getDescribe();
-        // Get a map of fields for the SObject
-        map < String, Schema.SObjectField > fieldMap = objDescribe.fields.getMap();
-        // Get the list of picklist values for this field.
-        list < Schema.PicklistEntry > values =
-        fieldMap.get(fieldName).getDescribe().getPickListValues();
+    @InvocableVariable(required=true)
+    public String fieldName;
+      
+  }
+  
+  public class Results {
 
-        List<String> picklistStringVals = new List<String>();
-
-        //assemble the values into a List of strings
-        for (Schema.PicklistEntry a: values) {
-            picklistStringVals.add(a.getValue());
-        }
-        
-        Results response = new Results();
-        List<Results> responseWrapper= new List<Results>();
-
-        response.picklistValues = picklistStringVals;
-        responseWrapper.add(response);
-        return responseWrapper;
-    
-    }
-
-    public class Requests {
-      @InvocableVariable(required=true)
-      public String objectName;
-
-      @InvocableVariable(required=true)
-      public String fieldName;
-        
-    }
-    
-    public class Results {
-     
-      @InvocableVariable
-      public List<String> picklistValues;
-    }
+    @InvocableVariable
+    public List<String> picklistValues;
+  }
 }
-
-

--- a/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValues.cls-meta.xml
+++ b/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValues.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="GetPicklistValues">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValuesTests.cls-meta.xml
+++ b/flow_action_components/GetPicklistValues/force-app/main/default/classes/GetPicklistValuesTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="urn:metadata.tooling.soap.sforce.com" fqn="GetPicklistValuesTests">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
The GetPicklistValues action was erroring when performing actions during a batch update. This change fixes the issue.

If you performed a mass update, and a flow containing this action was triggered on record update, you would get the following error message:

> The number of results does not match the number of interviews that were executed in a single bulk execution request.

The action has been updated to allow it to run correctly in such scenarios, by looping though the requests, instead of only executing on the first.

The API version of the class has also been updated to v52.0.

This issue was first raised in the comments of the flow action: https://unofficialsf.com/flow-action-get-picklist-values/#comment-5123649046