### PR TITLE
Allow Dual Column Overflow Text

### DIFF
--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,3 +1,3 @@
 {
-  "target-org": "lexhost"
+  "target-org": "pandaDoc"
 }

--- a/.sf/config.json
+++ b/.sf/config.json
@@ -1,3 +1,3 @@
 {
-  "target-org": "pandaDoc"
+  "target-org": "lexhost"
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
@@ -4,3 +4,7 @@
     margin-left: 0;
     margin-top: 1rem;
 }
+
+.wrapped-content{
+    overflow-wrap: break-word;
+}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
@@ -8,3 +8,4 @@
 .wrapped-content{
     overflow-wrap: break-word;
 }
+

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -94,7 +94,7 @@ Additional components packaged with this LWC:
                                         <div
                                             class="slds-media__body slds-border_left slds-p-left_small slds-p-top_xxx-small">
                                             <span class="slds-text-heading_medium slds-m-bottom_x-small">{item.name}</span>
-                                            <span class="slds-text-title">{item.description}</span>
+                                            <span class="slds-text-title wrapped-content">{item.description}</span>
                                         </div>
                                     </span>
                                 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -81,7 +81,7 @@ Additional components packaged with this LWC:
                                 <!-- Display Visual Card Pickers with Icons-->
                                 <template if:true={includeIcons}>
                                     <span
-                                        class="slds-visual-picker__figure slds-visual-picker__text class=slds-box slds-box_link slds-box_x-small slds-media"
+                                        class="slds-visual-picker__figure slds-visual-picker__text slds-box slds-box_link slds-box_x-small slds-media"
                                         style={cardSize}>
                                         <div
                                             class="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center slds-m-left_xx-small">

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -255,11 +255,11 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get gridClass() {
-        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center ' : 'slds-form-element__control ') + this.bottomPadding;
+        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center slds-grid_vertical-stretch ' : 'slds-form-element__control ') + this.bottomPadding;
     }
 
     get gridStyle() {
-        //return this.dualColumns ? 'width:52rem' : '';
+        return this.dualColumns ? 'width: auto' : '';
     }
 
     get columnClass() {
@@ -267,9 +267,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get cardSize() {
-        //return (this.dualColumns || !this.isResponsive) ? 'width:25rem' : 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
-        return 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
-
+        return (this.dualColumns || !this.isResponsive) ? 'min-height: calc(25vh - 8rem); width: auto !important' : 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
     }
 
     get responsiveSize() {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -259,7 +259,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get gridStyle() {
-        return this.dualColumns ? 'width:52rem' : '';
+        //return this.dualColumns ? 'width:52rem' : '';
     }
 
     get columnClass() {
@@ -267,7 +267,9 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get cardSize() {
-        return (this.dualColumns || !this.isResponsive) ? 'width:25rem' : 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
+        //return (this.dualColumns || !this.isResponsive) ? 'width:25rem' : 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
+        return 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
+
     }
 
     get responsiveSize() {


### PR DESCRIPTION
These changes a standardized height so all of the cards look the same when loading. This also fixes the issue where when you choose two columns the text-overflow wasn't enforced. 

What the new view will look like.

<img width="1107" alt="Screen Shot 2022-08-16 at 15 16 49" src="https://user-images.githubusercontent.com/22582720/184977182-0401c4af-241c-4cc0-acd0-779e45d04d1a.png">
