### PR TITLE
fixed tick box when selecting a visual choice box

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.css
@@ -11,4 +11,5 @@
 
 .paddingFix {
     padding-right: 0rem !important;
+    
 }


### PR DESCRIPTION
This fixes an issue when you select a QuickChoice Visual Box the tick that is put around the box doesn't line up with what was selected. This was a bug that was introduced when I made the changes to make dual columns dynamic sized.

Before:
<img width="120" alt="tick-before" src="https://user-images.githubusercontent.com/22582720/190525059-3162058c-1db3-46ba-8d49-83da0f99aa38.png">


After:
<img width="88" alt="tick-after" src="https://user-images.githubusercontent.com/22582720/190525066-72a7a335-da81-4a16-89f3-563d1310fe1b.png">
