### PR TITLE
Navigate to Next Flow Element on Save

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -10,7 +10,7 @@
 
 import { LightningElement, api, track, wire } from 'lwc';
 import getReturnResults from '@salesforce/apex/ers_DatatableController.getReturnResults';
-import { FlowAttributeChangeEvent } from 'lightning/flowSupport';
+import { FlowAttributeChangeEvent, FlowNavigationNextEvent } from 'lightning/flowSupport';
 import {getPicklistValuesByRecordType} from "lightning/uiObjectInfoApi";
 import { getConstants } from 'c/ers_datatableUtils';
 import CancelButton from '@salesforce/label/c.ers_CancelButton';
@@ -61,7 +61,8 @@ export default class Datatable extends LightningElement {
     @api numberOfRowsSelected = 0;
     @api numberOfRowsEdited = 0;
     @api isConfigMode = false;
-    @api tableHeight;
+    @api tableHeight;    
+    @api navOnSave = false;
     @api outputSelectedRows = [];
     @api outputSelectedRow;
     @api outputEditedRows = [];
@@ -1397,6 +1398,11 @@ export default class Datatable extends LightningElement {
             this.columns = [...this.columns];   // Force clearing of the edit highlights
             //clear draftValues. this is required for custom column types that need to specifically write into draftValues
             this.template.querySelector('c-ers_custom-lightning-datatable').draftValues = [];
+        }
+
+        if(this.navOnSave) {
+            const navigateNextEvent = new FlowNavigationNextEvent();
+            this.dispatchEvent(navigateNextEvent);
         }
     }
 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
@@ -98,6 +98,7 @@
             <property name="suppressBottomBar" label="Suppress Cancel/Save Buttons during Edit Mode?" type="Boolean" default="false" role="inputOnly" description="Cancel/Save buttons will appear by default at the very bottom of the table once a field is edited.  
                 When hiding these buttons, field updates will be applied as soon as the user Tabs out or selects a different field."/>
             <property name="cb_suppressBottomBar" type="String" role="inputOnly"/>
+            <property name="navOnSave" label="Navigate to Next Flow Element on Save?" type="Boolean" default="false" role="inputOnly" description="To be used with Save Buttons during Edit Mode."/>
             <property name="tableHeight" label="Table Height" type="String" role="inputOnly" description="CSS specification for the height of the datatable (Examples: 30rem, calc(50vh - 100px)  If you leave this blank, the datatable will expand to display all records.)"/>
             <property name="tableBorder" label="Table Border" type="Boolean" default="true" role="inputOnly" description="Display a border around the datatable."/>
             <property name="cb_tableBorder" type="String" role="inputOnly"/>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.html
@@ -299,6 +299,15 @@
         checked={inputValues.cb_suppressBottomBar.value} 
         oncheckboxchanged={handleCheckboxChange}
     ></c-fsc_flow-checkbox>  
+    <lightning-input class="slds-m-vertical_xx-small"
+        disabled={isNoEdits}
+        type="checkbox" 
+        name="select_navOnSave"
+        label={inputValues.navOnSave.label} 
+        field-level-help={inputValues.navOnSave.helpText}
+        checked={inputValues.navOnSave.value} 
+        onchange={handleValueChange}>
+    </lightning-input>
     <c-fsc_flow-checkbox
         name="select_hideHeaderActions"
         label={inputValues.hideHeaderActions.label} 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
@@ -427,6 +427,8 @@ export default class ers_datatableCPE extends LightningElement {
             helpText: "Cancel/Save buttons will appear by default at the very bottom of the table once a field is edited. \n" +  
             "When hiding these buttons, field updates will be applied as soon as the user Tabs out or selects a different field."},
         cb_suppressBottomBar: {value: null, valueDataType: null, isCollection: false, label: ''},
+        navOnSave: {value: null, valueDataType: null, isCollection: false, label: 'InstantNavigation Mode on Save', 
+            helpText: "Navigate to Next Flow Element on Save. To be used with Save Buttons during Edit Mode."},
         isUserDefinedObject: {value: null, valueDataType: null, isCollection: false, label: 'Input data is Apex-Defined', 
             helpText: 'Select if you are providing a User(Apex) Defined object rather than a Salesforce SObject.'},
         cb_isUserDefinedObject: {value: null, valueDataType: null, isCollection: false, label: ''},
@@ -507,7 +509,8 @@ export default class ers_datatableCPE extends LightningElement {
                 {name: 'hideCheckboxColumn'},
                 {name: 'singleRowSelection'},
                 {name: 'matchCaseOnFilters'},
-                {name: 'suppressBottomBar'},
+                {name: 'suppressBottomBar'},                
+                {name: 'navOnSave'},
                 {name: 'hideHeaderActions'},
                 {name: 'hideClearSelectionButton'},
                 {name: 'not_suppressNameFieldLink'},
@@ -1003,6 +1006,7 @@ export default class ers_datatableCPE extends LightningElement {
                                 this.dispatchFlowValueChangeEvent('isRequired', false, 'boolean');
                                 if (this.isNoEdits) {
                                     this.inputValues.suppressBottomBar.value = false;
+                                    this.inputValues.navOnSave.value = false;
                                     this.dispatchFlowValueChangeEvent('suppressBottomBar', false, 'boolean');
                                 }
                                 break;


### PR DESCRIPTION
Adding navigation on save to next flow element.
To be used with the Save Button to commit changes using a following Update Records flow element.

Idan.