### PR TITLE
v2.43 RecordTypeId attribute is now reactive

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -6,7 +6,7 @@ const CB_ATTRIB_PREFIX = 'cb_';       // Used with fsc_flowCheckbox component
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.42';
+    versionNumber = '2.43';
     staticChoicesModalClass = 'staticChoicesModal';
     _builderContext;
     _values;

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -18,6 +18,9 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+12/12/23 -  Eric Smith -    Version 2.43
+                            Added reactivity for the Record Type Id
+
 12/04/23 -  Eric Smith -    Version 2.42
                             Clear the selected value if the options change on a reactive screen
                             ALlow "Add a 'None' Choice" option for all valid picklist methods

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -64,10 +64,19 @@ export default class QuickChoiceFSC extends LightningElement {
 
     //-------------For inputMode = Picklist
     @api allowNoneToBeChosen; //For picklist field only
-    @api recordTypeId; //used for picklist fields
-    @api objectName; //used for picklist fields
-    @api fieldName; //used for picklist fields
-    @api sortList; //used for picklist fields
+    @api sortList;          //used for picklist fields
+
+    @api 
+    get recordTypeId() {    //used for picklist fields
+        return this._recordTypeId;
+    }
+    set recordTypeId(rtvalue) {
+        this._recordTypeId = (!rtvalue) ? this.masterRecordTypeId : rtvalue;
+    }
+    _recordTypeId;
+
+    @api objectName;        //used for picklist fields
+    @api fieldName;         //used for picklist fields
 
     _controllingPicklistValue;
     _controllingCheckboxValue;
@@ -298,6 +307,7 @@ export default class QuickChoiceFSC extends LightningElement {
     get calculatedObjectAndFieldName() {
         console.log(this._masterLabel + ": ", 'in getter: objectApiName is: ' + this.objectName);
         console.log(this._masterLabel + ": ", 'in getter: fieldApiName is: ' + this.fieldName);
+        console.log(this._masterLabel + ": ", 'in getter: _recordTypeId is: ' + this._recordTypeId);
 
         if ((this.objectName) && (this.fieldName)) {
             console.log(this._masterLabel + ": ", 'satisfied calculatedObjectAndFieldName test');
@@ -493,8 +503,8 @@ export default class QuickChoiceFSC extends LightningElement {
 
     connectedCallback() {
         console.log(this._masterLabel + ": ", "Entering Connected Callback for QuickChoice");
-        console.log(this._masterLabel + ": ", "recordtypeId is: " + this.recordTypeId);
-        if (!this.recordTypeId) this.recordTypeId = this.masterRecordTypeId;
+        console.log(this._masterLabel + ": ", "recordtypeId is: " + this._recordTypeId);
+        if (!this._recordTypeId) this._recordTypeId = this.masterRecordTypeId;
 
         if (this.displayMode === "Picklist") {
             console.log(this._masterLabel + ": ", "setting Picklist on");


### PR DESCRIPTION
This update adds reactivity to the RecordTypeId attribute for the QuickChoice component.

Please create a new version of the FlowScreenComponentsBasePack

Overview vidio is attached.

https://github.com/alexed1/LightningFlowComponents/assets/24724447/3cdb77b9-f389-4604-87e8-beeaf12be1f5

