### PR TITLE
Screen Flow Components - Refresh View and Navigate to Next

### DIFF
--- a/flow_action_components/RefreshView/.forceignore
+++ b/flow_action_components/RefreshView/.forceignore
@@ -1,0 +1,3 @@
+# List files or directories below to ignore them when running force:source:push, force:source:pull, and force:source:status
+# More information: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_exclude_source.htm
+#

--- a/flow_action_components/RefreshView/README.md
+++ b/flow_action_components/RefreshView/README.md
@@ -1,0 +1,21 @@
+# Refresh View
+
+## Use Case
+
+When a flow makes changes to record fields, you want your users to see those changes without them having to reload the browser page manually.
+
+## How to install
+
+Deploy to an org using:
+
+```
+sfdx force:source:deploy -p flow_action_components/RefreshView/force-app/main/default/aura/refreshView
+```
+
+## How to use
+
+Simply add this invocable action at the end of your flow to refresh the view. This is especially useful in screen flows after your last screen.
+
+## How it works
+
+This invocable action uses the `force:refreshView` event to reload the current view automatically. Refer to the [Salesforce Developer Documentation](https://developer.salesforce.com/docs/component-library/bundle/force:refreshView/documentation) for the techincal details

--- a/flow_action_components/RefreshView/config/project-scratch-def.json
+++ b/flow_action_components/RefreshView/config/project-scratch-def.json
@@ -1,0 +1,9 @@
+{
+  "orgName": "Demo Company",
+  "edition": "Developer",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    }
+  }
+}

--- a/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.cmp
+++ b/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.cmp
@@ -1,0 +1,2 @@
+<aura:component implements="lightning:availableForFlowActions,force:hasRecordId">
+</aura:component>

--- a/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.cmp-meta.xml
+++ b/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.cmp-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>53.0</apiVersion>
+    <description>DESCRIPTION</description>
+</AuraDefinitionBundle>

--- a/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.design
+++ b/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshView.design
@@ -1,0 +1,11 @@
+<!--
+
+ Copyright (c) 2018, salesforce.com, inc.
+ All rights reserved.
+
+ Licensed under the BSD 3-Clause license.
+ For full license text, see LICENSE.txt file in the repo root  or https://opensource.org/licenses/BSD-3-Clause
+
+-->
+<design:component >
+</design:component>

--- a/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshViewController.js
+++ b/flow_action_components/RefreshView/force-app/main/default/aura/refreshView/refreshViewController.js
@@ -1,0 +1,11 @@
+// Modelled after 
+// https://developer.salesforce.com/docs/component-library/bundle/force:refreshView/documentation
+
+({
+    invoke : function(component, event, helper) {        
+        return new Promise(function(resolve, reject) {
+            $A.get("e.force:refreshView").fire();
+            resolve();
+        });
+    }
+})

--- a/flow_action_components/RefreshView/sfdx-project.json
+++ b/flow_action_components/RefreshView/sfdx-project.json
@@ -1,0 +1,18 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true,
+      "package": "Refresh View",
+      "versionName": "Basic",
+      "versionNumber": "1.0.0.NEXT"
+    }
+  ],
+  "name": "Refresh View",
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "53.0",
+  "packageAliases": {
+    "Refresh View": "0Ho8d000000wk4FCAQ"
+  }
+}

--- a/flow_screen_components/navigateToNext/.forceignore
+++ b/flow_screen_components/navigateToNext/.forceignore
@@ -1,0 +1,3 @@
+# List files or directories below to ignore them when running force:source:push, force:source:pull, and force:source:status
+# More information: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_exclude_source.htm
+#

