### PR TITLE
Fix issue with commas not being replace after parse

### DIFF
--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -23,7 +23,7 @@ public with sharing class ConvertCSVToRecords {
                 String csvStringContent = blobToString(csvBlobContent, 'ISO-8859-1');
                 String fSepRepl = '~`~', newlineRepl = '-`-';
                 csvStringContent = csvStringContent.replaceAll('(\r\n|\r)', '\n');
-                csvStringContent = removeCommas(csvStringContent, 0,curInput.FSep,fSepRepl, newlineRepl);
+                csvStringContent = removeFSeps(csvStringContent, 0,curInput.FSep,fSepRepl, newlineRepl);
                 String[] csvRows = csvStringContent.split('\n');
                 String[] fields = csvRows[0].split(curInput.FSep); //Gives all the API names of the fields from the 1st CSV row 
                 csvRows.remove(0);
@@ -49,7 +49,7 @@ public with sharing class ConvertCSVToRecords {
                     String[] fieldInputValues = row.split(curInput.FSep,-1);
                     for (Integer i = 0; i < fields.size(); i++) {
                         String fieldValue = fieldInputValues[i].replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
-                        fieldValue = replaceComma(fieldValue, curInput.Fsep, fSepRepl);
+                        fieldValue = replaceFSep(fieldValue, curInput.Fsep, fSepRepl);
                         fieldValue = removeQuotes(fieldValue); // Remove " characters if they bracket the field value
                         String Tsep = curInput.Tsep;
                         String Dsep = curInput.Dsep;
@@ -176,7 +176,7 @@ public with sharing class ConvertCSVToRecords {
         return convertedFieldValue;
     }
 
-    static String removeCommas(String text, Integer eloc, String fSep, String fSepRepl, String newlineRepl) {
+    static String removeFSeps(String text, Integer eloc, String fSep, String fSepRepl, String newlineRepl) {
         Integer sloc = -1;
         if (eloc == 0 && text.substring(eloc, 1) == '"') {
             sloc = 0;
@@ -196,7 +196,7 @@ public with sharing class ConvertCSVToRecords {
         }
         String subText = text.substring(sloc + 1, eloc).replace(fSep, fSepRepl).replace('\n', newlineRepl);
         String replText = text.substring(0, sloc + 1) + subText + text.substring(eloc);
-        return removeCommas(replText, eloc,fSep, fSepRepl, newlineRepl);
+        return removeFSeps(replText, eloc,fSep, fSepRepl, newlineRepl);
     }
 
     static Integer getNextQuoteIndex(String text, Integer startingFrom, Boolean isClosing) {
@@ -214,7 +214,7 @@ public with sharing class ConvertCSVToRecords {
         return -1;
     }
 
-    static String replaceComma(String text, String fSep, String fSepRepl) {
+    static String replaceFSep(String text, String fSep, String fSepRepl) {
         return text.replace(fSepRepl,fSep);
     }
 

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -21,9 +21,9 @@ public with sharing class ConvertCSVToRecords {
 
                 Blob csvBlobContent = getCsvContent(curContentDocumentId);
                 String csvStringContent = blobToString(csvBlobContent, 'ISO-8859-1');
-                String commaRepl = '~`~', newlineRepl = '-`-';
+                String fSepRepl = '~`~', newlineRepl = '-`-';
                 csvStringContent = csvStringContent.replaceAll('(\r\n|\r)', '\n');
-                csvStringContent = removeCommas(csvStringContent, 0,curInput.FSep,commaRepl, newlineRepl);
+                csvStringContent = removeCommas(csvStringContent, 0,curInput.FSep,fSepRepl, newlineRepl);
                 String[] csvRows = csvStringContent.split('\n');
                 String[] fields = csvRows[0].split(curInput.FSep); //Gives all the API names of the fields from the 1st CSV row 
                 csvRows.remove(0);
@@ -49,7 +49,7 @@ public with sharing class ConvertCSVToRecords {
                     String[] fieldInputValues = row.split(curInput.FSep,-1);
                     for (Integer i = 0; i < fields.size(); i++) {
                         String fieldValue = fieldInputValues[i].replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
-                        fieldValue = replaceComma(fieldValue, curInput.Fsep, commaRepl);
+                        fieldValue = replaceComma(fieldValue, curInput.Fsep, fSepRepl);
                         fieldValue = removeQuotes(fieldValue); // Remove " characters if they bracket the field value
                         String Tsep = curInput.Tsep;
                         String Dsep = curInput.Dsep;
@@ -176,7 +176,7 @@ public with sharing class ConvertCSVToRecords {
         return convertedFieldValue;
     }
 
-    static String removeCommas(String text, Integer eloc, String fSep, String commaRepl, String newlineRepl) {
+    static String removeCommas(String text, Integer eloc, String fSep, String fSepRepl, String newlineRepl) {
         Integer sloc = -1;
         if (eloc == 0 && text.substring(eloc, 1) == '"') {
             sloc = 0;
@@ -194,9 +194,9 @@ public with sharing class ConvertCSVToRecords {
                 return text;
             }
         }
-        String subText = text.substring(sloc + 1, eloc).replace(fSep, commaRepl).replace('\n', newlineRepl);
+        String subText = text.substring(sloc + 1, eloc).replace(fSep, fSepRepl).replace('\n', newlineRepl);
         String replText = text.substring(0, sloc + 1) + subText + text.substring(eloc);
-        return removeCommas(replText, eloc,fSep, commaRepl, newlineRepl);
+        return removeCommas(replText, eloc,fSep, fSepRepl, newlineRepl);
     }
 
     static Integer getNextQuoteIndex(String text, Integer startingFrom, Boolean isClosing) {
@@ -214,8 +214,8 @@ public with sharing class ConvertCSVToRecords {
         return -1;
     }
 
-    static String replaceComma(String text, String fSep, String commaRepl) {
-        return text.replace(commaRepl,fSep);
+    static String replaceComma(String text, String fSep, String fSepRepl) {
+        return text.replace(fSepRepl,fSep);
     }
 
     static String replaceNewline(String text, String newlineRepl) {

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -49,6 +49,8 @@ public with sharing class ConvertCSVToRecords {
                     String[] fieldInputValues = row.split(curInput.FSep);
                     for (Integer i = 0; i < fields.size(); i++) {
                         String fieldValue = fieldInputValues[i].replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
+                        fieldValue = replaceComma(fieldValue, commaRepl);
+                        fieldValue = removeQuotes(fieldValue); // Remove " characters if they bracket the field value
                         String Tsep = curInput.Tsep;
                         String Dsep = curInput.Dsep;
                         String vCur = curInput.vCur;

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -23,7 +23,7 @@ public with sharing class ConvertCSVToRecords {
                 String csvStringContent = blobToString(csvBlobContent, 'ISO-8859-1');
                 String commaRepl = '~`~', newlineRepl = '-`-';
                 csvStringContent = csvStringContent.replaceAll('(\r\n|\r)', '\n');
-                csvStringContent = removeCommas(csvStringContent, 0, commaRepl, newlineRepl);
+                csvStringContent = removeCommas(csvStringContent, 0,curInput.FSep,commaRepl, newlineRepl);
                 String[] csvRows = csvStringContent.split('\n');
                 String[] fields = csvRows[0].split(curInput.FSep); //Gives all the API names of the fields from the 1st CSV row 
                 csvRows.remove(0);
@@ -45,11 +45,11 @@ public with sharing class ConvertCSVToRecords {
                 for (String row : csvRows) {
                     row = replaceNewline(row, newlineRepl);
                     SObject obj = sObjType.newSObject();
-                    row = row.replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
-                    String[] fieldInputValues = row.split(curInput.FSep);
+                    //row = row.replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
+                    String[] fieldInputValues = row.split(curInput.FSep,-1);
                     for (Integer i = 0; i < fields.size(); i++) {
                         String fieldValue = fieldInputValues[i].replace(curInput.Fsep + '"',curInput.Fsep).replace('"' + curInput.Fsep,curInput.Fsep);
-                        fieldValue = replaceComma(fieldValue, commaRepl);
+                        fieldValue = replaceComma(fieldValue, curInput.Fsep, commaRepl);
                         fieldValue = removeQuotes(fieldValue); // Remove " characters if they bracket the field value
                         String Tsep = curInput.Tsep;
                         String Dsep = curInput.Dsep;
@@ -176,7 +176,7 @@ public with sharing class ConvertCSVToRecords {
         return convertedFieldValue;
     }
 
-    static String removeCommas(String text, Integer eloc, String commaRepl, String newlineRepl) {
+    static String removeCommas(String text, Integer eloc, String fSep, String commaRepl, String newlineRepl) {
         Integer sloc = -1;
         if (eloc == 0 && text.substring(eloc, 1) == '"') {
             sloc = 0;
@@ -194,9 +194,9 @@ public with sharing class ConvertCSVToRecords {
                 return text;
             }
         }
-        String subText = text.substring(sloc + 1, eloc).replace(',', commaRepl).replace('\n', newlineRepl);
+        String subText = text.substring(sloc + 1, eloc).replace(fSep, commaRepl).replace('\n', newlineRepl);
         String replText = text.substring(0, sloc + 1) + subText + text.substring(eloc);
-        return removeCommas(replText, eloc, commaRepl, newlineRepl);
+        return removeCommas(replText, eloc,fSep, commaRepl, newlineRepl);
     }
 
     static Integer getNextQuoteIndex(String text, Integer startingFrom, Boolean isClosing) {
@@ -214,8 +214,8 @@ public with sharing class ConvertCSVToRecords {
         return -1;
     }
 
-    static String replaceComma(String text, String commaRepl) {
-        return text.replace(commaRepl, ',');
+    static String replaceComma(String text, String fSep, String commaRepl) {
+        return text.replace(commaRepl,fSep);
     }
 
     static String replaceNewline(String text, String newlineRepl) {

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
@@ -2,6 +2,8 @@
 public with sharing class ConvertCSVToRecordsTest {
     private static final String SPACE = ' ';
     private static final String SAMPLE_DESCRIPTION = 'Sample Description';
+    private static final String DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES='Agent, Commercial; Agent, Residential; Appraiser; Broker \n Business; ""Escrow Officer""; Landlord; Property Manager';
+    private static final String DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES_POST_PARSE='Agent, Commercial; Agent, Residential; Appraiser; Broker \n Business; "Escrow Officer"; Landlord; Property Manager'; // '""' is replaced indicates a single '"' within a column. The value after parsing should indicate that.
     private static final String NEW_YORK = 'New York';
     private static final String HOT = 'Hot';
 
@@ -35,6 +37,9 @@ public with sharing class ConvertCSVToRecordsTest {
         ConvertCSVToRecords.Response[] flowOutputs = ConvertCSVToRecords.convert(flowInputs);
         Test.stopTest();
         System.assert(flowOutputs[0].convertedCSVRows.size() == 3);
+        List<Account> accList = flowOutputs[0].convertedCSVRows;
+        System.assertEquals(3,accList.size(),'Expected 2 accounts to be parsed from csv input');
+        System.assertEquals(DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES_POST_PARSE,accList[1].Description,'The description field with commas, newline and quotes was not parsed correctly');
     }
 
     @isTest
@@ -115,7 +120,7 @@ public with sharing class ConvertCSVToRecordsTest {
         csvStringContent = csvHeader;
         csvStringContent += SPACE + SAMPLE_DESCRIPTION + ',500000,300,' + SPACE + HOT + ',"Acme, Inc",' + NEW_YORK + SPACE;
         csvStringContent += '\n';
-        csvStringContent += '"Sample Description,with new line",40000,30,Hot,"Universal Containers","Washington, DC"';
+        csvStringContent += '"'+DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES+'",40000,30,Hot,"Universal Containers","Washington, DC"';
         csvStringContent += '\n';
         csvStringContent += ',40000,20,Hot,"Universal Containers", ';
         return Blob.valueOf(csvStringContent);


### PR DESCRIPTION
Fix for issue #902 reported here.
The merged code was missing calls to add commas and quotes back in after
the values have been parsed.
The tests were missing asserts to validate that the final parsed value
matches what we expect when the value contains commas, newlines and
quotes. Added asserts to verify that.
I ran tests in #660 separately. However, did not commit those to the repo since those tests use Person Accounts.