### PR TITLE
removed default value as this would cause an issue when a user clicks…

### DIFF
--- a/flow_screen_components/lightningInputFSC/force-app/main/default/aura/lightingInputFSC/lightingInputFSC.cmp
+++ b/flow_screen_components/lightningInputFSC/force-app/main/default/aura/lightingInputFSC/lightingInputFSC.cmp
@@ -4,7 +4,7 @@
   <!--All types-->
   <aura:attribute name="type" type="String" required="true" default="text" />
   <aura:attribute name="label" type="String" required="true" default="Label" />
-  <aura:attribute name="value" type="String" default='' />
+  <aura:attribute name="value" type="String" />
   <aura:attribute name="class" type="String" />
   <aura:attribute name="name" type="String" />
   <aura:attribute name="readonly" type="String" />


### PR DESCRIPTION
… previous button.

We have to remove the default value because when using a variable to define the value field, Flow doesn't understand what that data type is only when a user selects the previous button on a screen. On initial load, the screen and component load fine, but after navigating off that screen and navigating back to the screen, the error populate. 

This resolves issue
#1223 