### PR TITLE
4.1.2 release

### DIFF
--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -51,8 +51,8 @@ https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 4.1.2 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)   
-[Version 4.1.2 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)
+[Version 4.1.3 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MsQAK)   
+[Version 4.1.3 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MsQAK)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -72,7 +72,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes 
  
- ## 06/13/23 -  Eric Smith -    Version 4.1.2 
+ ## 06/13/23 -  Eric Smith -    Version 4.1.3 
 **Bug Fixes:**  
 -   Fixed issue where Datatables fed by DataFetcher were defaulting to single row selection only 
   

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -51,8 +51,8 @@ https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 4.1.1 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7LzQAK)   
-[Version 4.1.1 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7LzQAK)
+[Version 4.1.2 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)   
+[Version 4.1.2 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -72,14 +72,17 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes 
  
-
+ ## 06/13/23 -  Eric Smith -    Version 4.1.2 
+**Bug Fixes:**  
+-   Fixed issue where Datatables fed by DataFetcher were defaulting to single row selection only 
+  
  ## 06/04/23 -  Eric Smith -    Version 4.1.1 
 **Updates:** 
--   Added reactivity for Apex-Defind objects (Pre-Selected Rows are not reactive)
--   Made the placeholder for 'Enter search term ...' a translatable label
+-   Added reactivity for Apex-Defind objects (Pre-Selected Rows are not reactive) 
+-   Made the placeholder for 'Enter search term ...' a translatable label 
  
 **Bug Fixes:**  
--   Fixed reactivity for DataFetcher on initial load of screen
+-   Fixed reactivity for DataFetcher on initial load of screen 
  
 ## 05/21/23 -  Eric Smith -    Version 4.1.0 
 **Updates:** 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -94,6 +94,7 @@ export default class Datatable extends LightningElement {
     set tableData(data = []) {
         if(this.isUpdateTable) {       
             if (Array.isArray(data)) {
+                this.maxRowSelection = (this.singleRowSelection) ? 1 : this._tableData.length + 1; // If maxRowSelection=1 then Radio Buttons are used (v4.1.2)                
                 this._tableData = data;
                 if(this.columnFields) {
                     this.processDatatable();

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -33,7 +33,7 @@ console.log("DATATABLE isCommunity, isFlowBuilder:", isCommunity, isFlowBuilder)
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '4.1.1',       // Current Source Code Version #
+        VERSION_NUMBER : '4.1.3',       // Current Source Code Version #
         MAXROWCOUNT : 2000,             // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,                 // Used to round off the column widths during Config Mode to nearest value
         WIZROWCOUNT : 6,                // Number of records to display in the Column Wizard datatable

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -86,6 +86,7 @@
     "datatable@4.0.12-0": "04t5G0000043wt5QAA",
     "datatable@4.1.0": "04t5G000004J7LQQA0",
     "datatable@4.1.1": "04t5G000004J7LzQAK",
-    "datatable@4.1.2": "04t5G000004J7MnQAK"
+    "datatable@4.1.2": "04t5G000004J7MnQAK",
+    "datatable@4.1.3": "04t5G000004J7MsQAK"
   }
 }

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -85,6 +85,7 @@
     "datatable@4.0.11-0": "04t5G0000043wpmQAA",
     "datatable@4.0.12-0": "04t5G0000043wt5QAA",
     "datatable@4.1.0": "04t5G000004J7LQQA0",
-    "datatable@4.1.1": "04t5G000004J7LzQAK"
+    "datatable@4.1.1": "04t5G000004J7LzQAK",
+    "datatable@4.1.2": "04t5G000004J7MnQAK"
   }
 }


### PR DESCRIPTION
Fixed issue where Datatables fed by DataFetcher were defaulting to single row selection only 

[Version 4.1.2 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)   
[Version 4.1.2 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004J7MnQAK)