### PR TITLE
Allow for SObject field type to be null (CloneSourceId)

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.js
@@ -585,13 +585,13 @@ export default class FlowCombobox extends LightningElement {
                 let localOptions = curOption.options;
 
                 if (this.builderContextFilterType) {
-                    localOptions = localOptions.filter(opToFilter => opToFilter.displayType.toLowerCase() === this.builderContextFilterType.toLowerCase() || opToFilter.storeOutputAutomatically === true || (  opToFilter.type === 'SObject' && !this.builderContextFilterCollectionBoolean));
+                    localOptions = localOptions.filter(opToFilter => opToFilter.displayType?.toLowerCase() === this.builderContextFilterType.toLowerCase() || opToFilter.storeOutputAutomatically === true || (  opToFilter.type === 'SObject' && !this.builderContextFilterCollectionBoolean));
                 }
 
                 if (typeof this.builderContextFilterCollectionBoolean !== "undefined") {
                     localOptions = localOptions.filter(opToFilter =>  {
                         return((opToFilter.isCollection === this.builderContextFilterCollectionBoolean) 
-                         || (opToFilter.storeOutputAutomatically === true))}
+                            || (opToFilter.storeOutputAutomatically === true))}
 
                     ) ;
                 }


### PR DESCRIPTION
It looks like API 52.0 introduced a CloneSourceId reference in an SObject with a Type of null.  This fix avoids a CPE erroring out when trying to enter an Object>Field reference using fsc_flowCombobox.

PLEASE BUILD A NEW FlowScreenComponentsBasePack.