### PR TITLE
Made single scan reactive

### DIFF
--- a/flow_screen_components/barcodeScanner/force-app/main/default/lwc/barcodeScanner/barcodeScanner.js
+++ b/flow_screen_components/barcodeScanner/force-app/main/default/lwc/barcodeScanner/barcodeScanner.js
@@ -7,7 +7,7 @@
 **/
 // barcodeScanner.js
 import { LightningElement,api } from 'lwc';
-import { FlowNavigationNextEvent } from 'lightning/flowSupport';
+import { FlowNavigationNextEvent, FlowAttributeChangeEvent } from 'lightning/flowSupport';
 import { ShowToastEvent } from 'lightning/platformShowToastEvent';
 import { getBarcodeScanner } from 'lightning/mobileCapabilities';
 
@@ -165,6 +165,7 @@ export default class BarcodeScanner extends LightningElement {
                     // Clean up by ending capture,
                     // whether we completed successfully or had an error
                     this.myScanner.endCapture();
+                    this.dispatchEvent(new FlowAttributeChangeEvent('scannedBarcode',this.scannedBarcode));
                 });
 
                                                


### PR DESCRIPTION
Added the reactivity for single barcode scan.  Still unsure how to make continuous scan reactive, though that could be an undesirable situation.

This modification allowed me to present a lookup field as well as the scanner.  The scanner populated a formula variable SOQL which was used by data fetcher to then populate the lookup field's default value.

It allowed the user the ability to scan a barcode that wasn't a record Id, but another unique identified that data fetcher could then locate the correct record.