### PR TITLE
ConvertCSVToRecords: Refactor and add more tests

### DIFF
--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -15,13 +15,14 @@ public with sharing class ConvertCSVToRecords {
                     curInput.contentDocumentIdList.add(curInput.contentDocumentId);
                 }
             }
+            SObjectType sObjType = ((SObject) Type.forName(curInput.objectApiName).newInstance()).getSObjectType();
+            Map<String, SObjectField> fieldMap = sObjType.getDescribe().fields.getMap();
             for (String curContentDocumentId : curInput.contentDocumentIdList) {
-                SObjectType sObjType = ((SObject) Type.forName(curInput.objectApiName).newInstance()).getSObjectType();
-                Map<String, SObjectField> fieldMap = sObjType.getDescribe().fields.getMap();
 
                 Blob csvBlobContent = getCsvContent(curContentDocumentId);
                 String csvStringContent = blobToString(csvBlobContent, 'ISO-8859-1');
-                String fSepRepl = '~`~', newlineRepl = '-`-';
+                String fSepRepl = '~`~';
+                String newlineRepl = '-`-';
                 csvStringContent = csvStringContent.replaceAll('(\r\n|\r)', '\n');
                 csvStringContent = removeFSeps(csvStringContent, 0,curInput.FSep,fSepRepl, newlineRepl);
                 String[] csvRows = csvStringContent.split('\n');

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
@@ -8,13 +8,13 @@ public with sharing class ConvertCSVToRecordsTest {
     private static final String HOT = 'Hot';
 
     @TestSetup
-    static void createData() {
+    private static void createData() {
         ContentVersion cv = new ContentVersion(Title = 'Demo Accounts CSV', VersionData = createCSVBlob(), PathOnClient = 'DemoAccounts.csv');
         insert cv;
     }
 
     @isTest
-    static void testconvertMethodExceptions() {
+    private static void testconvertMethodExceptions() {
         ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
 
         /* 1. FlowInput list size more than 1 exception
@@ -31,7 +31,7 @@ public with sharing class ConvertCSVToRecordsTest {
     }
 
     @isTest
-    static void testconvertMethod() {
+    private static void testconvertMethod() {
         ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
         Test.startTest();
         ConvertCSVToRecords.Response[] flowOutputs = ConvertCSVToRecords.convert(flowInputs);
@@ -43,7 +43,7 @@ public with sharing class ConvertCSVToRecordsTest {
     }
 
     @isTest
-    static void testIsTrimFlagPositive() {
+    private static void testIsTrimFlagPositive() {
         ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
         flowInputs[0].isTrim = true;
         Test.startTest();
@@ -59,7 +59,7 @@ public with sharing class ConvertCSVToRecordsTest {
     }
 
     @isTest
-    static void testIsTrimFlagNegative() {
+    private static void testIsTrimFlagNegative() {
         ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
         flowInputs[0].isTrim = false;
         Test.startTest();
@@ -73,7 +73,7 @@ public with sharing class ConvertCSVToRecordsTest {
     }
 
     @isTest
-    static void testGetFieldTypeMethodException() {
+    private static void testGetFieldTypeMethodException() {
         try {
             ConvertCSVToRecords.getFieldType(Schema.SObjectType.Account.fields.getMap(), 'TestField');
         } catch (Exception e) {
@@ -82,7 +82,7 @@ public with sharing class ConvertCSVToRecordsTest {
     }
 
     @isTest
-    static void testGetConvertedFieldValue() {
+    private static void testGetConvertedFieldValue() {
         /**
          * Check DOUBLE field
          */
@@ -111,7 +111,25 @@ public with sharing class ConvertCSVToRecordsTest {
         System.assertEquals('1234.56', String.valueOf((Decimal)result));
     }
 
-    static Blob createCSVBlob() {
+    @isTest
+    private static void testConvertMultipleContentDocs() {
+        createData(); //Create the document once more so we have a list of contentdocument ids
+        //System.assert(false,[Select Id from ContentVersion].size());
+        ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
+        Test.startTest();
+        ConvertCSVToRecords.Response[] flowOutputs = ConvertCSVToRecords.convert(flowInputs);
+        Test.stopTest();
+        //We should get 2 responses in the output array, one for each ContentDocument Id
+        System.assertEquals(2,flowOutputs.size(),'Expected 2 outputs from action, one for each Content Document Id');
+        for(ConvertCSVToRecords.Response flowOutput: flowOutputs){
+          System.assert(flowOutput.convertedCSVRows.size() == 3,'Expected 6 records but got '+flowOutput.convertedCSVRows.size());
+          List<Account> accList = flowOutput.convertedCSVRows;
+          System.assertEquals(3,accList.size(),'Expected 2 accounts to be parsed from csv input');
+          System.assertEquals(DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES_POST_PARSE,accList[1].Description,'The description field with commas, newline and quotes was not parsed correctly');
+        }
+    }
+
+    private static Blob createCSVBlob() {
         String csvStringContent;
         Blob csvBlobContent;
         string[] fields = new List<String>{ 'Description', 'AnnualRevenue', 'NumberOfEmployees', 'Rating', 'Name', 'Site' };
@@ -125,13 +143,22 @@ public with sharing class ConvertCSVToRecordsTest {
         csvStringContent += ',40000,20,Hot,"Universal Containers", ';
         return Blob.valueOf(csvStringContent);
     }
-    static ConvertCSVToRecords.Request[] createFlowInputsList() {
+
+    private static ConvertCSVToRecords.Request[] createFlowInputsList() {
         String contentDocumentId;
-        ContentVersion cv = [SELECT ContentDocumentId, FileType FROM ContentVersion WHERE Title = 'Demo Accounts CSV'];
+        List<ContentVersion> cvList = [SELECT ContentDocumentId, FileType FROM ContentVersion WHERE Title = 'Demo Accounts CSV'];
         ConvertCSVToRecords.Request[] flowInputs = new List<ConvertCSVToRecords.Request>{};
         ConvertCSVToRecords.Request input = new ConvertCSVToRecords.Request();
         input.objectApiName = 'Account';
-        input.contentDocumentId = cv.ContentDocumentId;
+        if(cvList.size()==1){
+          input.contentDocumentId = cvList[0].ContentDocumentId;
+        }
+        else if(cvList.size()>1){
+          input.contentDocumentIdList = new List<Id>();
+          for(ContentVersion cv: cvList){
+            input.contentDocumentIdList.add(cv.ContentDocumentId);
+          }
+        }
         input.FSep =',';
         flowInputs.add(input);
 


### PR DESCRIPTION
For ConvertCSVToRecords action:
Moved the statements for retrieving object fields map outside the inner
contentdocumentid loop for better performance. Added test to verify
handling of multiple content document ids. Added 'private' qualifier to
all methods in test class