### PR TITLE
Update ers_datatableCPE.js to fix Close Col Config Wizard Error

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
@@ -218,12 +218,20 @@ export default class ers_datatableCPE extends LightningElement {
 
     @api
     get isDisableNavigateNext() {
-        return (this.isNoEdits || this.inputValues.suppressBottomBar.value);
+        return this.isNoEdits || this.inputValues.suppressBottomBar.value;
+    }
+    //please follow https://github.com/alexed1/LightningFlowComponents/commit/9222af0e75760f3da325173cd3cc01d3aa878db3
+    set isDisableNavigateNext(value) {
+        this.inputValues.suppressBottomBar.value = value;
     }
 
     @api
     get isDisableSuppressBottomBar() {
-        return (this.isNoEdits || this.inputValues.navigateNextOnSave.value);
+        return this.isNoEdits || this.inputValues.navigateNextOnSave.value;
+    }
+    //please follow https://github.com/alexed1/LightningFlowComponents/commit/9222af0e75760f3da325173cd3cc01d3aa878db3
+    set isDisableSuppressBottomBar(value) {
+        this.inputValues.navigateNextOnSave.value = value;
     }
 
     @api


### PR DESCRIPTION
The setters that where removed by the following commit `https://github.com/alexed1/LightningFlowComponents/commit/9222af0e75760f3da325173cd3cc01d3aa878db3` cause a regression but totally removing the setters causes the following error to appear when closing the column configuration wizard.
```
If you're working on a screen component, check your component configuration for invalid values.
Uncaught Error: Invalid attempt to set a new value for property isDisableSuppressBottomBar of [object:vm ers_datatableCPE (2977)] that does not has a setter decorated with @api. throws at https://unogasenergiaspa--devmerge.sandbox.lightning.force.com/auraFW/javascript/5FtqNRNwJDpZNZFKfXyAmg/aura_proddebug.js:10781:11
```

this commit aims to solve both errors.