### PR TITLE
Quick Choice - Help Text Fix

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.html
@@ -76,7 +76,7 @@
                                 label={inputValues.controllingPicklistValue.label}
                                 value={inputValues.controllingPicklistValue.value} 
                                 value-type={inputValues.controllingPicklistValue.valueDataType}
-                                field-level-help="If the controlling field is a Picklist, reference it here."
+                                field-level-help="If the controlling field is a Picklist, reference the controlling value here."
                                 builder-context-filter-type="String"
                                 builder-context-filter-collection-boolean={inputValues.controllingPicklistValue.isCollection}
                                 builder-context={_builderContext}
@@ -88,7 +88,7 @@
                                 label={inputValues.controllingCheckboxValue.label}
                                 value={inputValues.controllingCheckboxValue.value} 
                                 value-type={inputValues.controllingCheckboxValue.valueDataType}
-                                field-level-help="If the controlling field is a Picklist, reference it here."
+                                field-level-help="If the controlling field is a Checkbox, reference the controlling value here."
                                 builder-context-filter-type="Boolean"
                                 builder-context-filter-collection-boolean={inputValues.controllingCheckboxValue.isCollection}
                                 builder-context={_builderContext}


### PR DESCRIPTION
Changes to fsc_quickChoiceCpe.html:
- Fixed help text of the `controllingCheckboxValue` field - to say `Checkbox` instead of `Picklist`.
- Clarified what `it` refers to in the help text of the `controllingCheckboxValue` and `controllingPicklistValue` fields.
