### PR TITLE
Update fsc_screenFlow.js

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_screenFlow/fsc_screenFlow.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_screenFlow/fsc_screenFlow.js
@@ -31,7 +31,7 @@ export default class ScreenFlow extends LightningElement {
             this.saveParams = event.data.flowParams;
             this.dispatchEvent(moveEvt);
         });
-        let sfIdent = 'force.com';
+        let sfIdent = '.com'; //in a previous version this was set to force.com by doing so it breaks on experience cloud where enhanced domain is enabled
         this.url = window.location.href.substring(0, window.location.href.indexOf(sfIdent) + sfIdent.length);
     }
 


### PR DESCRIPTION
Fixes issue for orgs with enhanced domain enabled where url for flow was returning as null due to looking for force.com in url so it wasn't working in vf page, experience site, or if on an external site.