### PR TITLE
DETECT AND LAUNCH | BUG FIX | Editing Page

### DIFF
--- a/lightning_page_components/DetectAndLaunch/force-app/main/default/aura/detectAndLaunch/detectAndLaunchHelper.js
+++ b/lightning_page_components/DetectAndLaunch/force-app/main/default/aura/detectAndLaunch/detectAndLaunchHelper.js
@@ -1,18 +1,27 @@
 ({
     processChangeEvent : function(component, eventParams) {
         console.log('entering processChangeEvent');
-        if(eventParams.changeType === "CHANGED") {
-            console.log ('changeType is: ' + eventParams.changeType);
-            this.callFlow(component, eventParams);
-        }  else if(eventParams.changeType === "REMOVED") {
-            console.log('record is being deleted');
-            //the other launch paths don't work well when the underlying page is deleted
-            var targetUrl = '/flow/' + component.get("v.targetFlowName") + '?recordId=' + component.get("v.recordId"); //added input variable
-            console.log('targetURL is: ' + targetUrl);
-            window.open(targetUrl);
-        } else if(eventParams.changeType === "LOADED") {
-            console.log ('changeType is: ' + eventParams.changeType);
-            this.callFlow(component, eventParams);
+        // Get current URL 
+        // If URL contains flexipageEditor do nothing
+        var currentUrl = window.location.href;
+        console.log('currentUrl is: ' + currentUrl);
+        if (currentUrl.includes('flexipageEditor')) {
+            console.log('currentUrl includes flexipageEditor');
+            return;
+        } else {
+            if(eventParams.changeType === "CHANGED") {
+                console.log ('changeType is: ' + eventParams.changeType);
+                this.callFlow(component, eventParams);
+            }  else if(eventParams.changeType === "REMOVED") {
+                console.log('record is being deleted');
+                //the other launch paths don't work well when the underlying page is deleted
+                var targetUrl = '/flow/' + component.get("v.targetFlowName") + '?recordId=' + component.get("v.recordId"); //added input variable
+                console.log('targetURL is: ' + targetUrl);
+                window.open(targetUrl);
+            } else if(eventParams.changeType === "LOADED") {
+                console.log ('changeType is: ' + eventParams.changeType);
+                this.callFlow(component, eventParams);
+            }
         }
     },
 


### PR DESCRIPTION
One issue with this component arose during editing of the record page, as the DetectAndLaunch would launch based on the configuration. The current PR will examine the URL and prevent the DetectAndLaunch from launching if the page is the flexipageEditor.

I have conducted tests with both modal and modeless and it is working as intended.

Commit Comments
fixed issue when editing a record page the detect and launch would launch when a loaded URL was added