### PR TITLE
feat: enable and disable rich text formats

### DIFF
--- a/flow_screen_components/richTextInputFSC/README.md
+++ b/flow_screen_components/richTextInputFSC/README.md
@@ -19,6 +19,12 @@ IMPORTANT:  Use enabledAdvancedTools = true input attribute if you want to lever
 1)  Default function is regular rich text input field.  To enable advanced features set enableAdvancedTools to true.
 2)  Setting label provides a field label for the rich text input.
 3)  Rich Text input/output is provided through the value attribute.
+##### Configure the default Rich Text Features in Flow:
+1)  By default, all rich text features (called formats) like bold, italic, image etc. are enabled.
+2)  Optionally, specify the exact formats you want to allow by providing a comma-separated list with formats to the "Enabled Formats" attribute. Example: bold, image
+3)  Optionally, disable certain categories by providing a comma-separated list with categories to the "Disabled Categories" attribute. Example: INSERT_CONTENT, ALIGN_TEXT
+4)  The complete list of formats and categories can be accessed in the Input Rich Text documentation on:
+https://developer.salesforce.com/docs/component-library/bundle/lightning-input-rich-text/documentation
 ##### Replace Text with Suggested Terms:
 1)  If autoReplaceMap is populated, then a button is shown to user.
 2)  Use autoReplaceMap to set up key:value pairs in JSON.  Example: {"Test":"GreatTest™"}
@@ -33,15 +39,17 @@ IMPORTANT:  Use enabledAdvancedTools = true input attribute if you want to lever
 2)  If warnOnly is not set when characterLimit is on, then the Flow Next/Finish cannot be used until resolved.
 
 |Parameter	               |I	 |O	     |Information 
-|--------------------------|-----|-------|----------------------------------------------------------------------------------------------------------------------------------|
-|**enableAdvancedTools**   |X    |       |Boolean.  Set to true if you want to use enhanced rich text.  Default is false (regular input component)                          |
-|**autoReplaceMap**	       |X	 |       |JSON formatted key:value map.  (example => {"Test": "GreatTest™"} )                                                               |
-|**disallowedSymbols**	   |X	 |       |Comma-separated list of words to block.  Example: /,@,*                                                                           |
-|**disallowedWords**	   |X    |	     |Comma-separated list of words to block.  Example: bad,worse,worst                                                                 |
-|**warnOnly**	           |X	 |	     |Boolean.  Set to True if you want to allow Next even where disallowed Symbol or Word remains.  Default is false.                  |
-|**characterLimit**	       |X	 |	     |Integer.  Set character limit.  This will enable character count and limit, and if warnOnly is not true, then will block next.    |
-|**value**	           	   |X	 |X	     |Input and output Rich Text that you’ll be editing                                                                                 |
-|**label**                 |X    |X      |Input to provide field-level label if desired                                                                                     |
+|--------------------------|-----|-------|----------------------------------------------------------------------------------------------------------------------------------------|
+|**enabledFormats**        |X    |       |An optional comma-seperated list of allowed formats. By default, the list is computed based on enabled categories. Example: bold, image |
+|**disabledCategories**    |X    |       |An optional comma-separated list of button categories to remove from the toolbar. Example: INSERT_CONTENT, ALIGN_TEXT                   |
+|**enableAdvancedTools**   |X    |       |Boolean.  Set to true if you want to use enhanced rich text.  Default is false (regular input component)                                |
+|**autoReplaceMap**	       |X	 |       |JSON formatted key:value map.  (example => {"Test": "GreatTest™"} )                                                                     |
+|**disallowedSymbols**	   |X	 |       |Comma-separated list of words to block.  Example: /,@,*                                                                                 |
+|**disallowedWords**	   |X    |	     |Comma-separated list of words to block.  Example: bad,worse,worst                                                                       |
+|**warnOnly**	           |X	 |	     |Boolean.  Set to True if you want to allow Next even where disallowed Symbol or Word remains.  Default is false.                        |
+|**characterLimit**	       |X	 |	     |Integer.  Set character limit.  This will enable character count and limit, and if warnOnly is not true, then will block next.          |
+|**value**	           	   |X	 |X	     |Input and output Rich Text that you’ll be editing                                                                                       |
+|**label**                 |X    |X      |Input to provide field-level label if desired                                                                                           |
 
 
 ### User Instructions:

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.html
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.html
@@ -3,7 +3,7 @@
     <!-- Start Rich Text Input Section -   -->
     <template if:true={disableAdvancedTools}>
         <div>
