### PR TITLE
Knowledge tree continuation and end functions

### DIFF
--- a/flow_apps/KnowledgeTree/force-app/main/default/flows/Twenty_Questions_Troubleshooter.flow-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/flows/Twenty_Questions_Troubleshooter.flow-meta.xml
@@ -38,7 +38,7 @@
         <description>If you reach a leaf node, it might not have a target node selected</description>
         <name>Does_Outcome_Have_a_Target_Node</name>
         <label>Does Outcome Have a Target Node?</label>
-        <locationX>1239</locationX>
+        <locationX>1242</locationX>
         <locationY>318</locationY>
         <defaultConnector>
             <targetReference>No_Node_Found</targetReference>
@@ -50,6 +50,13 @@
             <conditions>
                 <leftValueReference>outcomeChoices</leftValueReference>
                 <operator>IsNull</operator>
+                <rightValue>
+                    <booleanValue>false</booleanValue>
+                </rightValue>
+            </conditions>
+            <conditions>
+                <leftValueReference>curRecord.End_Node__c</leftValueReference>
+                <operator>EqualTo</operator>
                 <rightValue>
                     <booleanValue>false</booleanValue>
                 </rightValue>

--- a/flow_apps/KnowledgeTree/force-app/main/default/flows/Twenty_Questions_Troubleshooter.flow-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/flows/Twenty_Questions_Troubleshooter.flow-meta.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Flow xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49.0</apiVersion>
     <assignments>
         <description>Take the value of the radio button selected. That is the id of the next node to transition to.</description>
-        <name>Set_Next_Node</name>
-        <label>Set Next Node</label>
-        <locationX>500</locationX>
-        <locationY>38</locationY>
+        <name>Set_Next_Node_From_Choice</name>
+        <label>Set Next Node (From Choice)</label>
+        <locationX>514</locationX>
+        <locationY>311</locationY>
         <assignmentItems>
             <assignToReference>curDiagnosticNodeId</assignToReference>
             <operator>Assign</operator>
@@ -17,16 +18,32 @@
             <targetReference>Load_Current_Node</targetReference>
         </connector>
     </assignments>
+    <assignments>
+        <name>Set_Next_Node_From_Continuation_Node</name>
+        <label>Set Next Node (From Continuation Node)</label>
+        <locationX>514</locationX>
+        <locationY>180</locationY>
+        <assignmentItems>
+            <assignToReference>curDiagnosticNodeId</assignToReference>
+            <operator>Assign</operator>
+            <value>
+                <elementReference>curRecord.ContinuationDiagnosticNode__c</elementReference>
+            </value>
+        </assignmentItems>
+        <connector>
+            <targetReference>Load_Current_Node</targetReference>
+        </connector>
+    </assignments>
     <decisions>
         <description>If you reach a leaf node, it might not have a target node selected</description>
         <name>Does_Outcome_Have_a_Target_Node</name>
         <label>Does Outcome Have a Target Node?</label>
-        <locationX>1178</locationX>
+        <locationX>1239</locationX>
         <locationY>318</locationY>
         <defaultConnector>
             <targetReference>No_Node_Found</targetReference>
         </defaultConnector>
-        <defaultConnectorLabel>Outcome Doesn&#39;t Have Target</defaultConnectorLabel>
+        <defaultConnectorLabel>Outcome Doesn&apos;t Have Target</defaultConnectorLabel>
         <rules>
             <name>Yes_Has_Target_Node</name>
             <conditionLogic>and</conditionLogic>
@@ -38,16 +55,46 @@
                 </rightValue>
             </conditions>
             <connector>
-                <targetReference>Set_Next_Node</targetReference>
+                <targetReference>Set_Next_Node_From_Choice</targetReference>
             </connector>
             <label>Yes, Has Target Node</label>
