### PR TITLE
3.3.2

### DIFF
--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -74,12 +74,13 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
  
 ## xx/xx/21 -  Eric Smith -    Version 3.3.1 
 **Updates:** 
+-   Converted interface elements to Custom Labels so they can be Translated 
 -   Updated all component API versions to 52.0
  
 **Bug Fixes:** 
 -   Added missing variable in the CPE for automaticOutputVariables
 -   Check for CurrencyConversion returning null values before committing any changes
-
+ 
 ## 07/18/21 -  Eric Smith -    Version 3.3.0 
 **Updates:** 
 -   Added a custom object (ers_datatableConfig) to provide the ability to Save and Retrieve column configuration attributes
@@ -90,7 +91,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 -   Fixed an error that ocurred when trying to save an edited row from a datatable that contained a time field 
 -   Fixed a bug that kept Date and Time fields from displaying in datatables when the User's locale displays numbers with a . separator
 -   Rows with editable picklist fields will not default to a taller height (Even without picklist fields, all rows will still be slightly taller if any fields are editable)
-
+ 
 ## 06/26/21 -  Eric Smith -    Version 3.2.4 
 **Updates:** 
 -   New Output Attribute for the Number of Rows Edited (Because even when no rows are edited, the OutputEditedRows attribute is not null)
@@ -134,7 +135,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
     (Does not yet support Dependent picklists nor filtering by Record Type)
 -   Changed Table Header font from 1.5em to 1.2em to match the format of List Views
 -   Renamed components used by Datatable to reduce conflicts and allow easier upgrading from older versions
-
+ 
 **Bug Fixes:**
 -   Do not display a header if there is a Header Label value but the Display Table Header attribute is not checked
 -   Make output attributes available to visibility filters (this was inadvertantly removed from some prior releases)
@@ -142,13 +143,13 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
     (Edited percent fields must be the actual number ie: .25 = 25%)
     (Edited percent fields lose 2 decimal places during the edit from what is defined for the field)
 -   Edited date fields will stay in the User's local time-zone rather than switching to UTC
-
+ 
 ## 04/15/21 -  Eric Smith -    Version 3.1.1 
 **Updates:** 
 -   Moved the "Display ALL Objects for Selection" choice in the CPE from Advanced to Data Source
 -   Added an attribute to hide all column header actions such as Sort, Clip/Wrap Text and Filters
 -   If Multi-Currency is enabled, convert currency field values to the User's currency (Thanks to Novarg1)
-
+ 
 **Bug Fixes:**
 -   Text formula fields will now wrap correctly
 -   Display ALL Objects for Selection attribute is now persistent
@@ -371,7 +372,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 -   Unlike the original datatable component, only the edited records will be passed back to the flow  
 -   The maximum number of rows to display can be set by the user  
 -   Optional attribute overrides are supported and can be specified by list, column # or by field name, including:  
-
+ 
                 - Alignment               
                 - Editable
                 - Header Icon

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -74,7 +74,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
  
 ## xx/xx/21 -  Eric Smith -    Version 3.3.1 
 **Updates:** 
--   
+-   Updated all component API versions to 52.0
  
 **Bug Fixes:** 
 -   Added missing variable in the CPE for automaticOutputVariables

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -72,6 +72,13 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes
  
+## xx/xx/21 -  Eric Smith -    Version 3.3.1 
+**Updates:** 
+-   
+ 
+**Bug Fixes:** 
+-   Added missing variable in the CPE for automaticOutputVariables
+
 ## 07/18/21 -  Eric Smith -    Version 3.3.0 
 **Updates:** 
 -   Added a custom object (ers_datatableConfig) to provide the ability to Save and Retrieve column configuration attributes

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -80,6 +80,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 **Bug Fixes:** 
 -   Added missing variable in the CPE for automaticOutputVariables
 -   Check for CurrencyConversion returning null values before committing any changes
+-   Fix filtering on Date and Datetime column types
  
 ## 07/18/21 -  Eric Smith -    Version 3.3.0 
 **Updates:** 

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -51,8 +51,8 @@ https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 3.3.1 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaRQAU)   
-[Version 3.3.1 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaRQAU)
+[Version 3.3.2 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaWQAU)   
+[Version 3.3.2 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaWQAU)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -72,7 +72,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes
  
