### PR TITLE
Fix error message from being cut off

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.html
@@ -107,7 +107,7 @@
                     </div>
                 </div>
                 <template if:true={hasError}>
-                    <div class="slds-form-element__help">
+                    <div class="slds-form-element__help slds-m-top_large">
                         {labels.invalidReferenceError}
                     </div>
                 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowCombobox/fsc_flowCombobox.js
@@ -714,6 +714,11 @@ export default class FlowCombobox extends LightningElement {
             } else {
                 this._dataType = flowComboboxDefaults.stringDataType;
             }
+
+            // checkValidity on valueInput
+            if ( !valueInput.checkValidity() ) {
+                this.hasError = true;
+            }
         }
     }
 
@@ -735,7 +740,7 @@ export default class FlowCombobox extends LightningElement {
     get formElementClass() {
         let resultClass = 'slds-form-element';
         if (this.hasError) {
-            resultClass += ' slds-has-error';
+            resultClass += ' slds-has-error slds-m-bottom_medium';
         }
         return resultClass;
     }


### PR DESCRIPTION
Added a top margin to the custom error message the combo box had
Added a bottom margin to the OOB input error message
Added a validity checker anytime the input has changed. this.hasError was never being triggered and be set true or false