### PR TITLE
Update fsc_flowButtonBar.js to add validation (fixed issue)

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.js
@@ -190,12 +190,17 @@ export default class FlowButtonBar extends LightningElement {
         }
     }
     
-   // @api validate(){
-    //    return {
-      //      isValid: this.isNotRequired || !!this.value,
-      //      errorMessage: 'You must make a selection to continue'
-      //  };
-  //  }
+    @api validate(){
+        if((!!this.required && !!this.value) || (!!!this.required)) {
+            return { isValid: true }; 
+        } 
+        else { 
+            return { 
+                isValid: false, 
+                errorMessage: 'You must make a selection to continue' 
+            }; 
+        }
+    }
 
     /* ACTION FUNCTIONS */
     dispatchClickEvent() {


### PR DESCRIPTION
Added a validation handler so that users cannot navigate to the next flow screen without a button selection when the component is set to be required.

This PR resolves a previous issue in my commit e9bbfd9 / PR #1232 where the component was always treated as being required even when it was not set to be required in its properties. 

That change was subsequently rolled back in commit 1643e7a / PR #1263 

I have now tested this component in a variety of situations, including multiple instances of the component on a single screen with mixed requirement values. Requireness now behaves correctly in all scenarios.