-## 08/13/21 -  Eric Smith -    Version 3.3.1 
+## 08/13/21 -  Eric Smith -    Version 3.3.2 
 **Updates:** 
 -   Converted interface elements to Custom Labels so they can be Translated 
 -   Added support for Screen Readers for the visually impaired

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -78,6 +78,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
  
 **Bug Fixes:** 
 -   Added missing variable in the CPE for automaticOutputVariables
+-   Check for CurrencyConversion returning null values before committing any changes
 
 ## 07/18/21 -  Eric Smith -    Version 3.3.0 
 **Updates:** 

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -43,16 +43,16 @@ Twitter: 	https://twitter.com/esmith35
 
 ---
 **You must install these components FIRST in order to install and use the Datatable component**     
-FlowActionsBasePack Version 2.26 or later  
-FlowScreenComponentsBasePack Version 2.5.0 or later  
+FlowActionsBasePack Version 2.32 or later  
+FlowScreenComponentsBasePack Version 2.5.4 or later  
   
 Both Base Packs are available here:   
 https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 3.3.0 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xMwQAI)   
-[Version 3.3.0 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G0000047xMwQAI)
+[Version 3.3.1 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaRQAU)   
+[Version 3.3.1 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000003rUaRQAU)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -72,14 +72,14 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes
  
-## xx/xx/21 -  Eric Smith -    Version 3.3.1 
+## 08/13/21 -  Eric Smith -    Version 3.3.1 
 **Updates:** 
 -   Converted interface elements to Custom Labels so they can be Translated 
 -   Added support for Screen Readers for the visually impaired
 -   Updated all component API versions to 52.0
  
 **Bug Fixes:** 
--   Added missing variable in the CPE for automaticOutputVariables
+-   Added missing variable in the CPE to support automaticOutputVariables
 -   Check for CurrencyConversion returning null values before committing any changes
 -   Fix filtering on Date and Datetime column types
 -   Keep Checkbox selection instead of Radio Button when table size is 1 and Single Row Selection is not activated

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -75,6 +75,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ## xx/xx/21 -  Eric Smith -    Version 3.3.1 
 **Updates:** 
 -   Converted interface elements to Custom Labels so they can be Translated 
+-   Added support for Screen Readers for the visually impaired
 -   Updated all component API versions to 52.0
  
 **Bug Fixes:** 

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -81,6 +81,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 -   Added missing variable in the CPE for automaticOutputVariables
 -   Check for CurrencyConversion returning null values before committing any changes
 -   Fix filtering on Date and Datetime column types
+-   Keep Checkbox selection instead of Radio Button when table size is 1 and Single Row Selection is not activated
  
 ## 07/18/21 -  Eric Smith -    Version 3.3.0 
 **Updates:** 

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
@@ -16,7 +16,7 @@
  *              of the Name fields in the corresponding records. Return the
  *              records that now include both the Id and Name for each lookup.
  * 
- * 08/13/21 -   Eric Smith -    Version 3.3.1   Check for invalid Currency Conversion before committing any changes
+ * 08/13/21 -   Eric Smith -    Version 3.3.2   Check for invalid Currency Conversion before committing any changes
  *   
  * 06/13/21 -   Eric Smith -    Version 3.2.3   Return all Picklist values when the running user doesn't have Read access to table's SObject
  * 

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
@@ -15,6 +15,8 @@
  *              use the recordId values in the lookup fields get the values
  *              of the Name fields in the corresponding records. Return the
  *              records that now include both the Id and Name for each lookup.
+ * 
+ * 08/10/21 -   Eric Smith -    Version 3.3.1   Check for invalid Currency Conversion before committing any changes
  *   
  * 06/13/21 -   Eric Smith -    Version 3.2.3   Return all Picklist values when the running user doesn't have Read access to table's SObject
  * 
