### PR TITLE
Use setEntityAttachments() instead of setFileAttachments()

### DIFF
--- a/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailAddAttachmentToEmail.cls
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailAddAttachmentToEmail.cls
@@ -2,12 +2,13 @@
  * @description       : 
  * @author            : Refactored from Alex Edelstein
  * @group             : 
- * @last modified on  : 02-17-2021
- * @last modified by  : Jack D. Pond
+ * @last modified on  : 09-01-2021
+ * @last modified by  : Michael Kraus
  * Modifications Log 
  * Ver      Date        Author              Modification
  * 1.0      02-16-2021  Alex Edelstein      Initial Version
  * 2.0.5    02-16-2021  Jack D. Pond        Use Title instead of PathOnClient for attachment name
+ * 2.1.7    09-01-2021  Michael Kraus       Use setEntityAttachments() instead of setFileAttachments()
  * 
 **/
 public inherited sharing class SendBetterEmailAddAttachmentToEmail {
@@ -17,14 +18,11 @@ public inherited sharing class SendBetterEmailAddAttachmentToEmail {
         List<ContentDocumentLink> contentDocumentLinks,
         Map<Id, List<ContentVersion>> mapContentDocumentIdByContentVersion
     ) {
-        List<SObject> curAttachments = new List<SObject>();
+        Set<Id> contentVersionIds = new Set<Id>();
 
         if (contentDocumentLinks != null && !contentDocumentLinks.isEmpty()) {
-            Set<Id> cdIds = new Set<Id>();
             for (ContentDocumentLink cdl : contentDocumentLinks) {
-                cdIds.add(cdl.ContentDocumentId);
-            }
-            for (Id contentDocumentId : cdIds) {
+                Id contentDocumentId = cdl.ContentDocumentId;
                 if (
                     mapContentDocumentIdByContentVersion.get(
                         contentDocumentId
@@ -37,29 +35,16 @@ public inherited sharing class SendBetterEmailAddAttachmentToEmail {
                             contentDocumentId
                         )
                     ) {
-                        curAttachments.add(
-                            new StaticResource(
-                                Name = cv.Title + ((cv.FileExtension != null) ? '.'+cv.FileExtension : ''),
-                                Body = cv.VersionData
-                            )
-                        );
+                        contentVersionIds.add(cv.Id);
                     }
                 }
             }
         }
 
-        List<Messaging.EmailFileAttachment> attachments = new List<Messaging.EmailFileAttachment>();
-
-        if (curAttachments != null) {
-            for (SObject file : curAttachments) {
-                Messaging.EmailFileAttachment efa = new Messaging.EmailFileAttachment();
-                efa.setFileName((String) file.get('Name'));
-                efa.setBody((BLOB) file.get('Body'));
-                efa.setContentType((String) file.get('ContentType'));
-                attachments.add(efa);
-            }
-            mail.setFileAttachments(attachments);
+        if (contentVersionIds.size() > 0) {
+            mail.setEntityAttachments(new List<Id>(contentVersionIds));
         }
+
         return mail;
     }
 }


### PR DESCRIPTION
As a result of this change, the class was simplified quite a bit.

As far as I can tell in my tests, the attachment behaviour for users should be exactly the same.
The only difference seems to be, that attachments are now visible in activities.
Other than documentation and possibly apex tests (which all pass right now), I don't see any other impact of this change.

Unrelated, it seems to me, that `mapContentDocumentIdByContentVersion` will only ever have lists with up to `1` element.