### PR TITLE
Fix null value in Flow Flex Card

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js
@@ -2,7 +2,7 @@
  * @description       : 
  * @author            : Josh Dayment
  * @group             : 
- * @last modified on  : 05-01-2023
+ * @last modified on  : 07-06-2023
  * @last modified by  : Josh Dayment
 **/
 import { LightningElement, api, track, wire } from 'lwc';

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js
@@ -176,7 +176,7 @@ export default class FlexcardFlow extends LightningElement {
         this.recs.find(record => {
             if (record.Id === event.currentTarget.dataset.id && this.isClickable == true) {
                 this.selectedRecord = event.currentTarget.dataset.id;
-                //console.log(this.value = this.selectedRecord);
+                this.value = this.selectedRecord;
             }
 
         });


### PR DESCRIPTION
@alexed1 this one is a hotfix it was impacting values not being returned in single select in Flow Flex Cards so will need a new basepack I had a line commented out that wasn't supposed to be. 