### PR TITLE
Added Test Class for Apex Class: Resolve Approval Requests

### DIFF
--- a/flow_action_components/ApprovalProcessActions/force-app/main/default/classes/ResolveApprovalRequest.cls
+++ b/flow_action_components/ApprovalProcessActions/force-app/main/default/classes/ResolveApprovalRequest.cls
@@ -15,9 +15,12 @@ public with sharing class ResolveApprovalRequest {
             
             approvalWorkItem.setWorkitemId(approverId);
             
+            system.debug('approvalWorkItem ' + approvalWorkItem);
+            
             // Submit the request for approval
-            Approval.ProcessResult approvalResult =  Approval.process(approvalWorkItem);
+            Approval.ProcessResult[] approvalResult =  Approval.process(approvalWorkItem);
 
+            system.debug('ApprovalResult ' + approvalResult);
             
             // Verify the results
             System.assert(approvalResult.isSuccess(), 'Result Status:'+ approvalResult.isSuccess());

--- a/flow_action_components/ApprovalProcessActions/force-app/main/default/classes/ResolveApprovalRequestsTest.cls
+++ b/flow_action_components/ApprovalProcessActions/force-app/main/default/classes/ResolveApprovalRequestsTest.cls
@@ -1,0 +1,36 @@
+@isTest
+public with sharing class ResolveApprovalRequestsTest {
+    // Create New Request and Test Error Response
+    @isTest(SeeAllData=true)
+    public static void executeTest() {
+        // Get Current User Id
+        String userId = UserInfo.getUserId();
+
+        // Find Acme (Sample) Account
+        Account a = [SELECT Id FROM Account WHERE Name = 'Acme (Sample)'];
+
+        // Find Process Definition
+        ProcessDefinition pd = [SELECT Id FROM ProcessDefinition WHERE DeveloperName = 'Test_Process_Definition'];
+
+        // Find New Process Instance
+        ProcessInstance pi = [SELECT Id FROM ProcessInstance WHERE ProcessDefinitionId = :pd.Id LIMIT 1];
+
+        // Create Request Object
+        List<ResolveApprovalRequest.Requests> requests = new List<ResolveApprovalRequest.Requests>();
+        ResolveApprovalRequest.Requests req = new ResolveApprovalRequest.Requests();
+        req.action = 'Approve';
+        req.comments = 'Test Comments';
+        req.recordId = a.Id;
+        req.objName = 'Account';
+        req.nextApproverIds = new List<String>{userId};
+
+        // Add req to requests
+        requests.add(req);
+
+        // Run Test
+        Test.startTest();
+        //ResolveApprovalRequest r = new ResolveApprovalRequest();
+        ResolveApprovalRequest.execute(requests);
+        Test.stopTest();
+    }
+}

--- a/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/jsconfig.json
+++ b/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/jsconfig.json
@@ -4,7 +4,8 @@
     },
     "include": [
         "**/*",
-        "../../../../.sfdx/typings/lwc/**/*.d.ts"
+        "../../../../.sfdx/typings/lwc/**/*.d.ts",
+        "../../../../../../.sfdx/typings/lwc/**/*.d.ts"
     ],
     "paths": {
         "c/*": [


### PR DESCRIPTION
This test class will help pass the Resolve Approval Requests to production. Unfortunately, a lot of hard coding had to be done as Process Instances, and Process Definitions can not have a DML insert function. 

When using this test class, you will need to create the following:

- An Account with the name "Acme (Sample)."
- An Approval Process on the Account object with a Developer Name "Test_Process_Definition."
- Activate the Approval Process
- Submit for Approval the Acme (Sample) account. Leave it as pending, as that is what the code looks for.

If you want, you could make these changes within the test class to fit your orgs' test records, but this will need to be done for this class to run. You then will get a 93% code coverage.