+        </rules>
+        <rules>
+            <name>Yes_Has_Target_Continuation_Node</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>curRecord.Continuation_Node__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Set_Next_Node_From_Continuation_Node</targetReference>
+            </connector>
+            <label>Yes, Has Target Continuation Node</label>
+        </rules>
+        <rules>
+            <name>Yes_Has_Target_End_Node</name>
+            <conditionLogic>and</conditionLogic>
+            <conditions>
+                <leftValueReference>curRecord.End_Node__c</leftValueReference>
+                <operator>EqualTo</operator>
+                <rightValue>
+                    <booleanValue>true</booleanValue>
+                </rightValue>
+            </conditions>
+            <connector>
+                <targetReference>Display_Finish_Screen</targetReference>
+            </connector>
+            <label>Yes, Has Target End Node</label>
         </rules>
     </decisions>
     <decisions>
         <name>Next_Node_Found</name>
         <label>Next Node Found?</label>
-        <locationX>178</locationX>
-        <locationY>203</locationY>
+        <locationX>134</locationX>
+        <locationY>493</locationY>
         <defaultConnector>
             <targetReference>No_Node_Found</targetReference>
         </defaultConnector>
@@ -71,8 +118,8 @@
     <decisions>
         <name>What_is_Data_Source</name>
         <label>What is Data Source?</label>
-        <locationX>371</locationX>
-        <locationY>216</locationY>
+        <locationX>331</locationX>
+        <locationY>497</locationY>
         <defaultConnector>
             <targetReference>Display_Diagnostic_Node</targetReference>
         </defaultConnector>
@@ -97,6 +144,7 @@
         <name>curOutcomeChoices</name>
         <dataType>String</dataType>
         <displayField>Label__c</displayField>
+        <filterLogic>and</filterLogic>
         <filters>
             <field>HomeDiagnosticNode__c</field>
             <operator>EqualTo</operator>
@@ -107,12 +155,19 @@
         <object>DiagnosticOutcome__c</object>
         <valueField>TargetDiagnosticNode__c</valueField>
     </dynamicChoiceSets>
+    <environments>Default</environments>
     <interviewLabel>Twenty Questions (Troubleshooter) {!$Flow.CurrentDateTime}</interviewLabel>
     <label>Twenty Questions (Troubleshooter)</label>
     <processMetadataValues>
         <name>BuilderType</name>
         <value>
             <stringValue>LightningFlowBuilder</stringValue>
+        </value>
+    </processMetadataValues>
+    <processMetadataValues>
+        <name>CanvasMode</name>
+        <value>
+            <stringValue>FREE_FORM_CANVAS</stringValue>
         </value>
     </processMetadataValues>
     <processMetadataValues>
@@ -125,12 +180,13 @@
     <recordLookups>
         <name>Get_Knowledge</name>
         <label>Get Knowledge</label>
-        <locationX>383</locationX>
-        <locationY>389</locationY>
+        <locationX>337</locationX>
+        <locationY>676</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Display_Knowledge_Node</targetReference>
         </connector>
+        <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
             <operator>EqualTo</operator>
@@ -149,12 +205,13 @@
     <recordLookups>
         <name>Load_Current_Node</name>
         <label>Load Current Node</label>
-        <locationX>184</locationX>
-        <locationY>46</locationY>
+        <locationX>142</locationX>
+        <locationY>302</locationY>
         <assignNullValuesIfNoRecordsFound>false</assignNullValuesIfNoRecordsFound>
         <connector>
             <targetReference>Next_Node_Found</targetReference>
         </connector>
+        <filterLogic>and</filterLogic>
         <filters>
             <field>Id</field>
             <operator>EqualTo</operator>
@@ -169,12 +226,15 @@
         <queriedFields>Node_Content__c</queriedFields>
         <queriedFields>Use_Knowledge_Article_Content__c</queriedFields>
         <queriedFields>Knowledge__c</queriedFields>
+        <queriedFields>End_Node__c</queriedFields>
+        <queriedFields>Continuation_Node__c</queriedFields>
+        <queriedFields>ContinuationDiagnosticNode__c</queriedFields>
     </recordLookups>
     <screens>
         <name>Display_Diagnostic_Node</name>
         <label>Display Diagnostic Node</label>
-        <locationX>600</locationX>
-        <locationY>219</locationY>
+        <locationX>559</locationX>
+        <locationY>496</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -198,6 +258,7 @@
             <name>rule1</name>
             <extensionName>c:horizontalRuleFSC</extensionName>
             <fieldType>ComponentInstance</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -222,7 +283,24 @@
                     <stringValue>record</stringValue>
                 </value>
             </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
