### PR TITLE
ReactiveConditionalVisibility Initial Release

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.html
@@ -1,0 +1,17 @@
+<!-- 
+
+Lightning Web Component for Flow Screens:   reactiveConditionalVisibility
+
+    Use this component to provide reactive conditional visibility on a flow screen
+
+        Reactive formulas based on screen values cannot be used to control conditional visibility of other components on the same screen.
+        Provide a boolean formula as input to this component and use the component output to control the conditional visibility of other components.
+
+12/05/23 -  Eric Smith -    Version 1.0.0 
+                            Included in the ScreenComponentsBasePack v3.2.6 and later
+-->
+
+<template>
+    <!-- Track, but do not display the reactive attribute(s) -->
+    <span hidden><lightning-formatted-text value={textReactiveValue}></lightning-formatted-text></span>
+</template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.js
@@ -1,0 +1,28 @@
+import { api, track, LightningElement } from 'lwc'; 
+import { FlowAttributeChangeEvent } from 'lightning/flowSupport';
+
+export default class Fsc_reactiveConditionalVisibility extends LightningElement {
+
+    @api
+    get reactiveValue() {
+        return this._reactiveValue;
+    }
+    set reactiveValue(value) {
+        this._reactiveValue = value;
+    }
+    _reactiveValue;
+
+    @track oldReactiveValue;
+
+    get textReactiveValue() {
+        return JSON.stringify(this._reactiveValue);
+    }
+
+    renderedCallback() {
+        if (this.textReactiveValue && this.textReactiveValue != this.oldReactiveValue) {
+            this.dispatchEvent(new FlowAttributeChangeEvent("reactiveValue", this._reactiveValue));
+        }
+        this.oldReactiveValue = this._reactiveValue;
+    }
+
+}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_reactiveConditionalVisibility/fsc_reactiveConditionalVisibility.js-meta.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <isExposed>true</isExposed>
+    <masterLabel>Reactive Conditional Visibility</masterLabel>
+    <targets>
+        <target>lightning__FlowScreen</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__FlowScreen">
+            <property name="reactiveValue" label="Value" type="Boolean" description="Reactive Value (True/False)" required="true"/>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>


### PR DESCRIPTION
@alexed1 This is a new component for the ScreenComponentsBasePack.

Problem:  Formulas can be reactive to changes in outputs from screen components but they cannot be used to control the conditional visibility of other components.

Solution: Use a boolean formula as the input attribute for this screen component and use the output of this component to control conditional visibility of other components on the same screen.

How: This component is reactive to the value of the input attribute and just passes it through as the output attribute.

Use Case: https://trailhead.salesforce.com/trailblazer-community/feed/0D54V00007RIt4O