### PR TITLE
Add Safe Navigation Operator to converted sObject

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
+++ b/flow_screen_components/datatable/force-app/main/default/classes/ers_DatatableController.cls
@@ -318,7 +318,7 @@ public with sharing class ers_DatatableController {
             for (SObject so : records) {
                 SObject converted = sobjCurrencyFields.get(so.Id);
                 for (String currField : currencyFields) {
-                    if (converted.get(currField) != null) {
+                    if (converted?.get(currField) != null) {
                         so.put(currField, converted.get(currField));
                     }
                 }


### PR DESCRIPTION
In a Multi-Currency Organization, if you are using Datatable to define new records (by placing a temporary unique value in the Id field that starts with the 3-character object prefix), a null pointer exception is thrown at line 321 when attempting to access the value of the currency field from the sObject retrieved via SOQL query (which found no results). I added a Safe Navigation Operator at line 321 to ensure the "converted" variable is not null before attempting to retrieve the value of one of its properties.