### PR TITLE
jerrypoon - Fixed content overflowing from table when table height is set

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.html
@@ -128,34 +128,32 @@ Features:   The only required paramters are the SObject collection of records an
 
             <template if:true={isShowTable}>
                 <div style={tableHeightAttribute} class={borderClass} id="datatable">
-                    <div style={tableBorderStyle}>
-                        <c-ers_custom-lightning-datatable
-                            aria-label={tableLabel}
-                            data={mydata}
-                            columns={columns}
-                            key-field={keyField}
-                            sorted-by={sortedBy}
-                            sorted-direction={sortedDirection}
-                            max-row-selection={maxRowSelection}
-                            selected-rows={selectedRows}
-                            show-row-number-column={showRowNumbers}
-                            hide-checkbox-column={hideCheckboxColumn}
-                            suppress-bottom-bar={suppressBottomBar}
-                            onsort={updateColumnSorting}
-                            oncellchange={handleCellChange}
-                            onsave={handleSave}
-                            oncancel={cancelChanges}
-                            onheaderaction={handleHeaderAction}
-                            onrowselection={handleRowSelection}
-                            onrowaction={handleRowAction}
-                            onresize={handleResize}
-                            oncombovaluechange={handleComboValueChange}
-                        >
-                        
-                        </c-ers_custom-lightning-datatable>
-                        <div if:true={showClearButton} class="slds-m-top_x-small">
-                            <lightning-button variant="brand-outline" label={label.ClearSelectionButton} icon-name="utility:clear" onclick={handleClearSelection}></lightning-button>
-                        </div>
+                    <c-ers_custom-lightning-datatable
+                        aria-label={tableLabel}
+                        data={mydata}
+                        columns={columns}
+                        key-field={keyField}
+                        sorted-by={sortedBy}
+                        sorted-direction={sortedDirection}
+                        max-row-selection={maxRowSelection}
+                        selected-rows={selectedRows}
+                        show-row-number-column={showRowNumbers}
+                        hide-checkbox-column={hideCheckboxColumn}
+                        suppress-bottom-bar={suppressBottomBar}
+                        onsort={updateColumnSorting}
+                        oncellchange={handleCellChange}
+                        onsave={handleSave}
+                        oncancel={cancelChanges}
+                        onheaderaction={handleHeaderAction}
+                        onrowselection={handleRowSelection}
+                        onrowaction={handleRowAction}
+                        onresize={handleResize}
+                        oncombovaluechange={handleComboValueChange}
+                    >
+                    
+                    </c-ers_custom-lightning-datatable>
+                    <div if:true={showClearButton} class="slds-m-top_x-small">
+                        <lightning-button variant="brand-outline" label={label.ClearSelectionButton} icon-name="utility:clear" onclick={handleClearSelection}></lightning-button>
                     </div>
                 </div>
             </template>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -281,9 +281,6 @@ export default class Datatable extends LightningElement {
     @track isAllFilter = false;
     @track showClearButton = false;
     @track tableHeightAttribute = 'height:';
-    @track tableBorderStyle = 'border-left: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229));' 
-        +' border-top: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229));' 
-        + ' border-right: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229)); margin: -1px;';
 
     // Handle Lookup Field Variables   
     @api lookupId;
@@ -681,7 +678,8 @@ export default class Datatable extends LightningElement {
         console.log('tableHeightAttribute',this.tableHeightAttribute);
 
         // Set table border display
-        this.borderClass = (this.tableBorder == true) ? 'slds-box' : '';
+        //this.borderClass = (this.tableBorder == true) ? 'slds-box' : ''; commented out to remove padding. replaced with below
+        this.borderClass = (this.tableBorder == true) ? 'datatable-border' : '';
 
         // Add overflow if max height is not set so the combobox will spill outside the table
         this.borderClass += (this.allowOverflow) ? ' overflowEnabled' : '';

--- a/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
+++ b/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
@@ -72,3 +72,9 @@ c-datatable c-ers_custom-lightning-datatable .dt-outer-container lightning-primi
     opacity: 0.5;
     visibility: hidden;
 }
+.datatable-border {
+    border-left: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229));
+    border-top: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229));
+    border-right: var(--lwc-borderWidthThin,1px) solid var(--lwc-colorBorder,rgb(229, 229, 229));
+    margin: -1px;
+}


### PR DESCRIPTION
- Removed extra div. This was overflowing as the height is dictated by the parent div
- Moved border styling to CSS
- Removed padding by removing slds-box. This is replaced by custom styling of border from previous commits