+        </fields>
+        <showFooter>true</showFooter>
+        <showHeader>true</showHeader>
+    </screens>
+    <screens>
+        <name>Display_Finish_Screen</name>
+        <label>Display Finish Screen</label>
+        <locationX>1248</locationX>
+        <locationY>571</locationY>
+        <allowBack>true</allowBack>
+        <allowFinish>true</allowFinish>
+        <allowPause>true</allowPause>
+        <fields>
+            <name>Finish_Message</name>
+            <fieldText>&lt;p&gt;No further action required. Click &quot;Finish&quot; to return to the start screen.&lt;/p&gt;</fieldText>
+            <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
         <showHeader>true</showHeader>
@@ -230,8 +308,8 @@
     <screens>
         <name>Display_Knowledge_Node</name>
         <label>Display Knowledge Node</label>
-        <locationX>593</locationX>
-        <locationY>388</locationY>
+        <locationX>583</locationX>
+        <locationY>676</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>false</allowPause>
@@ -255,6 +333,7 @@
             <name>rule1_0</name>
             <extensionName>c:horizontalRuleFSC</extensionName>
             <fieldType>ComponentInstance</fieldType>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <fields>
@@ -279,6 +358,7 @@
                     <stringValue>record</stringValue>
                 </value>
             </inputParameters>
+            <inputsOnNextNavToAssocScrn>UseStoredValues</inputsOnNextNavToAssocScrn>
             <isRequired>true</isRequired>
         </fields>
         <showFooter>true</showFooter>
@@ -287,21 +367,27 @@
     <screens>
         <name>No_Node_Found</name>
         <label>No Node Found</label>
-        <locationX>185</locationX>
-        <locationY>640</locationY>
+        <locationX>142</locationX>
+        <locationY>777</locationY>
         <allowBack>true</allowBack>
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
         <fields>
             <name>dispNoNodeMessage</name>
-            <fieldText>&lt;p&gt;The flow couldn&#39;t find a diagnostic node corresponding to the choice you just selected. Contact your Salesforce Admin, or build out the node by creating a new DiagnosticNode record and then editing the DiagnosticOutcome corresponding to the choice you just selected to point to the new record.&lt;/p&gt;</fieldText>
+            <fieldText>&lt;p&gt;The flow couldn&apos;t find a diagnostic node corresponding to the choice you just selected. Contact your Salesforce Admin, or build out the node by creating a new DiagnosticNode record and then editing the DiagnosticOutcome corresponding to the choice you just selected to point to the new record.&lt;/p&gt;</fieldText>
             <fieldType>DisplayText</fieldType>
         </fields>
         <showFooter>true</showFooter>
         <showHeader>true</showHeader>
     </screens>
-    <startElementReference>Load_Current_Node</startElementReference>
-    <status>Draft</status>
+    <start>
+        <locationX>16</locationX>
+        <locationY>90</locationY>
+        <connector>
+            <targetReference>Load_Current_Node</targetReference>
+        </connector>
+    </start>
+    <status>Active</status>
     <variables>
         <name>curDiagnosticNodeId</name>
         <dataType>String</dataType>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/ContinuationDiagnosticNode__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/ContinuationDiagnosticNode__c.field-meta.xml
@@ -3,6 +3,7 @@
     <fullName>ContinuationDiagnosticNode__c</fullName>
     <deleteConstraint>SetNull</deleteConstraint>
     <externalId>false</externalId>
+    <inlineHelpText>If Continuation Node is marked true, lookup to the next Diagnostic Node this continuation node will lead to.</inlineHelpText>
     <label>ContinuationDiagnosticNode</label>
     <referenceTo>DiagnosticNode__c</referenceTo>
     <relationshipLabel>DiagnosticNodes</relationshipLabel>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/ContinuationDiagnosticNode__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/ContinuationDiagnosticNode__c.field-meta.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>ContinuationDiagnosticNode__c</fullName>
