### PR TITLE
Bug Fix for validate error

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLine/fsc_drawLine.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLine/fsc_drawLine.js
@@ -10,6 +10,9 @@
  * 
  *                      Lightning Web Components:       fsc_drawLineCPE
  * 
+ * 11/13/23 -   Eric Smith -    Version 1.0.1
+ *              Bug Fixes:      Line thickness attribute was causing an error when other components on the same screen had validation errors
+ * 
  * CREATED BY:          Eric Smith
  * 
  * VERSION:             1.0.0
@@ -26,7 +29,7 @@ export default class Fsc_drawLine extends LightningElement {
     // Component Input Attributes
     @api marginTop;
     @api marginBottom;
-    @api thickness;
+    @api thickness='';
     @api color;
     @api vCard;
 
@@ -40,7 +43,7 @@ export default class Fsc_drawLine extends LightningElement {
     }
 
     get styleThickness() {
-        return (this.thickness) ? this.thickness : '1';
+        return (this.thickness) ? this.thickness : '1px';
     }
 
     get styleColor() {
@@ -52,11 +55,16 @@ export default class Fsc_drawLine extends LightningElement {
     }
 
     get lineStyle() {
-        return `border-width: ${this.styleThickness}px;border-color: ${this.styleColor};`;
+        return `border-width: ${this.styleThickness};border-color: ${this.styleColor};`;
     }
 
     get displayVCard() {
         return (this.vCard === true) ? true : false;
     }
 
+    // @api validate(){
+    //     console.log("Draw Line entering validate: vCard=" + this.vCard);
+    //     return { isValid: true }; 
+    // }
+    
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLine/fsc_drawLine.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLine/fsc_drawLine.js-meta.xml
@@ -2,7 +2,7 @@
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
     <masterLabel>Draw a Line</masterLabel>
     <description>Similar to horizontalRule, use this component to add a line to a Flow Screen or Lightning Record Page - By Eric Smith</description>
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <isExposed>true</isExposed>
     <targets>
         <target>lightning__FlowScreen</target>
@@ -16,8 +16,8 @@
                 description="Size selection for the top margin (Default = none)"/>
             <property name="marginBottom" type="String" label="Bottom Margin" default="xx-small"  
                 description="Size selection for the bottom margin (Default = xx-small)"/>
-            <property name="thickness" type="String" label="Line Thickness" default="1" 
-                description="Number of pixels for the line thickness (Default = 1)"/>
+            <property name="thickness" type="String" label="Line Thickness" default="1px" 
+                description="Number of pixels for the line thickness (Default = 1px)"/>
             <property name="color" type="String" label="Line Color" default="Gray" 
                 description="Color code for the line (Default = Gray)"/>
         </targetConfig>
@@ -28,8 +28,8 @@
             <property name="marginBottom" type="String" label="Bottom Margin" default="large"  
                 datasource="none,xxx-small,xx-small,x-small,small,medium,large,x-large,xx-large" 
                 description="Size selection for the bottom margin (Default = large)"/>
-            <property name="thickness" type="String" label="Line Thickness" default="1" 
-                description="Number of pixels for the line thickness (Default = 1)"/>
+            <property name="thickness" type="String" label="Line Thickness" default="1px" 
+                description="Number of pixels for the line thickness (Default = 1px)"/>
             <property name="color" type="String" label="Line Color" default="Gray" 
                 description="Color code for the line (Default = Gray)"/>
             <property name="vCard" type="Boolean" label="Display as vCard?" default="true" 

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.html
@@ -45,7 +45,7 @@
         <lightning-slider 
             name="select_thickness"
             label={inputValues.thickness.label}
-            value={inputValues.thickness.value}
+            value={thicknessPixels}
             min="1"
             max="30"
             step="1"

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.js
@@ -7,6 +7,9 @@
  * Attributes are available for vetical margins, color and thickness.
  * 
  * This component is packaged as part of the unofficialsf.com FlowScreenComponentsBasePack
+ * 
+ * 11/13/23 -   Eric Smith -    Version 1.0.1
+ *              Bug Fixes:      Line thickness attribute was causing an error when other components on the same screen had validation errors
  *
  * CREATED BY:          Eric Smith
  * 
@@ -14,12 +17,13 @@
  * 
  * DATE:                4/11/2023
  *
+ * 
  *
  **/
 
 import { LightningElement, api, track } from 'lwc';
 
-const VERSION_NUMBER = "1.0.0";
+const VERSION_NUMBER = "1.0.1";
 
 const defaults = {
     inputAttributePrefix: "select_",
@@ -53,6 +57,10 @@ export default class Fsc_drawLineCPE extends LightningElement {
         return this.inputValues['thickness'].value;
     }
 
+    get thicknessPixels() {
+        return this.inputValues['thickness'].value.slice(0,-2);
+    }
+
     get styleColor() {
         return this.inputValues['color'].value;
     }
@@ -62,7 +70,7 @@ export default class Fsc_drawLineCPE extends LightningElement {
     }
 
     get lineStyle() {
-        return `border-width: ${this.styleThickness}px;border-color: ${this.styleColor};`;
+        return `border-width: ${this.styleThickness};border-color: ${this.styleColor};`;
     }
 
     // Define any banner overrides you want to use (see fsc_flowBanner.js)
@@ -149,11 +157,11 @@ export default class Fsc_drawLineCPE extends LightningElement {
             helpText: "Size selection for the bottom margin (Default = xx-small)"
         },
         thickness: {
-            value: "1",
+            value: "1px",
             valueDataType: null,
             isCollection: false,
             label: "Line Thickness",
-            helpText: "Number of pixels for the line thickness (Default = 1)"
+            helpText: "Number of pixels for the line thickness (Default = 1px)"
         },
         color: {
             value: "#808080",
@@ -262,9 +270,12 @@ export default class Fsc_drawLineCPE extends LightningElement {
                         curInputParam.valueDataType;
 
                 // Handle any internal value settings based on attribute values here
-                // if (curInputParam.name == 'objectName') {
-                //     this.selectedSObject = curInputParam.value;
-                // }
+                if (curInputParam.name == "thickness") {
+                    if (this.inputValues[curInputParam.name].value.toString().slice(-1) != "x") {
+                        this.inputValues[curInputParam.name].value += "px";
+                        this.inputValues[curInputParam.name].valueDataType = "String";
+                    }
+                }
 
                 }
                 if (curInputParam.isError) {
@@ -318,8 +329,8 @@ export default class Fsc_drawLineCPE extends LightningElement {
             defaults.inputAttributePrefix,
             ""
         );
-        let newValue = event.detail.value;
-        this.dispatchFlowValueChangeEvent(changedAttribute, newValue, "Number");
+        let newValue = event.detail.value.toString() + "px";
+        this.dispatchFlowValueChangeEvent(changedAttribute, newValue, "String");
     }
 
     handleFlowComboboxValueChange(event) {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_drawLineCPE/fsc_drawLineCPE.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Draw Line CPE</masterLabel>
     <description>CPE for the fsc_drawLine LWC</description>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.js
@@ -176,6 +176,9 @@ export default class FlowButtonBar extends LightningElement {
             // Don't unselect a button if it is both required and the only selected button
             if (!this.required || this.values.length > 1)
                 this.values.splice(curIndex, 1);
+            if (!this.multiselect) {
+                this.value = clickedValue;
+            }
         } else {
             if (this.multiselect) {
                 this.values.push(clickedValue);


### PR DESCRIPTION
PLEASE CREATE A NEW FlowScreenComponentsBasePack

This fixes a bug in Draw A Line where a validation error on other screen components on the same screen will cause the flow to crash.

There is also a fix for Flow Button Bar where the clicked button value is not passed back to the Flow after a validation error by any other component.