### PR TITLE
Handle null value

### DIFF
--- a/flow_action_components/MultiselectMagic/force-app/main/default/classes/ManageMultiselectField.cls
+++ b/flow_action_components/MultiselectMagic/force-app/main/default/classes/ManageMultiselectField.cls
@@ -11,7 +11,7 @@ public with sharing class ManageMultiselectField {
             //verify type of specified field
             validateFieldType(curRequest);
             String fieldValue = (String)curRequest.curRecord.get(curRequest.fieldApiName);
-            List<String> selectedValueList = fieldValue.split(';');
+            List<String> selectedValueList = (fieldValue != null) ? fieldValue.split(';') : new List<String>();
             List<String> availableValuesList = getPicklistValues(curRequest.objectApiName, curRequest.fieldApiName);
             
             if (curRequest.operation != null) {


### PR DESCRIPTION
When multipicklist field has no item selected, its value is null. 
So the attempt to execute `fieldValue.split(';')` will raise an exception. If the value is null then returning an empty list makes sense.