### PR TITLE
Version upgraded to handle NetZero Cloud objects

### DIFF
--- a/flow_screen_components/quickLookup/force-app/main/default/classes/QuickLightningLookupController.cls-meta.xml
+++ b/flow_screen_components/quickLookup/force-app/main/default/classes/QuickLightningLookupController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_screen_components/quickLookup/force-app/main/default/classes/QuickLightningLookupControllerTest.cls-meta.xml
+++ b/flow_screen_components/quickLookup/force-app/main/default/classes/QuickLightningLookupControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
The quickLookup component was throwing the following error if used on "Stationary Asset Environmental Source" (NetZero Cloud object)

![image](https://user-images.githubusercontent.com/12510531/175011308-feb2e42b-5655-4add-93e7-de53307e7510.png)

with the newer Apex class API version everything works fine.