-            <lightning-input-rich-text value={value} onchange={handleValueChange} formats={formats} label={label} required={required} label-visible=true></lightning-input-rich-text>
+            <lightning-input-rich-text value={value} onchange={handleValueChange} formats={formats} label={label} required={required} label-visible=true disabled-categories={disabledCategories}></lightning-input-rich-text>
         </div>
     </template>
     <!-- End Rich Text Input Section-->
@@ -12,7 +12,7 @@
     <template if:false={disableAdvancedTools}>
         <div>
             <lightning-input-rich-text value={richText} formats={formats} label={label} onchange={handleTextChange} 
-                label-visible=true valid={isValidCheck} message-when-bad-input={errorMessage} required={required}>
+                label-visible=true valid={isValidCheck} message-when-bad-input={errorMessage} required={required} disabled-categories={disabledCategories}>
             </lightning-input-rich-text>
         </div>
         <div class="slds-grid slds-wrap slds-p-around_xx-small slds-m-bottom_x-small lgc-bg">

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
@@ -1,5 +1,6 @@
 // 06/25/21    Eric Smith       Added a Required attribute and increased the bottom margin to better match standard components
 // 07/02/21    Eric Smith       Added a Required * to the Input Label if Required is True
+// 04/04/23    Clifford Beul    Added disabled categories and optional overwrite of formats
 
 import { LightningElement, api, track } from 'lwc';
 
@@ -15,6 +16,8 @@ export default class inputRichTextFSC_LWC extends LightningElement {
     @api label;
     @api characterLimit;
     @api required = false;
+    @api disabledCategories = '';
+    @api enabledFormats;
 
     formats = ['font', 'size', 'bold', 'italic', 'underline',
         'strike', 'list', 'indent', 'align', 'link',
@@ -93,6 +96,12 @@ export default class inputRichTextFSC_LWC extends LightningElement {
                 sessionStorage.removeItem('tempValue'); //clear value after selection
             }
         }
+
+        if(this.enabledFormats){
+            this.formats = this.enabledFormats.split(',').map(function(item) {
+                return item.trim();
+            });
+        } 
 
         if(!this.disableAdvancedTools){
             console.log('disableAdvancedTools is false, in connected callback');

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata" fqn="Rich Text Area FSC">
-    <apiVersion>48.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>
@@ -8,6 +8,8 @@
     <targetConfigs>
         <targetConfig targets="lightning__FlowScreen">
             <property label="Disable Advanced Tools" name="disableAdvancedTools" type="Boolean" role="inputOnly" description="Set to true to disable expanded Rich Text tools - Search/Replace, Auto-replace, and blocked words/sybmols.  Default is false."/>
+            <property label="Disabled Categories" name="disabledCategories" type="String" role="inputOnly" description="An optional comma-separated list of button categories to remove from the toolbar."/>
+            <property label="Enabled Formats" name="enabledFormats" type="String" role="inputOnly" description="An optional comma-seperated list of allowed formats. By default, the list is computed based on enabled categories."/>
             <property label="Rich Text Value" name="value" type="String" description="Rich Text input/output to the Flow - this is the value you will be manipulating"/>
             <property label="Field Label" name="label" type="String" role="inputOnly" description="Label for the Rich Text field"/>
             <property label="Blocked Words" name="disallowedWordsList" type="String" role="inputOnly" description="Comma-separated list of words to block.  Example: bad,worse,worst"/>


### PR DESCRIPTION
Hello,

I'm using the richTextInput component to create and edit ContentNotes in Flow. The feature (format) disparity between the Salesforce Note Editor and this component caused some bugs, because some formats are not shown in the Salesforce Editor and vice versa. We have also encountered errors inside `<lightning-input-rich-text>` when creating links with the Link-Button.

For these reasons, I have updated the component, so that it uses the `disable-categories` attribute to remove button groups from the standard toolbar. Additionally, I also added an `enabledFormats` attribute in case someone wants to specify the toolbar feature set exactly.

- Both new attributes are optional
- I updated the documentation
- The new version is downward compatible to the existing version
- I have tested the new version with the following cases
  - enabledFormats is empty and disabledCategories is empty
  - enabledFormats is empty and disabledCategories is not empty
  - enabledFormats is not empty and disabledCategories is empty
  - enabledFormats is not empty and disabledCategories is not empty

So, basically, I implemented the formats and disabled-categories from here https://developer.salesforce.com/docs/component-library/bundle/lightning-input-rich-text/documentation while being downward compatible.

Best regards
Clifford