### PR TITLE
use String.valueOf to set fieldValue variables instead of null method.

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecords.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecords.cls
@@ -94,7 +94,7 @@ global without sharing class FindCommonAndUniqueRecords {
                             
                             for(sObject sourceRecord : sourceRecordCollection){
                                 //if it is, we add it to the common record collection and remove it from the target map. We do this
-                                String sourceFieldValue = sourceRecord.get(request.sourceUniqueID).toString();
+                                String sourceFieldValue = String.valueOf(sourceRecord.get(request.sourceUniqueID));
                                 
                                 if (targetMap.containsKey(sourceFieldValue)){
                                     result.sourceCommonRecordCollection.add(sourceRecord);
@@ -106,7 +106,7 @@ global without sharing class FindCommonAndUniqueRecords {
                             // we loop over the 'Target' collection to see if the record is in the 'Source' collection'.
                             for(sObject targetRecord : targetRecordCollection){
                                 //if it is, we add it to the common record collection and remove it from the target map. We do this
-                                String targetFieldValue = targetRecord.get(request.targetUniqueID).toString();
+                                String targetFieldValue = String.valueOf(targetRecord.get(request.targetUniqueID));
                                 
                                 if (sourceMap.containsKey(targetFieldValue)){
                                     result.targetCommonRecordCollection.add(targetRecord);

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecordsTest.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/FindCommonAndUniqueRecordsTest.cls
@@ -18,6 +18,9 @@ public class FindCommonAndUniqueRecordsTest {
         accounts.add(account3);        
         insert accounts;
         
+		accounts[2].ParentId=accounts[0].Id;
+        update accounts;
+        
     	List<Contact> contacts = new List<Contact>();
         
         Contact contact1 = new Contact(
@@ -61,6 +64,24 @@ public class FindCommonAndUniqueRecordsTest {
         Test.stopTest();
         System.assertEquals(1, results[0].sourceUniqueRecordCollection.size(), 'sourceUnique failed');
         System.assertEquals(2, results[0].sourceCommonRecordCollection.size(), 'sourceCommon failed');
+    }
+    
+    @IsTest
+    static void testCompareRecordswithNullUniqueIds() {
+        List<Account> accountsInSource = [Select Id, ParentId from Account];
+        
+        List<FindCommonAndUniqueRecords.Request> flowRequests = new List<FindCommonAndUniqueRecords.Request>();
+        FindCommonAndUniqueRecords.Request flowRequest = new FindCommonAndUniqueRecords.Request();
+        flowRequest.sourceRecordCollection = accountsInSource;
+        flowRequest.targetRecordCollection = accountsInSource;
+        flowRequest.sourceUniqueID = 'Id';
+        flowRequest.targetUniqueID = 'ParentId';
+        flowRequests.add(flowRequest);
+        Test.startTest();
+        List<FindCommonAndUniqueRecords.Result> results = FindCommonAndUniqueRecords.compareRecords(flowRequests);
+        Test.stopTest();
+        System.assertEquals(2, results[0].sourceUniqueRecordCollection.size(), 'sourceUnique failed');
+        System.assertEquals(1, results[0].sourceCommonRecordCollection.size(), 'sourceCommon failed');
     }
     
     @IsTest


### PR DESCRIPTION
When trying to compare a list of records that had a unique id that could be null, the use of the `.toString()` method causes  `EXCEPTION_THROWN [109]|System.NullPointerException: Attempt to de-reference a null object`. Changing this behavior to use `String.valueOf(toConvert)` avoids this exception.

I've added a test method to handle this error, as well.