@@ -316,7 +318,9 @@ public with sharing class ers_DatatableController {
             for (SObject so : records) {
                 SObject converted = sobjCurrencyFields.get(so.Id);
                 for (String currField : currencyFields) {
-                    so.put(currField, converted.get(currField));
+                    if (converted.get(currField) != null) {
+                        so.put(currField, converted.get(currField));
+                    }
                 }
             }
         }

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
@@ -16,7 +16,7 @@
  *              of the Name fields in the corresponding records. Return the
  *              records that now include both the Id and Name for each lookup.
  * 
- * 08/10/21 -   Eric Smith -    Version 3.3.1   Check for invalid Currency Conversion before committing any changes
+ * 08/13/21 -   Eric Smith -    Version 3.3.1   Check for invalid Currency Conversion before committing any changes
  *   
  * 06/13/21 -   Eric Smith -    Version 3.2.3   Return all Picklist values when the running user doesn't have Read access to table's SObject
  * 

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableControllerTest.cls-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_QueryNRecords.cls-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_QueryNRecords.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_QueryNRecordsTest.cls-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_QueryNRecordsTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_screen_components/datatable/force-app/main/default/flows/Datatable_Configuration_Wizard.flow-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/flows/Datatable_Configuration_Wizard.flow-meta.xml
@@ -113,7 +113,7 @@
             <name>recordString</name>
         </outputParameters>
     </actionCalls>
-    <apiVersion>49.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <assignments>
         <name>Add_Config_Quick_Choice_Option</name>
         <label>Add Config Quick Choice Option</label>

--- a/flow_screen_components/datatable/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomLabels xmlns="http://soap.sforce.com/2006/04/metadata">
+    <labels>
+        <fullName>ers_CancelButton</fullName>
+        <categories>buttons</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Cancel</shortDescription>
+        <value>Cancel</value>
+    </labels>
+    <labels>
+        <fullName>ers_SaveButton</fullName>
+        <categories>buttons</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Save</shortDescription>
+        <value>Save</value>
+    </labels>
+    <labels>
+        <fullName>ers_ClearSelectionButton</fullName>
+        <categories>buttons</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Clear Selection</shortDescription>
+        <value>Clear Selection</value>
+    </labels>
+    <labels>
+        <fullName>ers_SetFilterAction</fullName>
+        <categories>actions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Set Filter</shortDescription>
+        <value>Set Filter</value>
+    </labels>
+    <labels>
+        <fullName>ers_ClearFilterAction</fullName>
+        <categories>actions</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Clear Filter</shortDescription>
+        <value>Clear Filter</value>
+    </labels>
+    <labels>
+        <fullName>ers_ColumnHeader</fullName>
+        <categories>headers</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Column</shortDescription>
+        <value>Column</value>
+    </labels>
+    <labels>
+        <fullName>ers_FilterHeader</fullName>
+        <categories>headers</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Filter</shortDescription>
+        <value>Filter</value>
+    </labels>
+    <labels>
+        <fullName>ers_LabelHeader</fullName>
+        <categories>headers</categories>
+        <language>en_US</language>
+        <protected>false</protected>
+        <shortDescription>Label</shortDescription>
+        <value>Label</value>
+    </labels>
+</CustomLabels>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
@@ -128,6 +128,7 @@ Features:   The only required paramters are the SObject collection of records an
 
             <div style={tableHeightAttribute} class={borderClass} id="datatable">
                 <c-ers_custom-lightning-datatable
+                    aria-label={tableLabel}
                     data={mydata}
                     columns={columns}
                     key-field={keyField}

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
@@ -56,8 +56,8 @@ Features:   The only required paramters are the SObject collection of records an
                             </c-fsc_pick-icon>
                         </div>
                         <footer class="slds-modal__footer">
-                            <button class="slds-button slds-button_neutral" onclick={handleCloseIconModal}>Cancel</button>
-                            <button class="slds-button slds-button_brand" onclick={handleCommitIconSelection}>Save</button>
+                            <button class="slds-button slds-button_neutral" onclick={handleCloseIconModal}>{label.CancelButton}</button>
+                            <button class="slds-button slds-button_brand" onclick={handleCommitIconSelection}>{label.SaveButton}</button>
                         </footer>
                     </div>
                 </section>