+    <deleteConstraint>SetNull</deleteConstraint>
+    <externalId>false</externalId>
+    <label>ContinuationDiagnosticNode</label>
+    <referenceTo>DiagnosticNode__c</referenceTo>
+    <relationshipLabel>DiagnosticNodes</relationshipLabel>
+    <relationshipName>ContinuationDiagnosticNodes</relationshipName>
+    <required>false</required>
+    <trackTrending>false</trackTrending>
+    <type>Lookup</type>
+</CustomField>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/Continuation_Node__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/Continuation_Node__c.field-meta.xml
@@ -3,6 +3,7 @@
     <fullName>Continuation_Node__c</fullName>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
+    <inlineHelpText>Mark this field true if you intended this DiagnosticNode screen to allow the end-user to progress forward through the diagnostic pathway without requiring a selection from them (i.e. if you intend to make a guiding statement to them and but also want them to continue on through the diagnostic pathway).</inlineHelpText>
     <label>Continuation Node</label>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/Continuation_Node__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/Continuation_Node__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Continuation_Node__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>Continuation Node</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/End_Node__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/End_Node__c.field-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>End_Node__c</fullName>
+    <defaultValue>false</defaultValue>
+    <externalId>false</externalId>
+    <label>End Node</label>
+    <trackTrending>false</trackTrending>
+    <type>Checkbox</type>
+</CustomField>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/End_Node__c.field-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/fields/End_Node__c.field-meta.xml
@@ -3,6 +3,7 @@
     <fullName>End_Node__c</fullName>
     <defaultValue>false</defaultValue>
     <externalId>false</externalId>
+    <inlineHelpText>Mark this field true if you intended this DiagnosticNode screen to be the last screen that is presented to an end-user in a diagnostic pathway. If true, upon clicking &quot;Next&quot; on this screen, the next screen the end user will see is the &quot;Finish&quot; screen, with &quot;Previous&quot; and &quot;Finish&quot; buttons vs. &quot;Previous&quot; and &quot;Next&quot; buttons. Upon clicking &quot;Finish&quot; on that screen, the end-user will be routed back to the initial diagnostic start screen.</inlineHelpText>
     <label>End Node</label>
     <trackTrending>false</trackTrending>
     <type>Checkbox</type>

--- a/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/validationRules/DN001_RequireContinuationNodeValues.validationRule-meta.xml
+++ b/flow_apps/KnowledgeTree/force-app/main/default/objects/DiagnosticNode__c/validationRules/DN001_RequireContinuationNodeValues.validationRule-meta.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DN001_RequireContinuationNodeValues</fullName>
+    <active>true</active>
+    <description>Require all continuation node values in order to ensure screen flow runs without error.</description>
+    <errorConditionFormula>(Continuation_Node__c = true &amp;&amp; ISBLANK(ContinuationDiagnosticNode__c))
+||(Continuation_Node__c = false &amp;&amp; NOT(ISBLANK(ContinuationDiagnosticNode__c)))</errorConditionFormula>
+    <errorMessage>If this is a continuation node, you must complete both the &quot;Continuation Node&quot; checkbox and the &quot;ContinuationDiagnosticNode&quot; lookup field. [Error DN001]</errorMessage>
+</ValidationRule>


### PR DESCRIPTION
Added three new fields to Diagnostic Node object: Continuation_Node__c (boolean), End_Node__c (boolean), and Continuation Diagnostic Node (lookup to DiagnosticNode__c).

Added validation rule, if DiagnosticNode__c.Continuation_Node__c is true, DiagnosticNode__c.ContinuationDiagnosticNode__c lookup is required (and vice-versa).

Updated flow:
- Modified "Get Records:Load Current Node" to pull in the three new fields (Continuation_Node__c, End_Node__c, and ContinuationDiagnosticNode__c) and store them in {!curRecord} variable.
- Added two outcomes to "Decision:Does Outcome Have Target Node". "Yes, Has Target Continuation Node", condition Continuation_Node__c = true, and "Yes, Has Target End Node", condition End_Node__c = true. Added second condition to the existing outcome "Yes, Has Target Node", condition End_Node__c = false.
- Added assignment node "Set Next Node (From Continuation Node)", curDiagnosticNodeId = ContinuationDiagnosticNode__c to support continuation without selection functionality.
- Adding new screen "Display Finish Screen" to support end node functionality.