### PR TITLE
HTML to Slack refactor Text Area Plus

### DIFF
--- a/flow_screen_components/textAreaPlus/force-app/main/default/lwc/textAreaPlus/textAreaPlus.js
+++ b/flow_screen_components/textAreaPlus/force-app/main/default/lwc/textAreaPlus/textAreaPlus.js
@@ -74,6 +74,7 @@ export default class TextAreaPlus extends LightningElement {
   @api label;
   @api placeHolder;
   @api textMode;
+  @api slackOutput;
 
   // Component facing props
   @track runningBlockedInput = [];
@@ -228,7 +229,6 @@ export default class TextAreaPlus extends LightningElement {
   @api
   get value() {
     // need to separate textValue from api property
-    this.handleHtmlToSlack();
     return this.textValue;
   }
   set value(val) {
@@ -403,7 +403,7 @@ export default class TextAreaPlus extends LightningElement {
     this.ignoreCase = !this.ignoreCase;
   }
 
-  // Common text value updater for Plan or Rich text
+  // Common text value updater for Plain or Rich text
   updateText(item) {
     const value = item?.value;
     const init = item?.init;
@@ -456,6 +456,15 @@ export default class TextAreaPlus extends LightningElement {
     if (this.hasBlockedItems(target.value)) {
       this.isValidCheck = false;
     }
+
+    // convert HTML to Slack
+    if (this.textMode ="slack") {
+      this.handleHtmlToSlack(target.value);
+      this.slackOutput=this.slackText;
+    }
+
+    
+    
 
     // Check invalid symbols and words
     const rbi = this.runningBlockedInput;
@@ -637,24 +646,28 @@ export default class TextAreaPlus extends LightningElement {
 
   // Replaces html to slack markdown
   handleHtmlToSlack(){
-    if (this.textMode = "slack"){
-    this.textValue = this.textValue.replace(/<p>/g,"");
-    this.textValue = this.textValue.replace(/<\/p>/g,"");  
-    this.textValue = this.textValue.replace(/<strong>/g,"*");
-    this.textValue = this.textValue.replace(/<\/strong>/g,"*");
-    this.textValue = this.textValue.replace(/<em>/g,"_");
-    this.textValue = this.textValue.replace(/<\/em>/g,"_");
-    this.textValue = this.textValue.replace(/<strike>/g,"~");
-    this.textValue = this.textValue.replace(/<\/strike>/g,"~");
-    this.textValue = this.textValue.replace(/&nbsp;/g,"");
-    this.textValue = this.textValue.replace(/<br>/g,"\n");
-    this.textValue = this.textValue.replace(/<ul>/g,"");
-    this.textValue = this.textValue.replace(/<\/ul>/g,"");
-    this.textValue = this.textValue.replace(/<li>/g,"• ");
-    this.textValue = this.textValue.replace(/<\/li>/g,"\n");
+    this.slackText = this.textValue;
+    this.slackText = this.slackText.replace(/<p>/g,"");
+    this.slackText = this.slackText.replace(/<\/p>/g,"");  
+    this.slackText = this.slackText.replace(/<strong>/g,"*");
+    this.slackText = this.slackText.replace(/<\/strong>/g,"*");
+    this.slackText = this.slackText.replace(/<em>/g,"_");
+    this.slackText = this.slackText.replace(/<\/em>/g,"_");
+    this.slackText = this.slackText.replace(/<strike>/g,"~");
+    this.slackText = this.slackText.replace(/<\/strike>/g,"~");
+    this.slackText = this.slackText.replace(/&nbsp;/g,"");
+    this.slackText = this.slackText.replace(/<br>/g,"\n");
+    this.slackText = this.slackText.replace(/<ul>/g,"");
+    this.slackText = this.slackText.replace(/<\/ul>/g,"");
+    this.slackText = this.slackText.replace(/<li>/g,"• ");
+    this.slackText = this.slackText.replace(/<\/li>/g,"\n");
+    console.log("Slack text: " + this.slackText)
     
-    return this.textValue
+    return this.slackText;
+
+    
+    
+    
      
   }
-}
 }

--- a/flow_screen_components/textAreaPlus/force-app/main/default/lwc/textAreaPlus/textAreaPlus.js-meta.xml
+++ b/flow_screen_components/textAreaPlus/force-app/main/default/lwc/textAreaPlus/textAreaPlus.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>54.0</apiVersion>
+    <apiVersion>57.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Textarea Plus!</masterLabel>
     <description>Plain Text with a counter or Rich Text with a counter and search features</description>
@@ -16,7 +16,6 @@
             <property name="label" label="Label" type="String" role="inputOnly" />
             <property name="placeHolder" label="Placeholder Text" type="String" role="inputOnly" />
             <property name="textMode" label="Text Mode" type="String" default="Rich Text" role="inputOnly" description="Choose between Rich or Plain text" />
-
             <property label="Advanced Tools" name="advancedTools" type="Boolean" role="inputOnly" description="Enable Advanced Tools - Search/Replace, Auto-replace, and blocked words/symbols." />
             <property name="cb_advancedTools" type="String" role="inputOnly" />
             <property label="Blocked Words" name="disallowedWordsList" type="String" role="inputOnly" description="Comma-separated list of words to block.  Example: bad,worse,worst" />
@@ -28,6 +27,7 @@
             <property name="cb_required" type="String" role="inputOnly" />
             <property label="Show Counter" name="showCharCounter" type="Boolean" role="inputOnly" default="false" description="Display Character Counter" />
             <property name="cb_showCharCounter" type="String" role="inputOnly" />
+            <property name="slackOutput" label="Slack Formatted Output" type="String"/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
This moves slackOutput to be it's own output in flow so rich text and plain text can be used inside Salesforce while still outputting a slack friendly output to be used in Slack actions. Should also fix validation issues some users were reporting. 