### PR TITLE
Update ManageMultiselectField.cls

### DIFF
--- a/flow_action_components/MultiselectMagic/force-app/main/default/classes/ManageMultiselectField.cls
+++ b/flow_action_components/MultiselectMagic/force-app/main/default/classes/ManageMultiselectField.cls
@@ -11,6 +11,7 @@ public with sharing class ManageMultiselectField {
             //verify type of specified field
             validateFieldType(curRequest);
             String fieldValue = (String)curRequest.curRecord.get(curRequest.fieldApiName);
+            fieldValue = fieldValue != null ? fieldValue : '';
             List<String> selectedValueList = (fieldValue != null) ? fieldValue.split(';') : new List<String>();
             List<String> availableValuesList = getPicklistValues(curRequest.objectApiName, curRequest.fieldApiName);
             


### PR DESCRIPTION
If the multipicklist has no values selected, then its value will be null. Running .split() on a NULL string variable will throw an error.

We need the code I added in line 14 to help prevent such errors so that this code can run in a record triggered flow or scheduled flow where some records in the execution may not have any values selected in the multipicklist.

Let me know if you have any questions.