### PR TITLE
ConvertCSVToRecords - fixes #1100 - refactor response aggregation to avoid bulk execution list size mismatch error from Flow engine

### DIFF
--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecords.cls
@@ -9,6 +9,8 @@ public with sharing class ConvertCSVToRecords {
     Response[] responseList = new List<Response>{};
 
     for (Request curInput : inputs) {
+      Response output = new Response();
+      output.convertedCSVRows = new List<SObject>{};
       if (curInput.contentDocumentId == null && curInput.contentDocumentIdList == null) {
         throw new FlowCustomException(
           'You need to provide either a single ContentDocument Id OR a list of ContentDocumentIds as inputs to this Flow action.'
@@ -25,6 +27,7 @@ public with sharing class ConvertCSVToRecords {
       SObjectType sObjType = ((SObject) Type.forName(curInput.objectApiName).newInstance()).getSObjectType();
       Map<String, SObjectField> fieldMap = sObjType.getDescribe().fields.getMap();
       for (String curContentDocumentId : curInput.contentDocumentIdList) {
+        List<SObject> curFileConvertedCSVRows = new List<SObject>();
         Blob csvBlobContent = getCsvContent(curContentDocumentId);
         String csvStringContent = blobToString(csvBlobContent, 'UTF-8');
         String fSepRepl = '~`~';
@@ -47,8 +50,6 @@ public with sharing class ConvertCSVToRecords {
           fieldName.put(field, fieldApiName);
         }
 
-        Response output = new Response();
-        output.convertedCSVRows = new List<SObject>{};
         for (String row : csvRows) {
           row = replaceNewline(row, newlineRepl);
           SObject obj = sObjType.newSObject();
@@ -77,10 +78,11 @@ public with sharing class ConvertCSVToRecords {
               obj.put(fieldName.get(fields[i]), null);
             }
           }
-          output.convertedCSVRows.add(obj);
+          curFileConvertedCSVRows.add(obj);
         }
-        responseList.add(output);
+        output.convertedCSVRows.addAll(curFileConvertedCSVRows);
       }
+      responseList.add(output);
     }
     return responseList;
   }

--- a/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
+++ b/flow_action_components/ConvertCSVToRecords/force-app/main/default/classes/ConvertCSVToRecordsTest.cls
@@ -168,26 +168,25 @@ public with sharing class ConvertCSVToRecordsTest {
     System.assertEquals('2021-01-12', String.valueOf((Date) result));
   }
 
-  @IsTest
+  @isTest
   private static void testConvertMultipleContentDocs() {
-    createData(); //Create the document once more so we have a list of contentdocument ids
-    //System.assert(false,[Select Id from ContentVersion].size());
-    ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
-    Test.startTest();
-    ConvertCSVToRecords.Response[] flowOutputs = ConvertCSVToRecords.convert(flowInputs);
-    Test.stopTest();
-    //We should get 2 responses in the output array, one for each ContentDocument Id
-    System.assertEquals(2, flowOutputs.size(), 'Expected 2 outputs from action, one for each Content Document Id');
-    for (ConvertCSVToRecords.Response flowOutput : flowOutputs) {
-      System.assert(flowOutput.convertedCSVRows.size() == 3, 'Expected 6 records but got ' + flowOutput.convertedCSVRows.size());
-      List<Account> accList = flowOutput.convertedCSVRows;
-      System.assertEquals(3, accList.size(), 'Expected 2 accounts to be parsed from csv input');
-      System.assertEquals(
-        DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES_POST_PARSE,
-        accList[1].Description,
-        'The description field with commas, newline and quotes was not parsed correctly'
-      );
-    }
+      //Create the document once more so we have a list of contentdocument ids
+      createData();
+      //System.assert(false,[Select Id from ContentVersion].size());
+      ConvertCSVToRecords.Request[] flowInputs = createFlowInputsList();
+      Test.startTest();
+      ConvertCSVToRecords.Response[] flowOutputs = ConvertCSVToRecords.convert(flowInputs);
+      Test.stopTest();
+      // we should get 1 response in the output array, to match the 1 request we put in
+      //  one input co-ordinates with one call of the invokable, not the number of ContentDocument Id's uploaded during this call
+      //  otherwise -> Error Occurred: The number of results does not match the number of interviews that were executed in a single bulk execution request.
+      System.assertEquals(1, flowOutputs.size(), 'Expected 1 outputs from action, one for each input Request');
+      for (ConvertCSVToRecords.Response flowOutput : flowOutputs) {
+          System.assert(flowOutput.convertedCSVRows.size() == 6, 'Expected 6 records but got ' + flowOutput.convertedCSVRows.size());
+          List<Account> accList = flowOutput.convertedCSVRows;
+          System.assertEquals(6, accList.size(), 'Expected 6 accounts to be parsed from combined csv input');
+          System.assertEquals(DESCRIPTION_WITH_COMMAS_NEWLINE_AND_QUOTES_POST_PARSE, accList[1].Description, 'The description field with commas, newline and quotes was not parsed correctly');
+      }
   }
 
   @IsTest


### PR DESCRIPTION
Getting Input and Output collection size mismatch errors with multiple files. Updated to pass back only one Response in the List, as that is what is passed in. Updated unit tests as well to match