### PR TITLE
allow full row search when empty cells are present

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -2260,7 +2260,7 @@ export default class Datatable extends LightningElement {
                                 }
                                 
                                 if (cols[col].type != 'boolean' && (!row[fieldName] || row[fieldName] == null)) {    // No match because the field is empty
-                                    break; 
+                                    continue; 
                                 }                   
 
                                 switch(cols[col].type) {


### PR DESCRIPTION
Currently the row search will evaluate rows until it hits an empty cell in which case it breaks out of the loop without searching the rest of the cells in the row. By using a 'continue' statement instead of a 'break' statement the entire row will get evaluated even with the presence of empty cells.
