### PR TITLE
Fixing bug that threw record lock error

### DIFF
--- a/flow_screen_components/fileUploadImproved/force-app/main/default/classes/FileUploadImprovedHelper.cls
+++ b/flow_screen_components/fileUploadImproved/force-app/main/default/classes/FileUploadImprovedHelper.cls
@@ -166,7 +166,14 @@ public without sharing class FileUploadImprovedHelper{
             List<ContentDocumentLink> links = new List<ContentDocumentLink>();
             for(Input input : inputs){
                 Id recordId = input.recordId;
-                Boolean visibleToAllUsers = input.visibleToAllUsers == null ? FALSE : input.visibleToAllUsers;
+                
+                Boolean visibleToAllUsers;
+                if(input.visibleToAllUsers == null){
+                    visibleToAllUsers = FALSE;
+                } else {
+                    visibleToAllUsers = input.visibleToAllUsers;
+                }
+
                 for(Id versId : input.versIds){
                     Id docId = mapVersIdToDocId.get(versId);
                     if(mapDocIdToRecordIds.get(docId).contains(recordId)){

--- a/flow_screen_components/fileUploadImproved/force-app/main/default/classes/FileUploadImproved_Test.cls
+++ b/flow_screen_components/fileUploadImproved/force-app/main/default/classes/FileUploadImproved_Test.cls
@@ -76,7 +76,7 @@ public class FileUploadImproved_Test {
     }
 
     @isTest
-    public static void invocable_test_create_link(){
+    public static void invocable_test_create_link_visibility_specified(){
         ContentVersion cv = getCV();
         Contact con = getCon();
 
@@ -92,6 +92,24 @@ public class FileUploadImproved_Test {
         ContentDocumentLink link = [SELECT Visibility FROM ContentDocumentLink WHERE LinkedEntityId = :con.Id];
 
         system.assert(link.Visibility == 'AllUsers');
+    }
+
+    @isTest
+    public static void invocable_test_create_link_visibility_not_specified(){
+        ContentVersion cv = getCV();
+        Contact con = getCon();
+
+        FileUploadImprovedHelper.Input input = new FileUploadImprovedHelper.Input();
+        input.versIds = new List<Id>{cv.Id};
+        input.recordId = con.Id;
+
+        system.test.startTest();
+            FileUploadImprovedHelper.createContentDocumentLinkDownstream(new List<FileUploadImprovedHelper.Input>{input});
+        system.test.stopTest();
+
+        ContentDocumentLink link = [SELECT Visibility FROM ContentDocumentLink WHERE LinkedEntityId = :con.Id];
+
+        system.assert(link.Visibility == 'InternalUsers');
     }
 
     @isTest


### PR DESCRIPTION
When embedded in external website, the files HAVE to be fully chunked (ie uploaded), prior to user clicking NEXT in flow. This fix holds the lightning spinner until the Apex is done.