### PR TITLE
Updated API Version of ExecuteSOQL class

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls-meta.xml
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/classes/ExecuteSOQL.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>55.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Added update to api version 55 to allow for new fields to be leveraged in the executeSOQL flow action. An example of some fields that became available in API v 52+
Opportunity.LastStageChangeDate
Opportunity.LastStageChangeInDays
Opportunity.AgeInDays
Opportunity.LastActivityInDays