### PR TITLE
Datatable-Fix column value for apex defined objects, if source field is empty

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1057,7 +1057,9 @@ export default class Datatable extends LightningElement {
             lookupFields.forEach(lookup => {
                 if (this.isUserDefinedObject) {
                     lufield = lookup;
-                    record[lufield + '_lookup'] = MYDOMAIN + record[lufield + '_lookup'];                    
+                    if(record[lufield]) {
+                        record[lufield + '_lookup'] = MYDOMAIN + record[lufield + '_lookup'];
+                    }
                 } else {
                     if(lookup.toLowerCase().endsWith('id')) {
                         lufield = lookup.replace(/Id$/gi,'');


### PR DESCRIPTION
Checks if the source field has a value and only then it populates value to the column. Without that check, if the source field is empty, the component populates the base url(MYDOMAIN) as label and active link to the column.