@@ -86,8 +86,8 @@ Features:   The only required paramters are the SObject collection of records an
                             ></lightning-input>
                         </div>
                         <footer class="slds-modal__footer">
-                            <button class="slds-button slds-button_neutral" onclick={handleCloseModal}>Cancel</button>
-                            <button class="slds-button slds-button_brand" onclick={handleCommit}>Save</button>
+                            <button class="slds-button slds-button_neutral" onclick={handleCloseModal}>{label.CancelButton}</button>
+                            <button class="slds-button slds-button_brand" onclick={handleCommit}>{label.SaveButton}</button>
                         </footer>
                     </div>
                 </section>
@@ -150,7 +150,7 @@ Features:   The only required paramters are the SObject collection of records an
                 >
                 </c-ers_custom-lightning-datatable>
                 <div if:true={showClearButton} class="slds-m-top_x-small">
-                    <lightning-button variant="brand-outline" label="Clear Selection" icon-name="utility:clear" onclick={handleClearSelection}></lightning-button>
+                    <lightning-button variant="brand-outline" label={label.ClearSelectionButton} icon-name="utility:clear" onclick={handleClearSelection}></lightning-button>
                 </div>
             </div>
             <div if:true={isWorking}>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1797,16 +1797,39 @@ export default class Datatable extends LightningElement {
                                     match = false;
                                     break; 
                                 }                   
