### PR TITLE
Reactivity and bug fixes for QuickChoice

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -6,7 +6,7 @@ const CB_ATTRIB_PREFIX = 'cb_';       // Used with fsc_flowCheckbox component
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.41';
+    versionNumber = '2.42';
     staticChoicesModalClass = 'staticChoicesModal';
     _builderContext;
     _values;

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -22,6 +22,7 @@ Additional components packaged with this LWC:
                             Clear the selected value if the options change on a reactive screen
                             ALlow "Add a 'None' Choice" option for all valid picklist methods
                             Added clarification to an error message that could appear if the component has conditional visibility on a screen that can be revisited.
+                            Fix the "Need a valid Input Mode. Didn't get one." error introduced in the prior release.
 
 7/23/23 -   Eric Smith -    Version 2.41 
                             Fixed default value being passed as output for reactivity

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -18,6 +18,11 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+12/04/23 -  Eric Smith -    Version 2.42
+                            Clear the selected value if the options change on a reactive screen
+                            ALlow "Add a 'None' Choice" option for all valid picklist methods
+                            Added clarification to an error message that could appear if the component has conditional visibility on a screen that can be revisited.
+
 7/23/23 -   Eric Smith -    Version 2.41 
                             Fixed default value being passed as output for reactivity
                             Added reactivity for choiceLabels, choiceValues & choiceIcons input attributes (updates require a change to choiceValues)

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -15,7 +15,14 @@ export default class QuickChoiceFSC extends LightningElement {
     @api
     availableActions = [];
 
-    @api masterLabel;
+    @api 
+    get masterLabel() {
+        return _masterLabel;
+    }
+    set masterLabel(ml_value) {
+        this._masterLabel = ml_value;
+    }
+    _masterLabel;
 
     @api helpText;
     get showHelpText() {
@@ -136,7 +143,7 @@ export default class QuickChoiceFSC extends LightningElement {
         return this._staticChoices || [];
     }
     set staticChoices(choices) {
-        console.log(this.masterLabel + ": ", 'setting staticChoices to '+ JSON.stringify(choices));
+        console.log(this._masterLabel + ": ", 'setting staticChoices to '+ JSON.stringify(choices));
         this._staticChoices = choices;
         this._choiceValues = [];
         this._choiceLabels = [];
@@ -254,7 +261,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     @api get radioGroup() {
-        return "RG-" + this.masterLabel + "_RG";
+        return "RG-" + this._masterLabel + "_RG";
     }
 
     set radioGroup(value) {
@@ -272,21 +279,21 @@ export default class QuickChoiceFSC extends LightningElement {
     })
     picklistValues({error, data}) {
         if (data) {
-            console.log(this.masterLabel + ": ", "getPicklistValues returned data", data);
+            console.log(this._masterLabel + ": ", "getPicklistValues returned data", data);
             this.setPicklistSelections(data);
             this.picklistFieldDetails = data;
         } else if (error) {
             this.error = JSON.stringify(error);
-            console.log(this.masterLabel + ": ", "getPicklistValues wire service returned error: " + this.error);
+            console.log(this._masterLabel + ": ", "getPicklistValues wire service returned error: " + this.error);
         }
     }
 
     get calculatedObjectAndFieldName() {
-        console.log(this.masterLabel + ": ", 'in getter: objectApiName is: ' + this.objectName);
-        console.log(this.masterLabel + ": ", 'in getter: fieldApiName is: ' + this.fieldName);
+        console.log(this._masterLabel + ": ", 'in getter: objectApiName is: ' + this.objectName);
+        console.log(this._masterLabel + ": ", 'in getter: fieldApiName is: ' + this.fieldName);
 
         if ((this.objectName) && (this.fieldName)) {
-            console.log(this.masterLabel + ": ", 'satisfied calculatedObjectAndFieldName test');
+            console.log(this._masterLabel + ": ", 'satisfied calculatedObjectAndFieldName test');
             return `${this.objectName}.${this.fieldName}`;
         }
         return undefined;
@@ -394,10 +401,10 @@ export default class QuickChoiceFSC extends LightningElement {
         let index = 0;
         if (this.displayMode === "Card" || this.displayMode === "Visual") {
             this.showVisual = true;
-            console.log(this.masterLabel + ": ", "includeIcons is: " + this.includeIcons);
-            console.log(this.masterLabel + ": ", "_choiceIcons is: " + this._choiceIcons);
+            console.log(this._masterLabel + ": ", "includeIcons is: " + this.includeIcons);
+            console.log(this._masterLabel + ": ", "_choiceIcons is: " + this._choiceIcons);
             if (!this.includeIcons || !this._choiceIcons) {
-                console.log(this.masterLabel + ": ", "icons not needed");
+                console.log(this._masterLabel + ": ", "icons not needed");
                 this._choiceIcons = this._choiceLabels;
             }
             if (this.numberOfColumns === "2") {
@@ -405,8 +412,8 @@ export default class QuickChoiceFSC extends LightningElement {
             }
 
             //User passes in Label collection of string for box header and Value collection of strings for box description
-            console.log(this.masterLabel + ": ", "entering input mode Visual Text Box");
-            console.log(this.masterLabel + ": ", "_choiceLabels is: " + this._choiceLabels);
+            console.log(this._masterLabel + ": ", "entering input mode Visual Text Box");
+            console.log(this._masterLabel + ": ", "_choiceLabels is: " + this._choiceLabels);
             this._choiceLabels.forEach(label => {
                 //Add the correct path to custom images
                 if (this._choiceIcons[index].includes(':')) {
@@ -418,12 +425,12 @@ export default class QuickChoiceFSC extends LightningElement {
                         icon: Quickchoice_Images + '/' + this._choiceIcons[index]
                     });
                 }
-                console.log(this.masterLabel + ": ", "items is: " + items);
+                console.log(this._masterLabel + ": ", "items is: " + items);
                 index += 1;
             });
         }
 
-        // console.log(this.masterLabel + ": ", "initializing QuickChoice. inputMode is: " + this._inputMode);
+        // console.log(this._masterLabel + ": ", "initializing QuickChoice. inputMode is: " + this._inputMode);
         let options = [];
         if (this.legitInputModes.includes(this._inputMode)) {
 
@@ -435,23 +442,23 @@ export default class QuickChoiceFSC extends LightningElement {
             switch (this._inputMode) {
                 //User can simply pass in a collection of strings as _choiceValues. The same text is used for both label and value
                 case "Single String Collection":
-                    console.log(this.masterLabel + ": ", "entering input mode String Collection");
-                    console.log(this.masterLabel + ": ", "_choiceValues is: " + this._choiceValues);
+                    console.log(this._masterLabel + ": ", "entering input mode String Collection");
+                    console.log(this._masterLabel + ": ", "_choiceValues is: " + this._choiceValues);
                     //console.log ('splitting choice values would be: ' + this._choiceValues.split(','));
                     //let values = this._choiceValues.split(';');
 
                     this._choiceValues.forEach(value => {
-                        console.log(this.masterLabel + ": ", "value is: " + value);
+                        console.log(this._masterLabel + ": ", "value is: " + value);
                         options.push({label: value, value: value});
-                        console.log(this.masterLabel + ": ", "options is: " + options);
+                        console.log(this._masterLabel + ": ", "options is: " + options);
                     });
                     break;
 
                 //User can  pass in one collection of strings for visible labels and another for the underlying values (such as recordIds)
                 case "Dual String Collections":
                 case "Static Choices":
-                    console.log(this.masterLabel + ": ", "entering input mode Dual String Collections");
-                    console.log(this.masterLabel + ": ", "_choiceValues is: " + this._choiceValues);
+                    console.log(this._masterLabel + ": ", "entering input mode Dual String Collections");
+                    console.log(this._masterLabel + ": ", "_choiceValues is: " + this._choiceValues);
                     for (let i=0; i<this._choiceLabels.length; i++) {
                         options.push({label: this._choiceLabels[i], value: this._choiceValues[i]});
                     }
@@ -471,19 +478,19 @@ export default class QuickChoiceFSC extends LightningElement {
             this.firstPassCompleted = true;     
 
         } else {
-            console.log(this.masterLabel + ": ", "QuickChoiceFSC: Need a valid Input Mode value. Didn't get one");
+            console.log(this._masterLabel + ": ", "QuickChoiceFSC: Need a valid Input Mode value. Didn't get one");
             throw new Error("QuickChoiceFSC: Need a valid Input Mode value. Didn't get one.  If this component has conditional visibility, you should set the Advanced option to 'Refresh inputs to incorporate changes elsewhere in the flow'.");
         }
 
     }
 
     connectedCallback() {
-        console.log(this.masterLabel + ": ", "Entering Connected Callback for QuickChoice");
-        console.log(this.masterLabel + ": ", "recordtypeId is: " + this.recordTypeId);
+        console.log(this._masterLabel + ": ", "Entering Connected Callback for QuickChoice");
+        console.log(this._masterLabel + ": ", "recordtypeId is: " + this.recordTypeId);
         if (!this.recordTypeId) this.recordTypeId = this.masterRecordTypeId;
 
         if (this.displayMode === "Picklist") {
-            console.log(this.masterLabel + ": ", "setting Picklist on");
+            console.log(this._masterLabel + ": ", "setting Picklist on");
             this.showRadio = false;
         }
 
@@ -492,7 +499,7 @@ export default class QuickChoiceFSC extends LightningElement {
 
     //show default visual card as selected
     renderedCallback() {
-        console.log(this.masterLabel + ": ", "Entering Rendered Callback for QuickChoice");
+        console.log(this._masterLabel + ": ", "Entering Rendered Callback for QuickChoice");
         if (this.showVisual && this.value != null) {
             if (this.template.querySelector('[data-id="' + this.value + '"]') != null) {
                 this.template.querySelector('[data-id="' + this.value + '"]').checked = true;
@@ -507,8 +514,8 @@ export default class QuickChoiceFSC extends LightningElement {
     @api
     validate() {
     	//If the component is invalid, return the isValid parameter as false and return an error message.
-        console.log(this.masterLabel + ": ", "entering validate: required=" + this.required + " value=" + this.value);
-        let errorMessage = "You must make a selection in: " + this.masterLabel + " to continue";
+        console.log(this._masterLabel + ": ", "entering validate: required=" + this.required + " value=" + this.value);
+        let errorMessage = "You must make a selection in: " + this._masterLabel + " to continue";
 
         if (this.required === true && !this.value) {
             return {
@@ -521,10 +528,10 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     handleChange(event) {
-        console.log(this.masterLabel + ": ", 'EVENT', event);
+        console.log(this._masterLabel + ": ", 'EVENT', event);
         this._selectedValue = (this.showVisual) ? event.target.value : event.detail.value;
         this.dispatchFlowAttributeChangedEvent('value', this._selectedValue);
-        console.log(this.masterLabel + ": ", "selected value is: " + this._selectedValue);
+        console.log(this._masterLabel + ": ", "selected value is: " + this._selectedValue);
         if (this.navOnSelect && this.availableActions.find(action => action === 'NEXT')) {
             const navigateNextEvent = new FlowNavigationNextEvent();
             this.dispatchEvent(navigateNextEvent);

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -17,7 +17,7 @@ export default class QuickChoiceFSC extends LightningElement {
 
     @api 
     get masterLabel() {
-        return _masterLabel;
+        return this._masterLabel;
     }
     set masterLabel(ml_value) {
         this._masterLabel = ml_value;
@@ -35,7 +35,9 @@ export default class QuickChoiceFSC extends LightningElement {
     }
     set choiceLabels(value) {
         this._choiceLabels = value;
-        this._handleChoiceCollections();
+        if (this.isConnected) {
+            this._handleChoiceCollections();
+        }
     }
     _choiceLabels = [];
 
@@ -45,7 +47,9 @@ export default class QuickChoiceFSC extends LightningElement {
     }
     set choiceValues(value) {
         this._choiceValues = value;
-        this._handleChoiceCollections();
+        if (this.isConnected) {
+            this._handleChoiceCollections();
+        }
     }
     _choiceValues = [];
 
@@ -72,7 +76,8 @@ export default class QuickChoiceFSC extends LightningElement {
     picklistFieldDetails;
     isControlledByCheckbox = false;
     priorOptions = [];
-    firstPassCompleted = true; 
+    firstPassCompleted = false; 
+    isConnected = false;
 
     @api
     get dependentPicklist() {
@@ -115,7 +120,9 @@ export default class QuickChoiceFSC extends LightningElement {
     }
     set choiceIcons(value) {
         this._choiceIcons = value;
-        this._handleChoiceCollections();
+        if (this.isConnected) {
+            this._handleChoiceCollections();
+        }
     }
     _choiceIcons = [];
 
@@ -495,6 +502,7 @@ export default class QuickChoiceFSC extends LightningElement {
         }
 
         this._handleChoiceCollections();
+        this.isConnected = true;
     }
 
     //show default visual card as selected


### PR DESCRIPTION
This update provides:

1. Clarification on the error message that could occur when a screen is revisited and the component has conditional visibility
2. Adds a --None-- option for datasources from collections or static choices
3. Clears the previously selected value when the options change on a reactive screen
4. Fix the "Need a valid Input Mode. Didn't get one." error introduced in the prior release.

This will require a new ScreenComponentsBasePack package build