### PR TITLE
Issue 1067: Compare Existing Records with Records To Insert

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecords.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecords.cls
@@ -3,7 +3,7 @@
 * 						Specify the Ids you want to compare for each sObject and the action will take care of the rest.
 * @Author             : Adam White
 * @Last Modified By   : adamwhiteuva@gmail.com
-* @Last Modified On   : 1/26/2021 
+* @Last Modified On   : 4/14/2022 
 * @Modification Log   : 
 * Ver      Date            Author      		      		  Modification
 * 1.0      1/26/2021      adamwhiteuva@gmail.com      Initial release
@@ -44,17 +44,17 @@ global without sharing class FindCommonAndUniqueRecords {
                     if(!targetRecordCollection.isEmpty() && !sourceRecordCollection.isEmpty()){
                         //puts the source collection into a map so we can compare with the target collection map
                         Map<String, Sobject> sourceMap = new Map<String, Sobject>();
-                        string objectType = string.valueOf(sourceRecordCollection[0].Id.getSObjectType());
-                        string targetObjectType = string.valueOf(targetRecordCollection[0].Id.getSObjectType());
+                        string objectType = string.valueOf(sourceRecordCollection[0].getSObjectType());
+                        string targetObjectType = string.valueOf(targetRecordCollection[0].getSObjectType());
                         
                         if(!sobjectTypeMap.containsKey(objectType)){
-                            Schema.SObjectType s = sourceRecordCollection[0].Id.getSObjectType();
+                            Schema.SObjectType s = sourceRecordCollection[0].getSObjectType();
                             Map<String, SObjectField> sourceFieldMap = s.getDescribe().fields.getMap();
                             sobjectTypeMap.put(string.valueOf(s), sourceFieldMap);
                         }
                         
                         if(!sobjectTypeMap.containsKey(targetObjectType)){
-                            Schema.SObjectType s = targetRecordCollection[0].Id.getSObjectType();
+                            Schema.SObjectType s = targetRecordCollection[0].getSObjectType();
                             Map<String, SObjectField> sourceFieldMap = s.getDescribe().fields.getMap();
                             sobjectTypeMap.put(string.valueOf(s), sourceFieldMap);
                         }

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecordsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecordsTest.cls
@@ -66,7 +66,7 @@ public class FindCommonAndUniqueRecordsTest {
     @IsTest
     static void testEmptyCollection() {
         List<Account> accountsInSource = [Select Id from Account];
-        List<Contact> contactsInTarget = [Select Id,AccountId from Contact WHERE FirstName = 'Darth'];
+        List<Contact> contactsInTarget = [Select Id,AccountId,Name from Contact WHERE FirstName = 'Darth'];
         
         List<FindCommonAndUniqueRecords.Request> flowRequests = new List<FindCommonAndUniqueRecords.Request>();
         FindCommonAndUniqueRecords.Request flowRequest = new FindCommonAndUniqueRecords.Request();
@@ -80,5 +80,59 @@ public class FindCommonAndUniqueRecordsTest {
         Test.stopTest();
         System.assertEquals(3, results[0].sourceUniqueRecordCollection.size(), 'sourceUnique failed');
         System.assertEquals(0, results[0].sourceCommonRecordCollection.size(), 'sourceCommon failed');
+    }
+    
+    // Test created to specifically check against records that do not currently have record ids
+    // Target Unique can then be inserted by admins to avoid errors
+    // See github issue 1067
+    @IsTest
+    static void testUserWithoutPermissionSetAssignments() {
+        List<PermissionSetAssignment> psaList = new List<PermissionSetAssignment>();
+        
+        User u = new User();
+        u.FirstName = 'Fry';
+        u.LastName = 'McAllistor';
+        u.Alias = '12345F';
+        u.Email = 'frymcallistor@testingflows.com.fake';
+        u.Username = 'frymcallistor@testingflows.com.fake';
+        u.ProfileId = [SELECT Id FROM Profile WHERE Name = 'Standard User'][0].Id;
+        u.TimeZoneSidKey = 'America/Chicago';
+        u.LocaleSidKey = 'en_US';
+        u.EmailEncodingKey = 'ISO-8859-1';
+        u.LanguageLocaleKey = 'en_US';
+        insert u;
+        
+        PermissionSet p1 = new PermissionSet();
+        p1.Name = 'Testing_Has_Permission_Set';
+        p1.Label = 'Testing Has Permission Set';
+        
+        PermissionSet p2 = new PermissionSet();
+        p2.Name = 'Testing_Does_Not_Have_Permission_Set';
+        p2.Label = 'Testing Does Not Have Permission Set';
+        insert new List<PermissionSet>{p1, p2};
+        
+        PermissionSetAssignment psa1 = new PermissionSetAssignment();
+        psa1.PermissionSetId = p1.Id;
+        psa1.AssigneeId = u.Id;
+        insert psa1;
+        psaList.add(psa1);
+
+		PermissionSetAssignment psa2 = new PermissionSetAssignment();
+        psa2.PermissionSetId = p2.Id;
+        psa2.AssigneeId = u.Id;
+        psaList.add(psa2);
+        
+        List<FindCommonAndUniqueRecords.Request> flowRequests = new List<FindCommonAndUniqueRecords.Request>();
+        FindCommonAndUniqueRecords.Request flowRequest = new FindCommonAndUniqueRecords.Request();
+        flowRequest.sourceRecordCollection = [SELECT Id, PermissionSetId FROM PermissionSetAssignment WHERE AssigneeId = :u.Id];
+        flowRequest.targetRecordCollection = psaList;
+        flowRequest.sourceUniqueID = 'PermissionSetId';
+        flowRequest.targetUniqueID = 'PermissionSetId';
+        flowRequests.add(flowRequest);
+        Test.startTest();
+        List<FindCommonAndUniqueRecords.Result> results = FindCommonAndUniqueRecords.compareRecords(flowRequests);
+        Test.stopTest();
+        System.assertEquals(1, results[0].targetUniqueRecordCollection.size(), 'targetUnique failed');
+        System.assertEquals(1, results[0].targetCommonRecordCollection.size(), 'targetCommon failed');
     }
 }


### PR DESCRIPTION
Updates Code to not require records. to have ids in order to perform comparison.
[See Issue 1067](https://github.com/alexed1/LightningFlowComponents/issues/1067#issuecomment-1092298132)