--- a/flow_screen_components/navigateToNext/README.md
+++ b/flow_screen_components/navigateToNext/README.md
@@ -1,0 +1,21 @@
+# Navigate to Next
+
+## Use Case
+
+When users finish running a screen flow, you want to automatically close the modal without your users having to click the `Next` button.
+
+## How to install
+
+Deploy to an org using:
+
+```
+sfdx force:source:deploy -p flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext
+```
+
+## How to use
+
+Simply add this component in a blank screen at the end of your flow.
+
+## How it works
+
+This component uses the `component.get("v.navigateFlow")` to get the navigation controller, and sets it to `navigate("NEXT")` to advance to the next screen. Refer to the [Salesforce Developer Documentation](https://developer.salesforce.com/docs/component-library/bundle/force:refreshView/documentation) for the techincal details

--- a/flow_screen_components/navigateToNext/README.md
+++ b/flow_screen_components/navigateToNext/README.md
@@ -18,4 +18,4 @@ Simply add this component in a blank screen at the end of your flow.
 
 ## How it works
 
-This component uses the `component.get("v.navigateFlow")` to get the navigation controller, and sets it to `navigate("NEXT")` to advance to the next screen. Refer to the [Salesforce Developer Documentation](https://developer.salesforce.com/docs/component-library/bundle/force:refreshView/documentation) for the techincal details
+This component uses the `component.get("v.navigateFlow")` to get the navigation controller, and sets it to `navigate("NEXT")` to advance to the next screen. Refer to the [Salesforce Developer Documentation](https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning/components_config_for_flow_screens_navigate_custom.htm) for the techincal details

--- a/flow_screen_components/navigateToNext/config/project-scratch-def.json
+++ b/flow_screen_components/navigateToNext/config/project-scratch-def.json
@@ -1,0 +1,9 @@
+{
+  "orgName": "Demo Company",
+  "edition": "Developer",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    }
+  }
+}

--- a/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.cmp
+++ b/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.cmp
@@ -1,0 +1,3 @@
+<aura:component implements="lightning:availableForFlowScreens,force:hasRecordId">
+    <aura:handler name="init" value="{!this}" action="{!c.doInit}"/>
+</aura:component>

--- a/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.design
+++ b/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.design
@@ -1,0 +1,1 @@
+<design:component> </design:component>

--- a/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.js
+++ b/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.js
@@ -1,0 +1,11 @@
+// Modelled after 
+// https://developer.salesforce.com/docs/component-library/bundle/force:closeQuickAction/documentation
+
+({
+    doInit: function(component, event, helper) {
+        // Close the action panel
+        var navigate = component.get("v.navigateFlow");
+        navigate("NEXT");
+    }
+
+})

--- a/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.js
+++ b/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.js
@@ -1,11 +1,10 @@
-// Modelled after 
-// https://developer.salesforce.com/docs/component-library/bundle/force:closeQuickAction/documentation
+// Modelled after
+// https://developer.salesforce.com/docs/atlas.en-us.lightning.meta/lightning/components_config_for_flow_screens_navigate_custom.htm
 
 ({
-    doInit: function(component, event, helper) {
-        // Close the action panel
-        var navigate = component.get("v.navigateFlow");
-        navigate("NEXT");
-    }
-
-})
+  doInit: function (component, event, helper) {
+    // Close the action panel
+    var navigate = component.get("v.navigateFlow");
+    navigate("NEXT");
+  },
+});

--- a/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.xml
+++ b/flow_screen_components/navigateToNext/force-app/main/default/aura/navigateToNext/navigateToNext.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AuraDefinitionBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>53.0</apiVersion>
+    <description>Automatically navigates to next screen</description>
+</AuraDefinitionBundle>

--- a/flow_screen_components/navigateToNext/sfdx-project.json
+++ b/flow_screen_components/navigateToNext/sfdx-project.json
@@ -1,0 +1,11 @@
+{
+  "packageDirectories": [
+    {
+      "path": "force-app",
+      "default": true
+    }
+  ],
+  "namespace": "",
+  "sfdcLoginUrl": "https://login.salesforce.com",
+  "sourceApiVersion": "53.0"
+}


### PR DESCRIPTION
Users may use a Quick Action on a record page that calls a **screen flow that performs tasks that don't require user intervention** (e.g. edit fields or create related records). Without these components, the user has to close the modal (by clicking next, or with the X) and refresh the browser to see the update.

- The "Navigate to Next" screen component automatically "finishes" the flow and closes the modal.
- The "Refresh View" updates the current view without reloading the browser window.

You can get details of the use case and reference material in the readme file of each component. 
Below is an example of how to combine the two with the Show Toast in a screen flow.

<img width="551" alt="FlowActions_Example" src="https://user-images.githubusercontent.com/12436381/169067857-cabfefb9-a076-4123-adbe-0735f788f664.png">