### PR TITLE
minor bug fix

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -6,7 +6,7 @@ const CB_ATTRIB_PREFIX = 'cb_';       // Used with fsc_flowCheckbox component
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.38';
+    versionNumber = '2.39';
     staticChoicesModalClass = 'staticChoicesModal';
     _builderContext;
     _values;

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -18,6 +18,9 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+3/29/23 -   Eric Smith -    Version 2.39  
+                            Fixed dependent picklist bug (CB_TRUE not defined) 
+
 3/25/23 -   Eric Smith -    Version 2.38  
                             Updated to support dependent picklists in the Reactive Screens Beta (Dependent picklists must include a Controlling Value attribute) 
                             Added new attribute to support Rich Text for Visual Card descriptions

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -6,6 +6,8 @@ import Quickchoice_Images from '@salesforce/resourceUrl/fsc_Quickchoice_Images';
 /* eslint-disable no-alert */
 /* eslint-disable no-console */
 
+const CB_TRUE = true;
+
 export default class QuickChoiceFSC extends LightningElement {
 
     bottomPadding = 'slds-p-bottom_x-small';

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -6,7 +6,7 @@ import Quickchoice_Images from '@salesforce/resourceUrl/fsc_Quickchoice_Images';
 /* eslint-disable no-alert */
 /* eslint-disable no-console */
 
-const CB_TRUE = true;
+const CB_TRUE = 'CB_TRUE';
 
 export default class QuickChoiceFSC extends LightningElement {
 


### PR DESCRIPTION
There is a bug in QuickChoice that causes it to fail on dependent picklists (CB_TRUE is undefined)

Please process this PR and build a new FlowScreenComponentsBasePack