### PR TITLE
API 60.0

### DIFF
--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldDescriptor.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldDescriptor.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerController.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerControllerTest.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldPickerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldSelectorController.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldSelectorController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldSelectorControllerTest.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/FieldSelectorControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>60.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/sfdx-project.json
+++ b/flow_action_components/FlowActionsBasePack/sfdx-project.json
@@ -11,7 +11,7 @@
   ],
   "namespace": "usf3",
   "sfdcLoginUrl": "https://login.salesforce.com",
-  "sourceApiVersion": "51.0",
+  "sourceApiVersion": "60.0",
   "packageAliases": {
     "FlowActionsBasePack": "0Ho8b000000oLkPCAU",
     "FlowActionsBasePack@2.0.0-0": "04t4W000002vXU7QAM",


### PR DESCRIPTION
@alexed1 Could you please build a new version of the FlowActionsBasePack and make sure that the sfdx-project.json references API 60.0.

The current version (3.15) of the Base Pack shows that the FieldPickerController was built under API 53.0.  This means that any CPEs (Datatable and others) that use the Field and Object picker from the FlowScreenComponentsBasePack to select an Object will not expose any standard Objects that were added after API 53.0.