### PR TITLE
Padding fix

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -2,7 +2,7 @@ import { api, track, LightningElement } from 'lwc';
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.34';
+    versionNumber = '2.35';
     staticChoicesModalClass = 'staticChoicesModal';
     _builderContext;
     _values;

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -125,7 +125,7 @@ Additional components packaged with this LWC:
 
             <!-- Display Radio Buttons -->
             <template if:true={showRadio}>
-                <div style={inputStyle}>
+                <div style={inputStyle} class={inputClass}>
                     <lightning-radio-group 
                         name={radioGroup} 
                         label={masterLabel} 
@@ -140,7 +140,7 @@ Additional components packaged with this LWC:
 
             <!-- Display Picklist -->
             <template if:false={showRadio}>
-                <div style={inputStyle}>
+                <div style={inputStyle} class={inputClass}>
                     <lightning-combobox 
                         name={masterLabel} 
                         label={masterLabel} 

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -18,6 +18,9 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+5/28/22 -   Eric Smith -    Version 2.35  
+                            Changed bottom padding to match standard flow screen input components
+
 11/20/21 -  Eric Smith -    Version 2.34  
                             Added Controlling Field Value attribute for dependent picklists (Best with Reactive Screens)
 

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -8,6 +8,8 @@ import Quickchoice_Images from '@salesforce/resourceUrl/fsc_Quickchoice_Images';
 
 export default class QuickChoiceFSC extends LightningElement {
 
+    bottomPadding = 'slds-p-bottom_small';
+
     @api
     availableActions = [];
 
@@ -253,7 +255,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get gridClass() {
-        return this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center' : 'slds-form-element__control';
+        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center' : 'slds-form-element__control') + this.bottomPadding;
     }
 
     get gridStyle() {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -8,7 +8,7 @@ import Quickchoice_Images from '@salesforce/resourceUrl/fsc_Quickchoice_Images';
 
 export default class QuickChoiceFSC extends LightningElement {
 
-    bottomPadding = 'slds-p-bottom_small';
+    bottomPadding = 'slds-p-bottom_x-small';
 
     @api
     availableActions = [];
@@ -255,7 +255,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get gridClass() {
-        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center' : 'slds-form-element__control') + this.bottomPadding;
+        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center ' : 'slds-form-element__control ') + this.bottomPadding;
     }
 
     get gridStyle() {
@@ -438,7 +438,10 @@ export default class QuickChoiceFSC extends LightningElement {
             return 'max-width: ' + this.style_width + 'px';
         }
         return ''
+    }
 
+    get inputClass() {
+        return this.bottomPadding;
     }
 
 }

--- a/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.cmp
+++ b/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.cmp
@@ -25,20 +25,22 @@
 	<!-- 99% of the awesomesauce in this component comes from this LightningLookup component, created by
 		John Pipkin and Opfocus https://opfocus.com/lightning-lookup-input-field-2/ -->
 
-	<lightning:layout multipleRows="true">
-		<lightning:layoutItem size="12">
-			<label class="slds-form-element__label">
-				<abbr class="{!v.required ? 'slds-required' : 'slds-hide'}" title="required">*</abbr>
-				{!v.label}</label>
-		</lightning:layoutItem>
+	<div class="slds-p-bottom_x-small">
+		<lightning:layout multipleRows="true">
+			<lightning:layoutItem size="12">
+				<label class="slds-form-element__label">
+					<abbr class="{!v.required ? 'slds-required' : 'slds-hide'}" title="required">*</abbr>
+					{!v.label}</label>
+			</lightning:layoutItem>
 
-		<lightning:layoutItem size="12">
-			<c:QuickLightningLookup sObjectName="{!v.objectName}" displayedFieldName="{!v.displayFieldName}" searchFieldName="{!v.searchFieldName}"
-				whereClause="{!v.whereClause}" valueFieldName="{!v.valueFieldName}" label="{!v.label}"
-				selectedValue="{!v.selectedValue}" filteredFieldName="{!v.filterFieldName}"
-				filterFieldValue="{!v.filterFieldValue}" parentChild="{!v.parentChild}" required="{!v.required}"
-				defaultValue="{!v.defaultValue}" parentId="{!v.parentId}" cmpId="{!v.cmpid}" performLookupOnFocus="true"
-				svg="{!v.svg}" />
-		</lightning:layoutItem>
-	</lightning:layout>
+			<lightning:layoutItem size="12">
+				<c:QuickLightningLookup sObjectName="{!v.objectName}" displayedFieldName="{!v.displayFieldName}" searchFieldName="{!v.searchFieldName}"
+					whereClause="{!v.whereClause}" valueFieldName="{!v.valueFieldName}" label="{!v.label}"
+					selectedValue="{!v.selectedValue}" filteredFieldName="{!v.filterFieldName}"
+					filterFieldValue="{!v.filterFieldValue}" parentChild="{!v.parentChild}" required="{!v.required}"
+					defaultValue="{!v.defaultValue}" parentId="{!v.parentId}" cmpId="{!v.cmpid}" performLookupOnFocus="true"
+					svg="{!v.svg}" />
+			</lightning:layoutItem>
+		</lightning:layout>
+	</div>
 </aura:component>


### PR DESCRIPTION
@alexed1 These changes add a bottom padding of x-small to both the QuickChoice and the QuickLookup components.  With this change, their spacing on Flow Screens will now match that of the standard input components.

This will require a new package for the FlowScreenComponentsBasePack for QuickChoice.

This will require a new package for QuickLookup.