### PR TITLE
Quick choice 2.36

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -2,7 +2,7 @@ import { api, track, LightningElement } from 'lwc';
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.35';
+    versionNumber = '2.36';
     staticChoicesModalClass = 'staticChoicesModal';
     _builderContext;
     _values;

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -17,6 +17,9 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObject
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
+                                                
+10/12/22 -  Eric Smith -    Version 2.36  
+                            Fixed backwards compatability bug from 2.34 when no controlling value attribute is provided for a controlled picklist field
 
 5/28/22 -   Eric Smith -    Version 2.35  
                             Changed bottom padding to match standard flow screen input components

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -127,8 +127,8 @@ export default class QuickChoiceFSC extends LightningElement {
 
     @api 
     get showPicklist() {
-        // show if not controlled or if controlled (that there is a value for the controlling field & there are available picklist values based on the controlling field value) 
-        return (!this._isControlled || (this._controllingPicklistValue != null && this._picklistOptions.length > 0));
+        // Show if not controlled or if controlled that there are available picklist values
+        return (!this._isControlled || this._picklistOptions.length > 0);
     }
 
     set showPicklist(value) {
@@ -204,9 +204,10 @@ export default class QuickChoiceFSC extends LightningElement {
             if (this.allowNoneToBeChosen)
                 this._picklistOptions.push({label: "--None--", value: "None"});
 
+            // Set isControlled only if a controlling value was provided and there are available controller values
             this._isControlled = false;
             let controllingIndex;
-            if (Object.keys(data.controllerValues).length > 0) {
+            if (!!this._controllingPicklistValue && Object.keys(data.controllerValues).length > 0) {
                 this._isControlled = true;
                 controllingIndex = data.controllerValues[this._controllingPicklistValue];
             }


### PR DESCRIPTION
This patch enables backwards compatability after v2.34 introduced a new controlling value attribute.  Before this fix, QuickChoice would not display for a dependent picklist field if no controlling value was provided.

This will require a new version of the FlowScreenComponentsBasePack