### PR TITLE
GetChildCollection - Accept Child Relationship API Name

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls
@@ -18,51 +18,62 @@ global with sharing class GetChildCollection {
             SObject inputRecord = curRequest.inputRecord;
             String inputRecordId = curRequest.inputRecordId;
 
-            SObjectType recordType;
-            SObjectField lookupField;
+            SObjectType parentSobjType;
+            String childSobjTypeName;
+            String lookupFieldName;
 
             try {
-                if (inputRecordId == null && inputRecord == null) {
-                    throw new InvocableActionException(
-                        'You need to pass either a record or a recordId into this action, representing the entity you want to start with'
-                    );
-                } else if (inputRecordId != null && inputRecord != null) {
-                    throw new InvocableActionException(
-                        'You need to pass either a record or a recordId into this action, but you can not pass both'
-                    );
-                }
-                if (inputRecordId != null) {
-                    recordType = ID.valueOf(inputRecordId).getSObjectType();
-                    String typeName = recordType.getDescribe().getName();
-                    inputRecord = Database.query(
-                        'SELECT Id From ' +
-                            typeName +
-                            ' Where Id = :inputRecordId'
-                    );
+                // Get the parent SObjectType based on the incoming ID/record
+                if (inputRecordId == null) {
+                    // If we haven't received a record ID or record
+                    if (inputRecord == null) {
+                        throw new InvocableActionException(
+                            'You need to pass either a record or a recordId into this action, representing the entity you want to start with'
+                        );
+                    }
+                    parentSobjType = inputRecord.getSObjectType();
+                    inputRecordId = inputRecord.Id;
                 } else {
-                    recordType = inputRecord.getSObjectType();
+                    // If we received both a record ID and a record
+                    if (inputRecord != null) {
+                        throw new InvocableActionException(
+                            'You need to pass either a record or a recordId into this action, but you can not pass both'
+                        );
+                    }
+                    parentSobjType = Id.valueOf(inputRecordId).getSObjectType();
                 }
                 System.debug(
-                    'made it through validation. inputRecord is: ' + inputRecord
+                    'Made it through validation; parentSobjType is ' +
+                        parentSobjType +
+                        '; inputRecordId is ' +
+                        inputRecordId
                 );
                 for (
-                    ChildRelationship curChildRel : recordType.getDescribe()
+                    ChildRelationship curChildRel : parentSobjType.getDescribe()
                         .getChildRelationships()
                 ) {
-                    Schema.DescribeSObjectResult childRelDescribe = curChildRel.getChildSObject()
-                        .getDescribe();
-                    System.debug(
-                        'childRelDescribe.getName():::' +
-                        childRelDescribe.getName()
-                    );
+                    String curChildRelName = curChildRel.getRelationshipName();
+                    System.debug('curChildRelName: ' + curChildRelName);
+                    String curChildObjName = curChildRel.getChildSObject()
+                        .getDescribe()
+                        .getName();
+                    System.debug('curChildObjName: ' + curChildObjName);
+
+                    // If the provided childRelationshipName matches either the
+                    // API name of the child relationship OR the API name of the
+                    // child SObject, use this relationship
                     if (
-                        childRelDescribe.getName() ==
-                        curRequest.childRelationshipName
+                        curRequest.childRelationshipName == curChildRelName ||
+                        curRequest.childRelationshipName == curChildObjName
                     ) {
-                        lookupField = curChildRel.getField();
+                        lookupFieldName = curChildRel.getField()
+                            .getDescribe()
+                            .getName();
+                        childSobjTypeName = curChildObjName;
+                        break;
                     }
                 }
-                if (lookupField == null)
+                if (lookupFieldName == null)
                     throw new InvocableActionException(
                         'Did not find the relationship ' +
                             curRequest.childRelationshipName +
@@ -74,11 +85,11 @@ global with sharing class GetChildCollection {
                     'SELECT ' +
                     curRequest.childRecordFieldsCSV +
                     ' FROM ' +
-                    curRequest.childRelationshipName +
+                    childSobjTypeName +
                     ' WHERE ' +
-                    lookupField.getDescribe().getName() +
+                    lookupFieldName +
                     ' = \'' +
-                    inputRecord.Id +
+                    inputRecordId +
                     '\'';
                 System.debug('query is: ' + qry);
 

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls
@@ -1,16 +1,15 @@
 global with sharing class GetChildCollection {
- 
-
-        
     //    get the type of the input record
     //    get the child relationships of that type
     //    find the relationship that has the object type OpportunityContactRole (https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_ChildRelationship.htm#apex_Schema_ChildRelationship_getChildSObject)
     //    query for all of that object where the field *getField()* (https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_ChildRelationship.htm#apex_Schema_ChildRelationship_getField) is equal to the id of the record
 
-
-    @InvocableMethod(label='Get Child Collection [USF Collection Processor]' category='Util' iconName='resource:CollectionProcessorsSVG:colproc')
-    global static List <Results> get(List<Request> requestList) {
-
+    @InvocableMethod(
+        label='Get Child Collection [USF Collection Processor]'
+        category='Util'
+        iconName='resource:CollectionProcessorsSVG:colproc'
+    )
+    global static List<Results> get(List<Request> requestList) {
         List<Results> responseWrapper = new List<Results>();
 
         Results response = new Results();
@@ -21,61 +20,87 @@ global with sharing class GetChildCollection {
 
             SObjectType recordType;
             SObjectField lookupField;
-            
 
             try {
                 if (inputRecordId == null && inputRecord == null) {
-                    throw new InvocableActionException('You need to pass either a record or a recordId into this action, representing the entity you want to start with');
+                    throw new InvocableActionException(
+                        'You need to pass either a record or a recordId into this action, representing the entity you want to start with'
+                    );
                 } else if (inputRecordId != null && inputRecord != null) {
-                    throw new InvocableActionException('You need to pass either a record or a recordId into this action, but you can not pass both');
+                    throw new InvocableActionException(
+                        'You need to pass either a record or a recordId into this action, but you can not pass both'
+                    );
                 }
                 if (inputRecordId != null) {
                     recordType = ID.valueOf(inputRecordId).getSObjectType();
                     String typeName = recordType.getDescribe().getName();
-                    inputRecord = Database.query('SELECT Id From ' + typeName + ' Where Id = :inputRecordId');
+                    inputRecord = Database.query(
+                        'SELECT Id From ' +
+                            typeName +
+                            ' Where Id = :inputRecordId'
+                    );
                 } else {
-                    recordType = inputRecord.getSObjectType();    
+                    recordType = inputRecord.getSObjectType();
                 }
-                System.debug('made it through validation. inputRecord is: ' + inputRecord);
-                for(ChildRelationship curChildRel : recordType.getDescribe().getChildRelationships()){
-                    Schema.DescribeSObjectResult childRelDescribe = curChildRel.getChildSObject().getDescribe();
-                    System.debug('childRelDescribe.getName():::'+childRelDescribe.getName());
-                    if (childRelDescribe.getName() == curRequest.childRelationshipName) {
+                System.debug(
+                    'made it through validation. inputRecord is: ' + inputRecord
+                );
+                for (
+                    ChildRelationship curChildRel : recordType.getDescribe()
+                        .getChildRelationships()
+                ) {
+                    Schema.DescribeSObjectResult childRelDescribe = curChildRel.getChildSObject()
+                        .getDescribe();
+                    System.debug(
+                        'childRelDescribe.getName():::' +
+                        childRelDescribe.getName()
+                    );
+                    if (
+                        childRelDescribe.getName() ==
+                        curRequest.childRelationshipName
+                    ) {
                         lookupField = curChildRel.getField();
                     }
                 }
                 if (lookupField == null)
-                    throw new InvocableActionException('Did not find the relationship ' + curRequest.childRelationshipName + ' on the passed in record or id');
-    
-                
+                    throw new InvocableActionException(
+                        'Did not find the relationship ' +
+                            curRequest.childRelationshipName +
+                            ' on the passed in record or id'
+                    );
+
                 // query for all of that object where the field *getField()* (https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_class_Schema_ChildRelationship.htm#apex_Schema_ChildRelationship_getField) is equal to the id of the record
-                String qry = 'SELECT ' + curRequest.childRecordFieldsCSV + ' FROM ' + curRequest.childRelationshipName + ' WHERE ' + lookupField.getDescribe().getName() + ' = \'' + inputRecord.Id + '\'';
-                System.debug ('query is: ' + qry);
-                
-               
+                String qry =
+                    'SELECT ' +
+                    curRequest.childRecordFieldsCSV +
+                    ' FROM ' +
+                    curRequest.childRelationshipName +
+                    ' WHERE ' +
+                    lookupField.getDescribe().getName() +
+                    ' = \'' +
+                    inputRecord.Id +
+                    '\'';
+                System.debug('query is: ' + qry);
+
                 response.childCollection = Database.query(qry);
-                System.debug ('childCollection is: ' + response.childCollection);
-               
-            } 
-            catch ( Exception e) {
+                System.debug('childCollection is: ' + response.childCollection);
+            } catch (Exception e) {
                 response.errorText = e.getMessage();
                 System.debug('error is: ' + e.getMessage());
             }
-
-            
-            
         }
         responseWrapper.add(response);
         return responseWrapper;
     }
 
-    global class InvocableActionException extends Exception {}
+    global class InvocableActionException extends Exception {
+    }
 
     global class Request {
-        @InvocableVariable 
+        @InvocableVariable
         global SObject inputRecord;
 
-        @InvocableVariable 
+        @InvocableVariable
         global String inputRecordId;
 
         @InvocableVariable
@@ -83,25 +108,17 @@ global with sharing class GetChildCollection {
 
         @InvocableVariable
         global String childRecordFieldsCSV;
-
-         
-       
     }
 
     global class Results {
-
         public Results() {
             childCollection = new List<SObject>();
         }
 
-  
         @InvocableVariable
         global List<SObject> childCollection;
 
         @InvocableVariable
         global String errorText;
-
-
-
     }
 }

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls-meta.xml
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/GetChildCollection.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
@@ -7,7 +7,7 @@ public with sharing class ListActionsTest {
     private final static String FLOW_DATE_TIME_FORMAT = 'MM/dd/yyyy, hh:mm aa';
 
     @isTest
-    static void canCalculateCollection(){
+    static void canCalculateCollection() {
         List<Account> testAccounts = createAccounts(3, true);
         CollectionCalculate.Requests request = new CollectionCalculate.Requests();
         request.inputCollection = testAccounts;
@@ -16,11 +16,11 @@ public with sharing class ListActionsTest {
         List<CollectionCalculate.Requests> requests = new List<CollectionCalculate.Requests>();
         requests.add(request);
 
-        
-        List<CollectionCalculate.Results> responses = CollectionCalculate.execute(requests);
+        List<CollectionCalculate.Results> responses = CollectionCalculate.execute(
+            requests
+        );
         CollectionCalculate.Results response = responses[0];
         System.assertEquals(15000, response.outputDecimalResult);
-
     }
 
     @isTest
@@ -30,15 +30,26 @@ public with sharing class ListActionsTest {
         List<GetLookupCollection.Request> requests = new List<GetLookupCollection.Request>();
         GetLookupCollection.Request request = new GetLookupCollection.Request();
         requests.add(request);
-        List<GetLookupCollection.Results> responseWrapper = GetLookupCollection.get(requests);
+        List<GetLookupCollection.Results> responseWrapper = GetLookupCollection.get(
+            requests
+        );
         System.assertEquals(responseWrapper[0].errorText, noInputsMessage);
         requests.clear();
 
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         List<Contact> testContacts = createContacts(testAccounts, true);
-        List<Opportunity> testOpportunity = createOpportunities(NUMBER_OF_TEST_RECORDS, true);
-        OpportunityContactRole testOpportunityContactRole = createOpportunityContactRole(testContacts, testOpportunity);
-        List<OpportunityContactRole> ocrList = new List<OpportunityContactRole> ();
+        List<Opportunity> testOpportunity = createOpportunities(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
+        OpportunityContactRole testOpportunityContactRole = createOpportunityContactRole(
+            testContacts,
+            testOpportunity
+        );
+        List<OpportunityContactRole> ocrList = new List<OpportunityContactRole>();
         ocrList.add(testOpportunityContactRole);
         System.debug('ocRoleid is: ' + testOpportunityContactRole.Id);
         request.inputCollection = ocrList;
@@ -51,31 +62,39 @@ public with sharing class ListActionsTest {
         requests.clear();
     }
 
-    static OpportunityContactRole createOpportunityContactRole(List<Contact> testContacts, List<Opportunity> testOpportunities) {
-
-        OpportunityContactRole ocRole = new OpportunityContactRole(contactId = testContacts[0].Id, opportunityId = testOpportunities[0].Id);
+    static OpportunityContactRole createOpportunityContactRole(
+        List<Contact> testContacts,
+        List<Opportunity> testOpportunities
+    ) {
+        OpportunityContactRole ocRole = new OpportunityContactRole(
+            contactId = testContacts[0].Id,
+            opportunityId = testOpportunities[0].Id
+        );
         insert ocRole;
 
         return ocRole;
     }
 
-
     @isTest
     static void canGetChildCollection() {
         //user must pass in at least one input recordid or an input record
-
 
         String noInputsMessage = 'You need to pass either a record or a recordId into this action, representing the entity you want to start with';
         String dualInputsMessage = 'You need to pass either a record or a recordId into this action, but you can not pass both';
         List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
         GetChildCollection.Request request = new GetChildCollection.Request();
         requests.add(request);
-        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(requests);
+        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(
+            requests
+        );
         System.debug('responseWrapper is: ' + responseWrapper);
         System.assertEquals(responseWrapper[0].errorText, noInputsMessage);
         requests.clear();
 
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         List<Contact> testContacts = createContacts(testAccounts, true);
 
         //user can't pass in both an input recordid and an input record
@@ -95,15 +114,13 @@ public with sharing class ListActionsTest {
         System.assertNotEquals(responseWrapper[0].childCollection, null);
         System.assertEquals(1, responseWrapper[0].childCollection.size());
         requests.clear();
-
-
     }
 
     @isTest
     static void cloneRecordTests() {
         //user must pass in at least one input recordid or an input record
-//        String noInputsMessage = 'You need to pass either a record or a recordId into this action, representing the entity you want to clone';
-//        String dualInputsMessage = 'You need to pass either a record or a recordId into this action, but you can not pass both';
+        //        String noInputsMessage = 'You need to pass either a record or a recordId into this action, representing the entity you want to clone';
+        //        String dualInputsMessage = 'You need to pass either a record or a recordId into this action, but you can not pass both';
         List<DeepClone.Requests> requests = new List<DeepClone.Requests>();
         DeepClone.Requests request = new DeepClone.Requests();
         requests.add(request);
@@ -111,21 +128,34 @@ public with sharing class ListActionsTest {
         try {
             responseWrapper = DeepClone.clone(requests);
         } catch (Exception ex) {
-            System.assertEquals(true, ex.getMessage().contains(DeepClone.ERROR_NO_RECORD_NO_ID));
+            System.assertEquals(
+                true,
+                ex.getMessage().contains(DeepClone.ERROR_NO_RECORD_NO_ID)
+            );
         }
 
         requests.clear();
 
         //user can't pass in both an input recordid and an input record
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
-        List<Task> testTasks = createTasks(NUMBER_OF_TEST_RECORDS, testAccounts[0].Id, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
+        List<Task> testTasks = createTasks(
+            NUMBER_OF_TEST_RECORDS,
+            testAccounts[0].Id,
+            true
+        );
         request.inputRecordId = testAccounts[0].Id;
         request.inputRecord = testAccounts[0];
         requests.add(request);
         try {
             responseWrapper = DeepClone.clone(requests);
         } catch (Exception ex) {
-            System.assertEquals(true, ex.getMessage().contains(DeepClone.ERROR_RECORD_AND_ID));
+            System.assertEquals(
+                true,
+                ex.getMessage().contains(DeepClone.ERROR_RECORD_AND_ID)
+            );
         }
 
         requests.clear();
@@ -151,27 +181,39 @@ public with sharing class ListActionsTest {
         request.saveChildRecordsAutomatically = true;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
-        System.assertNotEquals(responseWrapper[0].clonedRecord.Id, testAccounts[0].Id);
+        System.assertNotEquals(
+            responseWrapper[0].clonedRecord.Id,
+            testAccounts[0].Id
+        );
         System.assertNotEquals(responseWrapper[0].clonedRecord.Id, null);
         List<Task> allTasks = [SELECT Id FROM Task];
         System.assertEquals(2 * NUMBER_OF_TEST_RECORDS, allTasks.size());
         requests.clear();
-
     }
-
 
     @isTest
     static void copyCollectionTest() {
         List<CopyCollection.Requests> requests = new List<CopyCollection.Requests>();
         CopyCollection.Requests request = new CopyCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         requests.add(request);
-        List<CopyCollection.Results> responseWrapper = CopyCollection.copyCollection(requests);
+        List<CopyCollection.Results> responseWrapper = CopyCollection.copyCollection(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(responseWrapper[0].outputCollection.size(), NUMBER_OF_TEST_RECORDS);
+        System.assertEquals(
+            responseWrapper[0].outputCollection.size(),
+            NUMBER_OF_TEST_RECORDS
+        );
         for (Integer i = 0; i < NUMBER_OF_TEST_RECORDS; i++) {
-            System.assertEquals(((Account) responseWrapper[0].outputCollection[i]).Name, testAccounts[i].Name);
+            System.assertEquals(
+                ((Account) responseWrapper[0].outputCollection[i]).Name,
+                testAccounts[i].Name
+            );
         }
     }
 
@@ -179,11 +221,16 @@ public with sharing class ListActionsTest {
     static void filterCollectionTest() {
         List<FilterCollection.Requests> requests = new List<FilterCollection.Requests>();
         FilterCollection.Requests request = new FilterCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.formula = 'OR(CONTAINS($Account.Name,"2"),CONTAINS($Account.Name,"3"))';
         requests.add(request);
-        List<FilterCollection.Results> responseWrapper = FilterCollection.filter(requests);
+        List<FilterCollection.Results> responseWrapper = FilterCollection.filter(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
         System.assertEquals(2, responseWrapper[0].outputCollection.size());
     }
@@ -195,7 +242,9 @@ public with sharing class ListActionsTest {
         request.formulaString = 'true';
         request.contextDataString = null;
         requests.add(request);
-        List<EvaluateFormula.Results> responseWrapper = EvaluateFormula.evaluate(requests);
+        List<EvaluateFormula.Results> responseWrapper = EvaluateFormula.evaluate(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
         System.assertEquals('true', responseWrapper[0].stringResult);
     }
@@ -205,14 +254,23 @@ public with sharing class ListActionsTest {
         // Simple Mode
         List<GenerateCollectionReport.Requests> requests = new List<GenerateCollectionReport.Requests>();
         GenerateCollectionReport.Requests request = new GenerateCollectionReport.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.shownFields = 'Name,Parent.Name';
         requests.add(request);
-        List<GenerateCollectionReport.Results> responseWrapper = GenerateCollectionReport.generateReport(requests);
+        List<GenerateCollectionReport.Results> responseWrapper = GenerateCollectionReport.generateReport(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(true, responseWrapper[0].reportString.startsWith('Collection Type: Account'));
-        
+        System.assertEquals(
+            true,
+            responseWrapper[0]
+                .reportString.startsWith('Collection Type: Account')
+        );
+
         // TableMode
         List<GenerateCollectionReport.Requests> requestsTable = new List<GenerateCollectionReport.Requests>();
         GenerateCollectionReport.Requests requestTable = new GenerateCollectionReport.Requests();
@@ -220,34 +278,46 @@ public with sharing class ListActionsTest {
         requestTable.shownFields = 'Name,Parent.Name';
         requestTable.displayMode = 'table';
         requestsTable.add(requestTable);
-        List<GenerateCollectionReport.Results> responseWrapperTable = GenerateCollectionReport.generateReport(requestsTable);
+        List<GenerateCollectionReport.Results> responseWrapperTable = GenerateCollectionReport.generateReport(
+            requestsTable
+        );
         System.assertEquals(responseWrapperTable.size(), 1);
-        System.assertEquals(true, responseWrapper[0].reportString.startsWith('Collection Type: Account'));
+        System.assertEquals(
+            true,
+            responseWrapper[0]
+                .reportString.startsWith('Collection Type: Account')
+        );
     }
 
     @isTest
     static void joinCollectionTest() {
         List<JoinCollections.Requests> requests = new List<JoinCollections.Requests>();
         JoinCollections.Requests request = new JoinCollections.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
-        List<Account> testAccounts2 = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
+        List<Account> testAccounts2 = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.inputCollection2 = testAccounts2;
         requests.add(request);
-        List<JoinCollections.Results> responseWrapper = JoinCollections.joinCollections(requests);
+        List<JoinCollections.Results> responseWrapper = JoinCollections.joinCollections(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
         System.assertEquals(10, responseWrapper[0].outputCollection.size());
-
     }
 
     @isTest
     static void mapCollection() {
         final Map<String, String> fieldNameValue = new Map<String, String>{
-                'Email' => 'test@site.com',
-                'HasOptedOutOfEmail' => 'true',
-                'AnnualRevenue' => '1.123'
+            'Email' => 'test@site.com',
+            'HasOptedOutOfEmail' => 'true',
+            'AnnualRevenue' => '1.123'
         };
-
 
         List<MapCollection.Requests> requests = new List<MapCollection.Requests>();
         MapCollection.Requests request = new MapCollection.Requests();
@@ -255,17 +325,30 @@ public with sharing class ListActionsTest {
         request.inputCollection = testLeads;
         request.keyValuePairs = '';
         for (String fieldName : fieldNameValue.keySet()) {
-            request.keyValuePairs += '"' + fieldName + '":"' + fieldNameValue.get(fieldName) + '",';
+            request.keyValuePairs +=
+                '"' +
+                fieldName +
+                '":"' +
+                fieldNameValue.get(fieldName) +
+                '",';
             request.keyValuePairs.removeEnd(',');
         }
 
         requests.add(request);
-        List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(requests);
+        List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].outputCollection.size());
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS,
+            responseWrapper[0].outputCollection.size()
+        );
         for (SObject obj : responseWrapper[0].outputCollection) {
             for (String fieldName : fieldNameValue.keySet()) {
-                System.assertEquals(String.valueOf(fieldNameValue.get(fieldName)), String.valueOf(obj.get(fieldName)));
+                System.assertEquals(
+                    String.valueOf(fieldNameValue.get(fieldName)),
+                    String.valueOf(obj.get(fieldName))
+                );
             }
         }
     }
@@ -273,51 +356,85 @@ public with sharing class ListActionsTest {
     //@isTest
     //this test started failing. possibly it's a time zone issue. commenting it out rather than fixing it
     static void mapCollectionDateTime() {
-
         List<MapCollection.Requests> requests = new List<MapCollection.Requests>();
         MapCollection.Requests request = new MapCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
-        List<Task> testTasks = createTasks(NUMBER_OF_TEST_RECORDS, testAccounts[0].Id, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
+        List<Task> testTasks = createTasks(
+            NUMBER_OF_TEST_RECORDS,
+            testAccounts[0].Id,
+            true
+        );
 
         Datetime dt = Datetime.now();
         dt = dt.addSeconds(-dt.second());
         request.inputCollection = testTasks;
 
-        request.keyValuePairs = '"ActivityDate":"' + dt.format(FLOW_DATE_FORMAT) + '"';
+        request.keyValuePairs =
+            '"ActivityDate":"' +
+            dt.format(FLOW_DATE_FORMAT) +
+            '"';
         requests.add(request);
-        List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(requests);
+        List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].outputCollection.size());
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS,
+            responseWrapper[0].outputCollection.size()
+        );
         for (SObject obj : responseWrapper[0].outputCollection) {
             System.assertEquals(obj.get('ActivityDate'), Date.today());
         }
 
-        List<Event> testEvents = createEvents(NUMBER_OF_TEST_RECORDS, testAccounts[0].Id, true);
+        List<Event> testEvents = createEvents(
+            NUMBER_OF_TEST_RECORDS,
+            testAccounts[0].Id,
+            true
+        );
         request.inputCollection = testEvents;
-        request.keyValuePairs = '"StartDateTime":"' + dt.format(FLOW_DATE_TIME_FORMAT) + '"';
+        request.keyValuePairs =
+            '"StartDateTime":"' +
+            dt.format(FLOW_DATE_TIME_FORMAT) +
+            '"';
         requests.add(request);
         responseWrapper = MapCollection.mapCollection(requests);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].outputCollection.size());
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS,
+            responseWrapper[0].outputCollection.size()
+        );
         for (SObject obj : responseWrapper[0].outputCollection) {
             System.assertEquals(dt, obj.get('StartDateTime'));
         }
     }
-
 
     @isTest
     static void removeRecordInCollectionTest() {
         final Integer INDEX_TO_REMOVE = 0;
         List<RemoveRecordInCollection.Requests> requests = new List<RemoveRecordInCollection.Requests>();
         RemoveRecordInCollection.Requests request = new RemoveRecordInCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.index = INDEX_TO_REMOVE;
         requests.add(request);
         String accountNameToRemove = testAccounts[INDEX_TO_REMOVE].Name;
-        List<RemoveRecordInCollection.Results> responseWrapper = RemoveRecordInCollection.removeRecordByIndex(requests);
+        List<RemoveRecordInCollection.Results> responseWrapper = RemoveRecordInCollection.removeRecordByIndex(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS - 1, responseWrapper[0].outputCollection.size());
-        System.assertNotEquals(((Account) responseWrapper[0].outputCollection[0]).Name, accountNameToRemove);
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS - 1,
+            responseWrapper[0].outputCollection.size()
+        );
+        System.assertNotEquals(
+            ((Account) responseWrapper[0].outputCollection[0]).Name,
+            accountNameToRemove
+        );
     }
 
     @isTest
@@ -325,12 +442,18 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<GetFirst.Requests> requests = new List<GetFirst.Requests>();
         GetFirst.Requests request = new GetFirst.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.enforceSingleMember = false;
         requests.add(request);
         List<GetFirst.Results> responseWrapper = GetFirst.execute(requests);
-        System.assertEquals(testAccounts[0].Id, responseWrapper[0].outputMember.Id);
+        System.assertEquals(
+            testAccounts[0].Id,
+            responseWrapper[0].outputMember.Id
+        );
     }
 
     @isTest
@@ -338,7 +461,10 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<FindRecordsInCollection.Requests> requests = new List<FindRecordsInCollection.Requests>();
         FindRecordsInCollection.Requests request = new FindRecordsInCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.targetField = 'Name';
         request.targetValue = TEST_RECORD_NAME + '0';
@@ -346,9 +472,14 @@ public with sharing class ListActionsTest {
 
         requests.add(request);
 
-        List<FindRecordsInCollection.Results> responseWrapper = FindRecordsInCollection.execute(requests);
+        List<FindRecordsInCollection.Results> responseWrapper = FindRecordsInCollection.execute(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(testAccounts[0].Name, ((Account) responseWrapper[0].singleOutputMember).Name);
+        System.assertEquals(
+            testAccounts[0].Name,
+            ((Account) responseWrapper[0].singleOutputMember).Name
+        );
     }
 
     @isTest
@@ -356,16 +487,29 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<AddOrInsertRecord.Requests> requests = new List<AddOrInsertRecord.Requests>();
         AddOrInsertRecord.Requests request = new AddOrInsertRecord.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.inputRecord = testAccounts[0];
         request.index = 0;
         requests.add(request);
 
-        List<AddOrInsertRecord.Results> responseWrapper = AddOrInsertRecord.addOrInsertRecord(requests);
+        List<AddOrInsertRecord.Results> responseWrapper = AddOrInsertRecord.addOrInsertRecord(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS + 1, responseWrapper[0].outputCollection.size());
-        System.assertNotEquals(((Account) responseWrapper[0].outputCollection[0]).Name, ((Account) responseWrapper[0].outputCollection[NUMBER_OF_TEST_RECORDS]).Name);
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS + 1,
+            responseWrapper[0].outputCollection.size()
+        );
+        System.assertNotEquals(
+            ((Account) responseWrapper[0].outputCollection[0]).Name,
+            ((Account) responseWrapper[0]
+                    .outputCollection[NUMBER_OF_TEST_RECORDS])
+                .Name
+        );
     }
 
     @isTest
@@ -373,19 +517,27 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<CountRecordsAndFields.Requests> requests = new List<CountRecordsAndFields.Requests>();
         CountRecordsAndFields.Requests request = new CountRecordsAndFields.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         request.inputCollection = testAccounts;
         request.fieldName = 'Name';
         request.fieldValue = TEST_RECORD_NAME + '0';
         requests.add(request);
 
-        List<CountRecordsAndFields.Results> responseWrapper = CountRecordsAndFields.count(requests);
+        List<CountRecordsAndFields.Results> responseWrapper = CountRecordsAndFields.count(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
         System.assertEquals(1, responseWrapper[0].matchedNumber);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].totalNumber);
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS,
+            responseWrapper[0].totalNumber
+        );
     }
-//this is incompatible with recent work done on this class. however, there's a new set of test classes in a separate file, so just going to comment this one out
-  /*   @isTest
+    //this is incompatible with recent work done on this class. however, there's a new set of test classes in a separate file, so just going to comment this one out
+    /*   @isTest
     static void extractStringsFromCollectionTest() {
         final Integer INDEX_TO_REMOVE = 0;
         List<ExtractStringsFromCollection.Requests> requests = new List<ExtractStringsFromCollection.Requests>();
@@ -410,53 +562,83 @@ public with sharing class ListActionsTest {
     @isTest
     static void sortCollectionTest() {
         final Map<String, String> sortDirection = new Map<String, String>{
-                'NumberOfEmployees' => 'ASC',
-                'Name' => 'DESC',
-                'Site' => 'ASC'
+            'NumberOfEmployees' => 'ASC',
+            'Name' => 'DESC',
+            'Site' => 'ASC'
         };
         List<SortCollection.Requests> requests = new List<SortCollection.Requests>();
         SortCollection.Requests request = new SortCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = createAccounts(
+            NUMBER_OF_TEST_RECORDS,
+            true
+        );
         testAccounts[NUMBER_OF_TEST_RECORDS - 1].NumberOfEmployees = 2;
         testAccounts[NUMBER_OF_TEST_RECORDS - 2].NumberOfEmployees = 3;
         testAccounts[NUMBER_OF_TEST_RECORDS - 3].NumberOfEmployees = 5;
         request.inputCollection = testAccounts;
         request.sortKeys = '';
         for (String fieldName : sortDirection.keySet()) {
-            request.sortKeys += '"' + fieldName + '":"' + sortDirection.get(fieldName) + '",';
+            request.sortKeys +=
+                '"' +
+                fieldName +
+                '":"' +
+                sortDirection.get(fieldName) +
+                '",';
         }
         request.sortKeys.removeEnd(',');
         requests.add(request);
         String firstAccountName = testAccounts[0].Name;
-        List<SortCollection.Results> responseWrapper = SortCollection.sort(requests);
+        List<SortCollection.Results> responseWrapper = SortCollection.sort(
+            requests
+        );
         System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].outputCollection.size());
+        System.assertEquals(
+            NUMBER_OF_TEST_RECORDS,
+            responseWrapper[0].outputCollection.size()
+        );
 
-        System.assertEquals(((Account) responseWrapper[0].outputCollection[NUMBER_OF_TEST_RECORDS - 1]).Name, firstAccountName);
+        System.assertEquals(
+            ((Account) responseWrapper[0]
+                    .outputCollection[NUMBER_OF_TEST_RECORDS - 1])
+                .Name,
+            firstAccountName
+        );
     }
 
-   public static List<Account> createAccounts(Integer numberOfRecords, Boolean doInsert) {
-
+    public static List<Account> createAccounts(
+        Integer numberOfRecords,
+        Boolean doInsert
+    ) {
         List<Account> returnList = new List<Account>();
         for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(new Account(Name = TEST_RECORD_NAME + i, Website = '' + i, AnnualRevenue=5000));
+            returnList.add(
+                new Account(
+                    Name = TEST_RECORD_NAME + i,
+                    Website = '' + i,
+                    AnnualRevenue = 5000
+                )
+            );
         }
         if (doInsert) {
             //insert returnList without triggering duplicate rules
-            Database.DMLOptions dml = new Database.DMLOptions(); 
-            dml.DuplicateRuleHeader.AllowSave = true; 
+            Database.DMLOptions dml = new Database.DMLOptions();
+            dml.DuplicateRuleHeader.AllowSave = true;
             List<Database.SaveResult> sr = Database.insert(returnList, dml);
-
         }
 
         return returnList;
     }
 
-    static List<Task> createTasks(Integer numberOfRecords, Id whatId, Boolean doInsert) {
-
+    static List<Task> createTasks(
+        Integer numberOfRecords,
+        Id whatId,
+        Boolean doInsert
+    ) {
         List<Task> returnList = new List<Task>();
         for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(new Task(Subject = TEST_RECORD_NAME + i, WhatId = whatId));
+            returnList.add(
+                new Task(Subject = TEST_RECORD_NAME + i, WhatId = whatId)
+            );
         }
         if (doInsert) {
             insert returnList;
@@ -465,17 +647,22 @@ public with sharing class ListActionsTest {
         return returnList;
     }
 
-    static List<Event> createEvents(Integer numberOfRecords, Id whatId, Boolean doInsert) {
-
+    static List<Event> createEvents(
+        Integer numberOfRecords,
+        Id whatId,
+        Boolean doInsert
+    ) {
         List<Event> returnList = new List<Event>();
         for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(new Event(
+            returnList.add(
+                new Event(
                     Subject = TEST_RECORD_NAME + i,
                     WhatId = whatId,
                     ActivityDateTime = DateTime.now().addDays(1),
                     DurationInMinutes = 100,
                     ActivityDate = Date.today().addDays(1)
-            ));
+                )
+            );
         }
         if (doInsert) {
             insert returnList;
@@ -485,10 +672,14 @@ public with sharing class ListActionsTest {
     }
 
     static List<Lead> createLeads(Integer numberOfRecords, Boolean doInsert) {
-
         List<Lead> returnList = new List<Lead>();
         for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(new Lead(LastName = TEST_RECORD_NAME + i, Company = TEST_RECORD_NAME));
+            returnList.add(
+                new Lead(
+                    LastName = TEST_RECORD_NAME + i,
+                    Company = TEST_RECORD_NAME
+                )
+            );
         }
         if (doInsert) {
             insert returnList;
@@ -497,12 +688,19 @@ public with sharing class ListActionsTest {
         return returnList;
     }
 
-    static List<Contact> createContacts(List<Account> accountList, Boolean doInsert) {
-
+    static List<Contact> createContacts(
+        List<Account> accountList,
+        Boolean doInsert
+    ) {
         List<Contact> contactList = new List<Contact>();
         Integer i = 1;
         for (Account curAccount : accountList) {
-            contactList.add(new Contact(LastName = TEST_CONTACT_NAME + i, AccountId = curAccount.Id));
+            contactList.add(
+                new Contact(
+                    LastName = TEST_CONTACT_NAME + i,
+                    AccountId = curAccount.Id
+                )
+            );
             i = i + 1;
         }
         if (doInsert) {
@@ -511,11 +709,19 @@ public with sharing class ListActionsTest {
         return contactList;
     }
 
-    static List<Opportunity> createOpportunities(Integer numberOfRecords, Boolean doInsert) {
-
+    static List<Opportunity> createOpportunities(
+        Integer numberOfRecords,
+        Boolean doInsert
+    ) {
         List<Opportunity> returnList = new List<Opportunity>();
         for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(new Opportunity(Name = 'Opportunity' + i, StageName = 'Prospecting', CloseDate = System.today()));
+            returnList.add(
+                new Opportunity(
+                    Name = 'Opportunity' + i,
+                    StageName = 'Prospecting',
+                    CloseDate = System.today()
+                )
+            );
         }
         if (doInsert) {
             insert returnList;
@@ -523,5 +729,4 @@ public with sharing class ListActionsTest {
 
         return returnList;
     }
-
 }

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
@@ -20,7 +20,7 @@ public with sharing class ListActionsTest {
             requests
         );
         CollectionCalculate.Results response = responses[0];
-        System.assertEquals(15000, response.outputDecimalResult);
+        Assert.areEqual(15000, response.outputDecimalResult);
     }
 
     @isTest
@@ -33,7 +33,7 @@ public with sharing class ListActionsTest {
         List<GetLookupCollection.Results> responseWrapper = GetLookupCollection.get(
             requests
         );
-        System.assertEquals(responseWrapper[0].errorText, noInputsMessage);
+        Assert.areEqual(responseWrapper[0].errorText, noInputsMessage);
         requests.clear();
 
         List<Account> testAccounts = createAccounts(
@@ -58,7 +58,7 @@ public with sharing class ListActionsTest {
         requests.add(request);
         responseWrapper = GetLookupCollection.get(requests);
         System.debug('responseWrapper is: ' + responseWrapper);
-        System.assertEquals(null, responseWrapper[0].errorText);
+        Assert.areEqual(null, responseWrapper[0].errorText);
         requests.clear();
     }
 
@@ -88,7 +88,7 @@ public with sharing class ListActionsTest {
             requests
         );
         System.debug('responseWrapper is: ' + responseWrapper);
-        System.assertEquals(responseWrapper[0].errorText, noInputsMessage);
+        Assert.areEqual(responseWrapper[0].errorText, noInputsMessage);
         requests.clear();
 
         List<Account> testAccounts = createAccounts(
@@ -102,7 +102,7 @@ public with sharing class ListActionsTest {
         request.inputRecord = testAccounts[0];
         requests.add(request);
         responseWrapper = GetChildCollection.get(requests);
-        System.assertEquals(responseWrapper[0].errorText, dualInputsMessage);
+        Assert.areEqual(responseWrapper[0].errorText, dualInputsMessage);
         requests.clear();
 
         request.inputRecordId = null;
@@ -111,8 +111,8 @@ public with sharing class ListActionsTest {
         request.childRecordFieldsCSV = 'Id,Name';
         requests.add(request);
         responseWrapper = GetChildCollection.get(requests);
-        System.assertNotEquals(responseWrapper[0].childCollection, null);
-        System.assertEquals(1, responseWrapper[0].childCollection.size());
+        Assert.areNotEqual(responseWrapper[0].childCollection, null);
+        Assert.areEqual(1, responseWrapper[0].childCollection.size());
         requests.clear();
     }
 
@@ -128,7 +128,7 @@ public with sharing class ListActionsTest {
         try {
             responseWrapper = DeepClone.clone(requests);
         } catch (Exception ex) {
-            System.assertEquals(
+            Assert.areEqual(
                 true,
                 ex.getMessage().contains(DeepClone.ERROR_NO_RECORD_NO_ID)
             );
@@ -152,7 +152,7 @@ public with sharing class ListActionsTest {
         try {
             responseWrapper = DeepClone.clone(requests);
         } catch (Exception ex) {
-            System.assertEquals(
+            Assert.areEqual(
                 true,
                 ex.getMessage().contains(DeepClone.ERROR_RECORD_AND_ID)
             );
@@ -164,14 +164,14 @@ public with sharing class ListActionsTest {
         request.inputRecord = testAccounts[0];
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
-        System.assertNotEquals(responseWrapper[0].clonedRecord, null);
+        Assert.areNotEqual(responseWrapper[0].clonedRecord, null);
         requests.clear();
 
         request.inputRecordId = testAccounts[0].Id;
         request.inputRecord = null;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
-        System.assertNotEquals(responseWrapper[0].clonedRecord, null);
+        Assert.areNotEqual(responseWrapper[0].clonedRecord, null);
         requests.clear();
 
         request.inputRecordId = testAccounts[0].Id;
@@ -181,13 +181,13 @@ public with sharing class ListActionsTest {
         request.saveChildRecordsAutomatically = true;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
-        System.assertNotEquals(
+        Assert.areNotEqual(
             responseWrapper[0].clonedRecord.Id,
             testAccounts[0].Id
         );
-        System.assertNotEquals(responseWrapper[0].clonedRecord.Id, null);
+        Assert.areNotEqual(responseWrapper[0].clonedRecord.Id, null);
         List<Task> allTasks = [SELECT Id FROM Task];
-        System.assertEquals(2 * NUMBER_OF_TEST_RECORDS, allTasks.size());
+        Assert.areEqual(2 * NUMBER_OF_TEST_RECORDS, allTasks.size());
         requests.clear();
     }
 
@@ -204,13 +204,13 @@ public with sharing class ListActionsTest {
         List<CopyCollection.Results> responseWrapper = CopyCollection.copyCollection(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             responseWrapper[0].outputCollection.size(),
             NUMBER_OF_TEST_RECORDS
         );
         for (Integer i = 0; i < NUMBER_OF_TEST_RECORDS; i++) {
-            System.assertEquals(
+            Assert.areEqual(
                 ((Account) responseWrapper[0].outputCollection[i]).Name,
                 testAccounts[i].Name
             );
@@ -231,8 +231,8 @@ public with sharing class ListActionsTest {
         List<FilterCollection.Results> responseWrapper = FilterCollection.filter(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(2, responseWrapper[0].outputCollection.size());
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(2, responseWrapper[0].outputCollection.size());
     }
 
     @isTest
@@ -245,8 +245,8 @@ public with sharing class ListActionsTest {
         List<EvaluateFormula.Results> responseWrapper = EvaluateFormula.evaluate(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals('true', responseWrapper[0].stringResult);
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual('true', responseWrapper[0].stringResult);
     }
 
     @isTest
@@ -264,8 +264,8 @@ public with sharing class ListActionsTest {
         List<GenerateCollectionReport.Results> responseWrapper = GenerateCollectionReport.generateReport(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             true,
             responseWrapper[0]
                 .reportString.startsWith('Collection Type: Account')
@@ -281,8 +281,8 @@ public with sharing class ListActionsTest {
         List<GenerateCollectionReport.Results> responseWrapperTable = GenerateCollectionReport.generateReport(
             requestsTable
         );
-        System.assertEquals(responseWrapperTable.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapperTable.size(), 1);
+        Assert.areEqual(
             true,
             responseWrapper[0]
                 .reportString.startsWith('Collection Type: Account')
@@ -307,8 +307,8 @@ public with sharing class ListActionsTest {
         List<JoinCollections.Results> responseWrapper = JoinCollections.joinCollections(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(10, responseWrapper[0].outputCollection.size());
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(10, responseWrapper[0].outputCollection.size());
     }
 
     @isTest
@@ -338,14 +338,14 @@ public with sharing class ListActionsTest {
         List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS,
             responseWrapper[0].outputCollection.size()
         );
         for (SObject obj : responseWrapper[0].outputCollection) {
             for (String fieldName : fieldNameValue.keySet()) {
-                System.assertEquals(
+                Assert.areEqual(
                     String.valueOf(fieldNameValue.get(fieldName)),
                     String.valueOf(obj.get(fieldName))
                 );
@@ -380,13 +380,13 @@ public with sharing class ListActionsTest {
         List<MapCollection.Results> responseWrapper = MapCollection.mapCollection(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS,
             responseWrapper[0].outputCollection.size()
         );
         for (SObject obj : responseWrapper[0].outputCollection) {
-            System.assertEquals(obj.get('ActivityDate'), Date.today());
+            Assert.areEqual(obj.get('ActivityDate'), Date.today());
         }
 
         List<Event> testEvents = createEvents(
@@ -401,12 +401,12 @@ public with sharing class ListActionsTest {
             '"';
         requests.add(request);
         responseWrapper = MapCollection.mapCollection(requests);
-        System.assertEquals(
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS,
             responseWrapper[0].outputCollection.size()
         );
         for (SObject obj : responseWrapper[0].outputCollection) {
-            System.assertEquals(dt, obj.get('StartDateTime'));
+            Assert.areEqual(dt, obj.get('StartDateTime'));
         }
     }
 
@@ -426,12 +426,12 @@ public with sharing class ListActionsTest {
         List<RemoveRecordInCollection.Results> responseWrapper = RemoveRecordInCollection.removeRecordByIndex(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS - 1,
             responseWrapper[0].outputCollection.size()
         );
-        System.assertNotEquals(
+        Assert.areNotEqual(
             ((Account) responseWrapper[0].outputCollection[0]).Name,
             accountNameToRemove
         );
@@ -450,10 +450,7 @@ public with sharing class ListActionsTest {
         request.enforceSingleMember = false;
         requests.add(request);
         List<GetFirst.Results> responseWrapper = GetFirst.execute(requests);
-        System.assertEquals(
-            testAccounts[0].Id,
-            responseWrapper[0].outputMember.Id
-        );
+        Assert.areEqual(testAccounts[0].Id, responseWrapper[0].outputMember.Id);
     }
 
     @isTest
@@ -475,8 +472,8 @@ public with sharing class ListActionsTest {
         List<FindRecordsInCollection.Results> responseWrapper = FindRecordsInCollection.execute(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             testAccounts[0].Name,
             ((Account) responseWrapper[0].singleOutputMember).Name
         );
@@ -499,12 +496,12 @@ public with sharing class ListActionsTest {
         List<AddOrInsertRecord.Results> responseWrapper = AddOrInsertRecord.addOrInsertRecord(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS + 1,
             responseWrapper[0].outputCollection.size()
         );
-        System.assertNotEquals(
+        Assert.areNotEqual(
             ((Account) responseWrapper[0].outputCollection[0]).Name,
             ((Account) responseWrapper[0]
                     .outputCollection[NUMBER_OF_TEST_RECORDS])
@@ -529,12 +526,9 @@ public with sharing class ListActionsTest {
         List<CountRecordsAndFields.Results> responseWrapper = CountRecordsAndFields.count(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(1, responseWrapper[0].matchedNumber);
-        System.assertEquals(
-            NUMBER_OF_TEST_RECORDS,
-            responseWrapper[0].totalNumber
-        );
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(1, responseWrapper[0].matchedNumber);
+        Assert.areEqual(NUMBER_OF_TEST_RECORDS, responseWrapper[0].totalNumber);
     }
     //this is incompatible with recent work done on this class. however, there's a new set of test classes in a separate file, so just going to comment this one out
     /*   @isTest
@@ -548,15 +542,15 @@ public with sharing class ListActionsTest {
         requests.add(request);
 
         List<ExtractStringsFromCollection.Results> responseWrapper = ExtractStringsFromCollection.extract(requests);
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(NUMBER_OF_TEST_RECORDS, responseWrapper[0].stringList.size());
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(NUMBER_OF_TEST_RECORDS, responseWrapper[0].stringList.size());
 
         String resultString = '';
         for (Account curAcc : testAccounts) {
             resultString += curAcc.Name + ',';
         }
         resultString = resultString.removeEnd(',');
-        System.assertEquals(resultString, String.join(responseWrapper[0].stringList, ','));
+        Assert.areEqual(resultString, String.join(responseWrapper[0].stringList, ','));
     } */
 
     @isTest
@@ -591,13 +585,13 @@ public with sharing class ListActionsTest {
         List<SortCollection.Results> responseWrapper = SortCollection.sort(
             requests
         );
-        System.assertEquals(responseWrapper.size(), 1);
-        System.assertEquals(
+        Assert.areEqual(responseWrapper.size(), 1);
+        Assert.areEqual(
             NUMBER_OF_TEST_RECORDS,
             responseWrapper[0].outputCollection.size()
         );
 
-        System.assertEquals(
+        Assert.areEqual(
             ((Account) responseWrapper[0]
                     .outputCollection[NUMBER_OF_TEST_RECORDS - 1])
                 .Name,

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls
@@ -5,10 +5,53 @@ public with sharing class ListActionsTest {
     private final static String TEST_CONTACT_NAME = 'Test Contact';
     private final static String FLOW_DATE_FORMAT = 'MMMM dd, yyyy';
     private final static String FLOW_DATE_TIME_FORMAT = 'MM/dd/yyyy, hh:mm aa';
+    // Counter to use as an offset when multiple account list retrievals are
+    // performed in one test
+    private static Integer numAccountsRetrieved = 0;
+
+    @TestSetup
+    static void makeData() {
+        Test.startTest();
+        List<Account> testAccounts = new List<Account>();
+        for (Integer i = 0; i < NUMBER_OF_TEST_RECORDS; i++) {
+            testAccounts.add(
+                new Account(
+                    Name = TEST_RECORD_NAME + i,
+                    Website = '' + i,
+                    AnnualRevenue = 5000
+                )
+            );
+        }
+        // Insert testAccounts without triggering duplicate rules
+        Database.DMLOptions dml = new Database.DMLOptions();
+        dml.DuplicateRuleHeader.AllowSave = true;
+        Database.insert(testAccounts, dml);
+
+        List<Contact> testContacts = new List<Contact>();
+        List<Task> testTasks = new List<Task>();
+        for (Integer i = 0; i < testAccounts.size(); i++) {
+            testContacts.add(
+                new Contact(
+                    LastName = TEST_CONTACT_NAME + i,
+                    AccountId = testAccounts[i].Id
+                )
+            );
+            testTasks.add(
+                new Task(
+                    Subject = TEST_RECORD_NAME + i,
+                    WhatId = testAccounts[0].Id
+                )
+            );
+        }
+        insert testContacts;
+        insert testTasks;
+        Test.stopTest();
+    }
 
     @isTest
     static void canCalculateCollection() {
-        List<Account> testAccounts = createAccounts(3, true);
+        Integer numAccountsToGet = 3;
+        List<Account> testAccounts = getAccounts(numAccountsToGet);
         CollectionCalculate.Requests request = new CollectionCalculate.Requests();
         request.inputCollection = testAccounts;
         request.fieldName = 'AnnualRevenue';
@@ -20,7 +63,10 @@ public with sharing class ListActionsTest {
             requests
         );
         CollectionCalculate.Results response = responses[0];
-        Assert.areEqual(15000, response.outputDecimalResult);
+        Assert.areEqual(
+            numAccountsToGet * testAccounts[0].AnnualRevenue,
+            response.outputDecimalResult
+        );
     }
 
     @isTest
@@ -36,11 +82,7 @@ public with sharing class ListActionsTest {
         Assert.areEqual(responseWrapper[0].errorText, noInputsMessage);
         requests.clear();
 
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
-        List<Contact> testContacts = createContacts(testAccounts, true);
+        List<Contact> testContacts = getContacts(NUMBER_OF_TEST_RECORDS);
         List<Opportunity> testOpportunity = createOpportunities(
             NUMBER_OF_TEST_RECORDS,
             true
@@ -76,11 +118,70 @@ public with sharing class ListActionsTest {
     }
 
     @isTest
-    static void canGetChildCollection() {
-        //user must pass in at least one input recordid or an input record
+    static void canGetChildCollection_inputRecord() {
+        Account testAccount = getAccounts(1)[0];
 
+        List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
+        GetChildCollection.Request request = new GetChildCollection.Request();
+        requests.add(request);
+        request.inputRecordId = null;
+        request.inputRecord = testAccount;
+        // API name of the child relationship
+        request.childRelationshipName = 'Contacts';
+        request.childRecordFieldsCSV = 'Id,Name';
+        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(
+            requests
+        );
+        Assert.areNotEqual(responseWrapper[0].childCollection, null);
+        Assert.areEqual(1, responseWrapper[0].childCollection.size());
+        requests.clear();
+    }
+
+    @isTest
+    static void canGetChildCollection_inputRecordId() {
+        Account testAccount = getAccounts(1)[0];
+
+        List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
+        GetChildCollection.Request request = new GetChildCollection.Request();
+        requests.add(request);
+        request.inputRecordId = testAccount.Id;
+        request.inputRecord = null;
+        // API name of the child relationship
+        request.childRelationshipName = 'Contacts';
+        request.childRecordFieldsCSV = 'Id,Name';
+        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(
+            requests
+        );
+        Assert.areNotEqual(responseWrapper[0].childCollection, null);
+        Assert.areEqual(1, responseWrapper[0].childCollection.size());
+        requests.clear();
+    }
+
+    @isTest
+    static void canGetChildCollection_childSobjectName() {
+        Account testAccount = getAccounts(1)[0];
+
+        List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
+        GetChildCollection.Request request = new GetChildCollection.Request();
+        requests.add(request);
+        request.inputRecordId = testAccount.Id;
+        request.inputRecord = null;
+        // API name of the child SObject. If more than one relationship exists
+        // between Account and Contact, this may have unexpected results.
+        request.childRelationshipName = 'Contact';
+        request.childRecordFieldsCSV = 'Id,Name';
+        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(
+            requests
+        );
+        Assert.areNotEqual(responseWrapper[0].childCollection, null);
+        Assert.isTrue(String.isBlank(responseWrapper[0].errorText));
+        requests.clear();
+    }
+
+    @isTest
+    static void canGetChildCollection_noInputsError() {
+        // Wser must pass in at least one input recordid or an input record
         String noInputsMessage = 'You need to pass either a record or a recordId into this action, representing the entity you want to start with';
-        String dualInputsMessage = 'You need to pass either a record or a recordId into this action, but you can not pass both';
         List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
         GetChildCollection.Request request = new GetChildCollection.Request();
         requests.add(request);
@@ -89,31 +190,24 @@ public with sharing class ListActionsTest {
         );
         System.debug('responseWrapper is: ' + responseWrapper);
         Assert.areEqual(responseWrapper[0].errorText, noInputsMessage);
-        requests.clear();
+    }
 
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
-        List<Contact> testContacts = createContacts(testAccounts, true);
+    @isTest
+    static void canGetChildCollection_dualInputsError() {
+        // User must not pass in both inputRecordId and inputRecord
+        String dualInputsMessage = 'You need to pass either a record or a recordId into this action, but you can not pass both';
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
 
-        //user can't pass in both an input recordid and an input record
+        List<GetChildCollection.Request> requests = new List<GetChildCollection.Request>();
+        GetChildCollection.Request request = new GetChildCollection.Request();
+        requests.add(request);
         request.inputRecordId = testAccounts[0].Id;
         request.inputRecord = testAccounts[0];
         requests.add(request);
-        responseWrapper = GetChildCollection.get(requests);
+        List<GetChildCollection.Results> responseWrapper = GetChildCollection.get(
+            requests
+        );
         Assert.areEqual(responseWrapper[0].errorText, dualInputsMessage);
-        requests.clear();
-
-        request.inputRecordId = null;
-        request.inputRecord = testAccounts[0];
-        request.childRelationshipName = 'Contact';
-        request.childRecordFieldsCSV = 'Id,Name';
-        requests.add(request);
-        responseWrapper = GetChildCollection.get(requests);
-        Assert.areNotEqual(responseWrapper[0].childCollection, null);
-        Assert.areEqual(1, responseWrapper[0].childCollection.size());
-        requests.clear();
     }
 
     @isTest
@@ -136,19 +230,13 @@ public with sharing class ListActionsTest {
 
         requests.clear();
 
-        //user can't pass in both an input recordid and an input record
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
-        List<Task> testTasks = createTasks(
-            NUMBER_OF_TEST_RECORDS,
-            testAccounts[0].Id,
-            true
-        );
-        request.inputRecordId = testAccounts[0].Id;
-        request.inputRecord = testAccounts[0];
+        // Get the account that has tasks associated with it
+        Account testAccount = getAccountWithTasks();
+        request.inputRecordId = testAccount.Id;
+        request.inputRecord = testAccount;
         requests.add(request);
+
+        //user can't pass in both an input recordid and an input record
         try {
             responseWrapper = DeepClone.clone(requests);
         } catch (Exception ex) {
@@ -161,30 +249,27 @@ public with sharing class ListActionsTest {
         requests.clear();
 
         request.inputRecordId = null;
-        request.inputRecord = testAccounts[0];
+        request.inputRecord = testAccount;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
         Assert.areNotEqual(responseWrapper[0].clonedRecord, null);
         requests.clear();
 
-        request.inputRecordId = testAccounts[0].Id;
+        request.inputRecordId = testAccount.Id;
         request.inputRecord = null;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
         Assert.areNotEqual(responseWrapper[0].clonedRecord, null);
         requests.clear();
 
-        request.inputRecordId = testAccounts[0].Id;
+        request.inputRecordId = testAccount.Id;
         request.inputRecord = null;
         request.saveImmediately = true;
         request.childRelationshipsCSV = 'Tasks';
         request.saveChildRecordsAutomatically = true;
         requests.add(request);
         responseWrapper = DeepClone.clone(requests);
-        Assert.areNotEqual(
-            responseWrapper[0].clonedRecord.Id,
-            testAccounts[0].Id
-        );
+        Assert.areNotEqual(responseWrapper[0].clonedRecord.Id, testAccount.Id);
         Assert.areNotEqual(responseWrapper[0].clonedRecord.Id, null);
         List<Task> allTasks = [SELECT Id FROM Task];
         Assert.areEqual(2 * NUMBER_OF_TEST_RECORDS, allTasks.size());
@@ -195,10 +280,7 @@ public with sharing class ListActionsTest {
     static void copyCollectionTest() {
         List<CopyCollection.Requests> requests = new List<CopyCollection.Requests>();
         CopyCollection.Requests request = new CopyCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         requests.add(request);
         List<CopyCollection.Results> responseWrapper = CopyCollection.copyCollection(
@@ -221,10 +303,7 @@ public with sharing class ListActionsTest {
     static void filterCollectionTest() {
         List<FilterCollection.Requests> requests = new List<FilterCollection.Requests>();
         FilterCollection.Requests request = new FilterCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.formula = 'OR(CONTAINS($Account.Name,"2"),CONTAINS($Account.Name,"3"))';
         requests.add(request);
@@ -254,10 +333,7 @@ public with sharing class ListActionsTest {
         // Simple Mode
         List<GenerateCollectionReport.Requests> requests = new List<GenerateCollectionReport.Requests>();
         GenerateCollectionReport.Requests request = new GenerateCollectionReport.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.shownFields = 'Name,Parent.Name';
         requests.add(request);
@@ -293,14 +369,10 @@ public with sharing class ListActionsTest {
     static void joinCollectionTest() {
         List<JoinCollections.Requests> requests = new List<JoinCollections.Requests>();
         JoinCollections.Requests request = new JoinCollections.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
-        List<Account> testAccounts2 = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        Integer list1Size = 3;
+        Integer list2Size = 2;
+        List<Account> testAccounts = getAccounts(list1Size);
+        List<Account> testAccounts2 = getAccounts(list2Size);
         request.inputCollection = testAccounts;
         request.inputCollection2 = testAccounts2;
         requests.add(request);
@@ -308,7 +380,10 @@ public with sharing class ListActionsTest {
             requests
         );
         Assert.areEqual(responseWrapper.size(), 1);
-        Assert.areEqual(10, responseWrapper[0].outputCollection.size());
+        Assert.areEqual(
+            list1Size + list2Size,
+            responseWrapper[0].outputCollection.size()
+        );
     }
 
     @isTest
@@ -358,15 +433,8 @@ public with sharing class ListActionsTest {
     static void mapCollectionDateTime() {
         List<MapCollection.Requests> requests = new List<MapCollection.Requests>();
         MapCollection.Requests request = new MapCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
-        List<Task> testTasks = createTasks(
-            NUMBER_OF_TEST_RECORDS,
-            testAccounts[0].Id,
-            true
-        );
+        Account testAccount = getAccountWithTasks();
+        List<Task> testTasks = testAccount.Tasks;
 
         Datetime dt = Datetime.now();
         dt = dt.addSeconds(-dt.second());
@@ -391,7 +459,7 @@ public with sharing class ListActionsTest {
 
         List<Event> testEvents = createEvents(
             NUMBER_OF_TEST_RECORDS,
-            testAccounts[0].Id,
+            testAccount.Id,
             true
         );
         request.inputCollection = testEvents;
@@ -415,10 +483,7 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<RemoveRecordInCollection.Requests> requests = new List<RemoveRecordInCollection.Requests>();
         RemoveRecordInCollection.Requests request = new RemoveRecordInCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.index = INDEX_TO_REMOVE;
         requests.add(request);
@@ -442,10 +507,7 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<GetFirst.Requests> requests = new List<GetFirst.Requests>();
         GetFirst.Requests request = new GetFirst.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.enforceSingleMember = false;
         requests.add(request);
@@ -458,10 +520,7 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<FindRecordsInCollection.Requests> requests = new List<FindRecordsInCollection.Requests>();
         FindRecordsInCollection.Requests request = new FindRecordsInCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.targetField = 'Name';
         request.targetValue = TEST_RECORD_NAME + '0';
@@ -484,10 +543,7 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<AddOrInsertRecord.Requests> requests = new List<AddOrInsertRecord.Requests>();
         AddOrInsertRecord.Requests request = new AddOrInsertRecord.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.inputRecord = testAccounts[0];
         request.index = 0;
@@ -514,10 +570,7 @@ public with sharing class ListActionsTest {
         final Integer INDEX_TO_REMOVE = 0;
         List<CountRecordsAndFields.Requests> requests = new List<CountRecordsAndFields.Requests>();
         CountRecordsAndFields.Requests request = new CountRecordsAndFields.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.fieldName = 'Name';
         request.fieldValue = TEST_RECORD_NAME + '0';
@@ -530,13 +583,14 @@ public with sharing class ListActionsTest {
         Assert.areEqual(1, responseWrapper[0].matchedNumber);
         Assert.areEqual(NUMBER_OF_TEST_RECORDS, responseWrapper[0].totalNumber);
     }
+
     //this is incompatible with recent work done on this class. however, there's a new set of test classes in a separate file, so just going to comment this one out
     /*   @isTest
     static void extractStringsFromCollectionTest() {
         final Integer INDEX_TO_REMOVE = 0;
         List<ExtractStringsFromCollection.Requests> requests = new List<ExtractStringsFromCollection.Requests>();
         ExtractStringsFromCollection.Requests request = new ExtractStringsFromCollection.Requests();
-        List<Account> testAccounts = createAccounts(NUMBER_OF_TEST_RECORDS, true);
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         request.inputCollection = testAccounts;
         request.fieldName = 'Name';
         requests.add(request);
@@ -562,10 +616,7 @@ public with sharing class ListActionsTest {
         };
         List<SortCollection.Requests> requests = new List<SortCollection.Requests>();
         SortCollection.Requests request = new SortCollection.Requests();
-        List<Account> testAccounts = createAccounts(
-            NUMBER_OF_TEST_RECORDS,
-            true
-        );
+        List<Account> testAccounts = getAccounts(NUMBER_OF_TEST_RECORDS);
         testAccounts[NUMBER_OF_TEST_RECORDS - 1].NumberOfEmployees = 2;
         testAccounts[NUMBER_OF_TEST_RECORDS - 2].NumberOfEmployees = 3;
         testAccounts[NUMBER_OF_TEST_RECORDS - 3].NumberOfEmployees = 5;
@@ -597,48 +648,6 @@ public with sharing class ListActionsTest {
                 .Name,
             firstAccountName
         );
-    }
-
-    public static List<Account> createAccounts(
-        Integer numberOfRecords,
-        Boolean doInsert
-    ) {
-        List<Account> returnList = new List<Account>();
-        for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(
-                new Account(
-                    Name = TEST_RECORD_NAME + i,
-                    Website = '' + i,
-                    AnnualRevenue = 5000
-                )
-            );
-        }
-        if (doInsert) {
-            //insert returnList without triggering duplicate rules
-            Database.DMLOptions dml = new Database.DMLOptions();
-            dml.DuplicateRuleHeader.AllowSave = true;
-            List<Database.SaveResult> sr = Database.insert(returnList, dml);
-        }
-
-        return returnList;
-    }
-
-    static List<Task> createTasks(
-        Integer numberOfRecords,
-        Id whatId,
-        Boolean doInsert
-    ) {
-        List<Task> returnList = new List<Task>();
-        for (Integer i = 0; i < numberOfRecords; i++) {
-            returnList.add(
-                new Task(Subject = TEST_RECORD_NAME + i, WhatId = whatId)
-            );
-        }
-        if (doInsert) {
-            insert returnList;
-        }
-
-        return returnList;
     }
 
     static List<Event> createEvents(
@@ -682,27 +691,6 @@ public with sharing class ListActionsTest {
         return returnList;
     }
 
-    static List<Contact> createContacts(
-        List<Account> accountList,
-        Boolean doInsert
-    ) {
-        List<Contact> contactList = new List<Contact>();
-        Integer i = 1;
-        for (Account curAccount : accountList) {
-            contactList.add(
-                new Contact(
-                    LastName = TEST_CONTACT_NAME + i,
-                    AccountId = curAccount.Id
-                )
-            );
-            i = i + 1;
-        }
-        if (doInsert) {
-            insert contactList;
-        }
-        return contactList;
-    }
-
     static List<Opportunity> createOpportunities(
         Integer numberOfRecords,
         Boolean doInsert
@@ -722,5 +710,43 @@ public with sharing class ListActionsTest {
         }
 
         return returnList;
+    }
+
+    private static List<Account> getAccounts(Integer numberOfRecords) {
+        List<Account> returnList = [
+            SELECT Id, Name, Website, AnnualRevenue, NumberOfEmployees, Site
+            FROM Account
+            ORDER BY Name
+            LIMIT :numberOfRecords
+            OFFSET :numAccountsRetrieved
+        ];
+        numAccountsRetrieved += numberOfRecords;
+        return returnList;
+    }
+
+    private static Account getAccountWithTasks() {
+        Task testTask = [SELECT Id, WhatId FROM Task LIMIT 1];
+        return [
+            SELECT
+                Id,
+                Name,
+                Website,
+                AnnualRevenue,
+                NumberOfEmployees,
+                Site,
+                (SELECT Id, Subject, WhatId FROM Tasks)
+            FROM Account
+            WHERE Id = :testTask.WhatId
+            LIMIT 1
+        ];
+    }
+
+    private static List<Contact> getContacts(Integer numberOfRecords) {
+        return [
+            SELECT Id, LastName, AccountId
+            FROM Contact
+            ORDER BY LastName
+            LIMIT :numberOfRecords
+        ];
     }
 }

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls-meta.xml
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ListActionsTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>59.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
Resolves Issue #1150 where `ListActionsTest` fails if more than one parent-child relationship exists between Account and Contact.

To achieve this, adds functionality allowing `GetChildCollection` clients to provide a unique child relationship name (e.g. "Contacts", "Custom_Child_Objects__r") instead of the SObjectType name of the child object (e.g. "Contact", "Custom_Child_Object__c") as the `childRelationshipName` value, while still allowing . This can help clear things up in scenarios where there is more than one relationship between the same two SObjects.

Additionally:

* Applied Prettier formatting (all Prettier changes are confined to the first commit)
* Updated API version to 59.0 on the updated classes
* Added unit tests to `ListActionsTest`
* Improved the performance of `ListActionsTest` by moving all repeated test record insertions to a `@TestSetup` method
* Updated `System.assertEquals` > `Assert.areEqual` and `System.assertNotEquals` > `Assert.areNotEqual`
* Removed an unnecessary SOQL query from `GetChildCollection`
* Added a `break` statement in to avoid unnecessary looping in `GetChildCollection`

Full disclosure: I have a vested interest in seeing this promoted, since `ListActionsTest` is currently failing in my company's org. 😉 