### PR TITLE
quickLookup - Output Display Value

### DIFF
--- a/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.cmp
+++ b/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.cmp
@@ -11,6 +11,7 @@
     <aura:attribute name="valueFieldName" type="String" default="Id" />
 	<aura:attribute name="label" type="String" />
 	<aura:attribute name="selectedValue" type="String" />
+	<aura:attribute name="displayedValue" type="String" />
 	<aura:attribute name="filterFieldName" type="String" />
 	<aura:attribute name="filterFieldValue" type="String" />
 	<aura:attribute name="parentChild" type="String" />
@@ -36,7 +37,7 @@
 			<lightning:layoutItem size="12">
 				<c:QuickLightningLookup sObjectName="{!v.objectName}" displayedFieldName="{!v.displayFieldName}" searchFieldName="{!v.searchFieldName}"
 					whereClause="{!v.whereClause}" valueFieldName="{!v.valueFieldName}" label="{!v.label}"
-					selectedValue="{!v.selectedValue}" filteredFieldName="{!v.filterFieldName}"
+					selectedValue="{!v.selectedValue}" selectedName="{!v.displayedValue}" filteredFieldName="{!v.filterFieldName}"
 					filterFieldValue="{!v.filterFieldValue}" parentChild="{!v.parentChild}" required="{!v.required}"
 					defaultValue="{!v.defaultValue}" parentId="{!v.parentId}" cmpId="{!v.cmpid}" performLookupOnFocus="true"
 					svg="{!v.svg}" />

--- a/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.design
+++ b/flow_screen_components/quickLookup/force-app/main/default/aura/quickLookup/quickLookup.design
@@ -10,6 +10,7 @@
    <!--If searchFieldName is set, it will be used for search instead of displayFieldName-->
     <design:attribute name="searchFieldName" label="I8_Search this Field instead of Display Field" />
     <design:attribute name="selectedValue" label="O1_Output Value" />
+    <design:attribute name="displayedValue" label="O2_Output Display Value" />
     <design:attribute name="required" label="Required?" />
     <design:attribute name="defaultValue" label="Default Value" />
     <design:attribute name="cmpid" label="Component ID" />


### PR DESCRIPTION
I've added an output attribute that will allow for referencing the name of the record that was selected in the quickLookup component in downstream flow configurations.