### PR TITLE
Add output to flowAutoNavigate

### DIFF
--- a/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js
+++ b/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js
@@ -8,9 +8,11 @@ export default class flowAutoNavigate extends LightningElement {
     @api showReset;
     @api timerLabel;
     @api availableActions = [];
+    @api triggered = false;
+    //set triggered to true if we auto navigated
 
     timeIntervalInstance;
-    totalMilliseconds = 0;
+    totalMilliseconds = 0;;
 
     connectedCallback() {
         var parentThis = this;
@@ -31,23 +33,27 @@ export default class flowAutoNavigate extends LightningElement {
             parentThis.totalMilliseconds += 100;
         }, 100);
 
-
+ 
 
     }
 
     renderedCallback() {
         var parentThis = this;
+        
         // Navigate to the next step in the flow either next action or finish
         if (parentThis.timeVal === parentThis.maxTime) {
             if (parentThis.availableActions.find(action => action === 'NEXT')) {
                 const navigateNextEvent = new FlowNavigationNextEvent();
                 parentThis.dispatchEvent(navigateNextEvent);
                 console.log("navigate next");
+
             } else if (parentThis.availableActions.find(action => action === 'FINISH')) {
                 const navigateFinishEvent = new FlowNavigationFinishEvent();
                 parentThis.dispatchEvent(navigateFinishEvent);
                 console.log("navigate finish");
             }
+           //set triggered to true if we auto navigated
+           parentThis.triggered = true;
         }
 
 

--- a/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js
+++ b/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js
@@ -12,7 +12,7 @@ export default class flowAutoNavigate extends LightningElement {
     //set triggered to true if we auto navigated
 
     timeIntervalInstance;
-    totalMilliseconds = 0;;
+    totalMilliseconds = 0;
 
     connectedCallback() {
         var parentThis = this;
@@ -33,7 +33,6 @@ export default class flowAutoNavigate extends LightningElement {
             parentThis.totalMilliseconds += 100;
         }, 100);
 
- 
 
     }
 

--- a/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js-meta.xml
+++ b/flow_screen_components/flowAutoNavigate/force-app/main/default/lwc/flowAutoNavigate/flowAutoNavigate.js-meta.xml
@@ -7,10 +7,12 @@
     </targets>
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen" category="Input">
-            <property name="maxTime" label="Maximum Time" type="String" default="0:1:30:0" role="inputOnly" description="This is the maximum time before the flow auto advances the format should be 'H:M:S:MS'" />
+            <property name="maxTime" label="Maximum Time" type="String" default="0:1:5:0" role="inputOnly" description="This is the maximum time before the flow auto advances the format should be 'H:M:S:MS'" />
             <property name="showTimer" label="Show Timer" type="Boolean" default="false" role="inputOnly" description="When marked as true this displays the timer on the screen" />
             <property name="showReset" label="Show Timer Reset" type="Boolean" default="false" role="inputOnly" description="When marked as true this displays a timer reset on the screen" />
             <property name="timerLabel" label="Message to Users" type="String" role="inputOnly" description="Display a message to users about the timer" />
-        </targetConfig>
+            <!--Output to indicate the auto navigate component triggered-->
+            <property name="triggered" type="Boolean" role="outputOnly" /> 
+            </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
Add a boolean output (triggered) that indicates if the timer expired and the screen advanced.   