### PR TITLE
Encode flow params using encodeURIComponent instead encodeURI

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_screenFlow/fsc_screenFlow.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_screenFlow/fsc_screenFlow.js
@@ -58,7 +58,7 @@ export default class ScreenFlow extends LightningElement {
     // }
 
     get fullUrl() {
-        let params = (this.flowParams ? '&params=' + encodeURI(this.flowParams) : '');
+        let params = (this.flowParams ? '&params=' + encodeURIComponent(this.flowParams) : '');
         let origin = (this.url ? '&origin=' + encodeURI(this.url) : '');
         return this.url + '/apex/fsc_screenFlow?flowname=' + this.flowName +  params+origin;
     }


### PR DESCRIPTION
If params would include e.g. value containing URL character, it might not be sufficient to use encoreURI.
Assume you have to encode a param like `inputDateTime=2022-10-02T08:30:00+01:00` only encoreURIComponent will encode the '+'.