-
+                                
                                 switch(this.filterColumns[col].type) {
                                     case 'number':
                                     case 'currency':
                                     case 'percent':
-                                    case 'date':
+                                        if (row[fieldName] != this.columnFilterValues[col]) {    // Check for exact match on numeric fields
+                                            match = false;
+                                            break;                                
+                                        }
+                                        break;
                                     case 'date-local':
+                                        let dl = row[fieldName];
+                                        let dtf = new Intl.DateTimeFormat('en', {
+                                            year: 'numeric',
+                                            month: '2-digit',
+                                            day: '2-digit'
+                                        });
+                                        const [{value: mo}, , {value: da}, , {value: ye}] = dtf.formatToParts(dl);
+                                        let formatedDate = `${ye}-${mo}-${da}`;
+                                        if (formatedDate != this.columnFilterValues[col]) {    // Check for date match on date & time fields
+                                            match = false;
+                                            break;                                
+                                        }
+                                        break;
+                                    case 'date':
                                     case 'datetime':
                                     case 'time':
-                                        if (row[fieldName] != this.columnFilterValues[col]) {    // Check for exact match on numeric and date fields
+                                        if (typeof(row[fieldName]) === typeof(+1)) { 
+                                            match = false;
+                                            break;  //TODO - Figure out a way to filter on Time fields
+                                        }
+                                        let dt = row[fieldName].slice(0,10);
+                                        if (dt != this.columnFilterValues[col]) {    // Check for date match on date & time fields
                                             match = false;
                                             break;                                
                                         }

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -617,7 +617,7 @@ export default class Datatable extends LightningElement {
         if (this.tableData) {
 
             // Set other initial values here
-            this.maxRowSelection = (this.singleRowSelection) ? 1 : this.tableData.length;
+            this.maxRowSelection = (this.singleRowSelection) ? 1 : this.tableData.length + 1; // If maxRowSelection=1 then Radio Buttons are used
             this.wizColumnFields = this.columnFields;
 
             console.log('Processing Datatable');
@@ -1414,7 +1414,7 @@ export default class Datatable extends LightningElement {
         // Return an SObject Record if just a single row is selected
         this.outputSelectedRow = (this.numberOfRowsSelected == 1) ? currentSelectedRows[0] : null;
         this.dispatchEvent(new FlowAttributeChangeEvent('outputSelectedRow', this.outputSelectedRow));
-        this.showClearButton = this.numberOfRowsSelected == 1 && (this.tableData.length == 1 || this.singleRowSelection) && !this.hideCheckboxColumn && !this.hideClearSelectionButton;
+        this.showClearButton = this.numberOfRowsSelected == 1 && (this.tableData.length == 1 && this.singleRowSelection) && !this.hideCheckboxColumn && !this.hideClearSelectionButton;
     }
 
     handleClearSelection() {

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -13,6 +13,14 @@ import getReturnResults from '@salesforce/apex/ers_DatatableController.getReturn
 import { FlowAttributeChangeEvent } from 'lightning/flowSupport';
 import {getPicklistValuesByRecordType} from "lightning/uiObjectInfoApi";
 import { getConstants } from 'c/ers_datatableUtils';
+import CancelButton from '@salesforce/label/c.ers_CancelButton';
+import SaveButton from '@salesforce/label/c.ers_SaveButton';
+import ClearSelectionButton from '@salesforce/label/c.ers_ClearSelectionButton';
+import SetFilterAction from '@salesforce/label/c.ers_SetFilterAction';
+import ClearFilterAction from '@salesforce/label/c.ers_ClearFilterAction';
+import ColumnHeader from '@salesforce/label/c.ers_ColumnHeader';
+import FilterHeader from '@salesforce/label/c.ers_FilterHeader';
+import LabelHeader from '@salesforce/label/c.ers_LabelHeader';
 
 const CONSTANTS = getConstants();   // From ers_datatableUtils : VERSION_NUMBER, MAXROWCOUNT, ROUNDWIDTH, MYDOMAIN, ISCOMMUNITY
 
@@ -21,6 +29,18 @@ const ISCOMMUNITY = CONSTANTS.ISCOMMUNITY;
 const CB_TRUE = CONSTANTS.CB_TRUE;
 
 export default class Datatable extends LightningElement {
+
+    // Translatable Labels
+    label = {
+        CancelButton,
+        SaveButton,
+        ClearSelectionButton,
+        SetFilterAction,
+        ClearFilterAction,
+        ColumnHeader,
+        FilterHeader,
+        LabelHeader
+    };
 
     // Component Input & Output Attributes
     @api tableData = [];
@@ -475,8 +495,8 @@ export default class Datatable extends LightningElement {
                     column: col,
                     filter: colFilter,
                     actions: [
-                        {label: 'Set Filter', disabled: false, name: 'filter_' + col, iconName: 'utility:filter'},
-                        {label: 'Clear Filter', disabled: true, name: 'clear_' + col, iconName: 'utility:clear'}
+                        {label: this.label.SetFilterAction, disabled: false, name: 'filter_' + col, iconName: 'utility:filter'},
+                        {label: this.label.ClearFilterAction, disabled: true, name: 'clear_' + col, iconName: 'utility:clear'}
                     ]
                 });
                 this.filterAttribType = 'cols';
@@ -975,8 +995,8 @@ export default class Datatable extends LightningElement {
                     filterAttrib.column = columnNumber; 
                     filterAttrib.filter = true;
                     filterAttrib.actions = [
-                        {label: 'Set Filter', disabled: false, name: 'filter_' + columnNumber, iconName: 'utility:filter'},
-                        {label: 'Clear Filter', disabled: true, name: 'clear_' + columnNumber, iconName: 'utility:clear'}
+                        {label: this.label.SetFilterAction, disabled: false, name: 'filter_' + columnNumber, iconName: 'utility:filter'},
+                        {label: this.label.ClearFilterAction, disabled: true, name: 'clear_' + columnNumber, iconName: 'utility:clear'}
                     ]; 
                     break;
                 default:
@@ -1448,8 +1468,8 @@ export default class Datatable extends LightningElement {
         this.filterColumns = JSON.parse(JSON.stringify([...this.columns]));
         this.columnNumber = Number(colDef.actions[0].name.split("_")[1]);
         this.baseLabel = this.filterColumns[this.columnNumber].label.split(' [')[0];
-        const prompt = (this.isConfigMode) ? 'Label' : 'Filter';
-        this.inputLabel = 'Column ' + prompt + ': ' + this.baseLabel;
+        const prompt = (this.isConfigMode) ? this.label.LabelHeader : this.label.FilterHeader;
+        this.inputLabel = this.label.ColumnHeader + ' ' + prompt + ': ' + this.baseLabel;
         switch(actionName.split('_')[0]) {
 
             case 'alignl':   // Config Mode Only

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <masterLabel>Datatable</masterLabel>
     <description>This component allows the user to configure and display a datatable in a Flow screen.</description>
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_comboboxColumnType/ers_comboboxColumnType.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <description>Custom datatable column type for comobobox</description>
     <isExposed>false</isExposed>
     <masterLabel>Combobox Column Type</masterLabel>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_customLightningDatatable.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_customLightningDatatable/ers_customLightningDatatable.js-meta.xml
@@ -2,6 +2,6 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <masterLabel>custom-lighting-datatable</masterLabel>
     <description>This component extends lightning datatable to use custom data types</description>
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
@@ -63,6 +63,7 @@ export default class ers_datatableCPE extends LightningElement {
     _flowVariables;
     _elementType;
     _elementName;
+    _automaticOutputVariables;
 
     // These are the parameter values being seeded to & coming back from the Wizard Flow
     _wiz_columnFields;

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <isExposed>true</isExposed>
 </LightningComponentBundle>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -20,7 +20,7 @@ if (baseURL.includes('--c.visualforce.')) {     // Running in Flow Builder
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '3.3.1',   // Current Source Code Version #
+        VERSION_NUMBER : '3.3.2',   // Current Source Code Version #
         MAXROWCOUNT : 1000,         // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,             // Used to round off the column widths during Config Mode to nearest value
         WIZROWCOUNT : 6,            // Number of records to display in the Column Wizard datatable

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -20,7 +20,7 @@ if (baseURL.includes('--c.visualforce.')) {     // Running in Flow Builder
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '3.3.0',   // Current Source Code Version #
+        VERSION_NUMBER : '3.3.1',   // Current Source Code Version #
         MAXROWCOUNT : 1000,         // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,             // Used to round off the column widths during Config Mode to nearest value
         WIZROWCOUNT : 6,            // Number of records to display in the Column Wizard datatable

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>50.0</apiVersion>
+    <apiVersion>52.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -58,6 +58,7 @@
         "datatable@3.3.0-0": "04t5G0000047xMwQAI",
         "FlowActionsBasePack@2.32.0-0": "04t4W0000034KebQAE",
         "FlowScreenComponentsBasePack@2.5.4-0": "04t5G000003rUaHQAU",
-        "datatable@3.3.1-0": "04t5G000003rUaRQAU"
+        "datatable@3.3.1-0": "04t5G000003rUaRQAU",
+        "datatable@3.3.2-0": "04t5G000003rUaWQAU"
     }
 }

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -5,10 +5,10 @@
             "default": true,
             "dependencies": [
                 {
-                    "package": "FlowActionsBasePack@2.26.0-0"
+                    "package": "FlowActionsBasePack@2.32.0-0"
                 },
                 {
-                    "package": "FlowScreenComponentsBasePack@2.5.0-0"
+                    "package": "FlowScreenComponentsBasePack@2.5.4-0"
                 }
             ],
             "package": "datatable",
@@ -55,6 +55,9 @@
         "FlowActionsBasePack@2.26.0-0": "04t4W00000308RmQAI",
         "FlowScreenComponentsBasePack@2.5.0-0": "04t5G0000047xMDQAY",
         "datatable@3.2.5-0": "04t5G0000047xMmQAI",
-        "datatable@3.3.0-0": "04t5G0000047xMwQAI"
+        "datatable@3.3.0-0": "04t5G0000047xMwQAI",
+        "FlowActionsBasePack@2.32.0-0": "04t4W0000034KebQAE",
+        "FlowScreenComponentsBasePack@2.5.4-0": "04t5G000003rUaHQAU",
+        "datatable@3.3.1-0": "04t5G000003rUaRQAU"
     }
 }


### PR DESCRIPTION
Datatable v3.2.2 Source Changes

**Updates:** 
-   Converted interface elements to Custom Labels so they can be Translated 
-   Added support for Screen Readers for the visually impaired
-   Updated all component API versions to 52.0

**Bug Fixes:** 
-   Added missing variable in the CPE to support automaticOutputVariables
-   Check for CurrencyConversion returning null values before committing any changes
-   Fix filtering on Date and Datetime column types
-   Keep Checkbox selection instead of Radio Button when table size is 1 and Single Row Selection is not activated