### PR TITLE
added Custom Event Change to utilize the LWC within another LWC or CPE

### DIFF
--- a/flow_action_components/ExecuteSOQLQuery/force-app/main/default/lwc/soqlQueryBuilder/soqlQueryBuilder.js
+++ b/flow_action_components/ExecuteSOQLQuery/force-app/main/default/lwc/soqlQueryBuilder/soqlQueryBuilder.js
@@ -188,6 +188,7 @@ export default class soqlQueryBuilder extends LightningElement {
     dispatchSoqlChangeEvent() {
         const attributeChangeEvent = new FlowAttributeChangeEvent('queryString', this._queryString);
         this.dispatchEvent(attributeChangeEvent);
+        this.dispatchEvent(new CustomEvent('change', { detail: this._queryString }));
     }
 
     clearSelectedValues() {


### PR DESCRIPTION
This is a small change that I will be utilizing within a custom lookup component.
This will allow users to do an onchange handler on the LWC component


```
  <c-soql-query-builder
      onchange={handleChange}
      object-type={inputValues.objectName.value}
      disable-object-type-selection=true
  ></c-soql-query-builder>
```