### PR TITLE
Fixed Bias in ReturnNRandomRecords When Selecting Random Records

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/ReturnNRandomRecords.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/ReturnNRandomRecords.cls
@@ -75,7 +75,7 @@ global inherited sharing class ReturnNRandomRecords {
                 } else {
                     // Generate a list of random numbers
                     while (randomNumbers.size() < recordCount) {
-                        Integer randomNumber = (Integer)Math.round(Math.random() * (inputCollection.size()-1));
+                        Integer randomNumber = (Integer)Math.floor(Math.random() * (inputCollection.size()));
                         if( !randomNumbers.contains(randomNumber) ) {
                             randomNumbers.add(randomNumber);
                         }


### PR DESCRIPTION
**Problem:**
The current implementation of the random number generation in the ReturnNRandomRecords flow action uses the following code:

`Integer randomNumber = (Integer)Math.round(Math.random() * (inputCollection.size() - 1));`
This approach favors middle numbers because they have a higher range for being picked. For example:

0 = 0 to 0.499, 1 = 0.5 to 1.499, 2 = 1.5 to 2
This results in a biased distribution, where middle indices are selected more frequently.

**Example Distribution Before Change:**
Test Account 0: 253 Test Account 1: 493 Test Account 2: 254
Test Account 0: 247 Test Account 1: 514 Test Account 2: 239

**Replacing with** 
`Integer randomNumber = (Integer)Math.floor(Math.random() * inputCollection.size());`

Test Account 0: 1714 Test Account 1: 1608 Test Account 2: 1678

**Impact:**
This change ensures that each index in the collection has an equal probability of being selected, thus removing any bias and improving the fairness of the random selection process.

Below image shows the problem over time (top three lines are tasks being created with ReturnNRandomRecords)
![image](https://github.com/alexed1/LightningFlowComponents/assets/61500446/81e5974e-8d85-4a3c-a2f2-db66e7f1c7cc)
