### PR TITLE
Fix issue with External Objects date fields

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1030,8 +1030,10 @@ export default class Datatable extends LightningElement {
             dateFields.forEach(date => {
                 if (record[date]) {
                     let dt = Date.parse(record[date] + "T12:00:00.000Z");   //Set to Noon to avoid DST issues with the offset (v4.0.4)
-                    let d = new Date();
-                    record[date] = new Date(d.setTime(Number(dt) - Number(this.timezoneOffset)));
+                    if (!isNaN(dt)) {
+                        let d = new Date();
+                        record[date] = new Date(d.setTime(Number(dt) - Number(this.timezoneOffset)));
+                    }
                 }
             });
 


### PR DESCRIPTION
Salesforce has a weird behavior with External Objects where date fields are formatted as datetime fields (they include the time in the string representation). This was causing the values to be processed incorrectly here. `Date.parse()` was returning `NaN` and then `record[date]` was being overwritten with `null` as a result.  By checking for `isNaN` we can prevent this from happening.

See open issue from my colleague Ben: https://github.com/alexed1/LightningFlowComponents/issues/1124