### PR TITLE
Datatable remove & select

### DIFF
--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -51,8 +51,8 @@ https://unofficialsf.com/flow-action-and-screen-component-basepacks/
   
 ---
 **Install Datatable**  
-[Version 4.2.1 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004fz7wQAA)   
-[Version 4.2.1 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004fz7wQAA)
+[Version 4.3.0 (Production or Developer)](https://login.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004fz81QAA)   
+[Version 4.3.0 (Sandbox)](https://test.salesforce.com/packaging/installPackage.apexp?p0=04t5G000004fz81QAA)
  
 ---
 **Starting with the Winter '21 Release, Salesforce requires that a User's Profile or Permission Set is given specific permission to access any @AuraEnabled Apex Method.**  
@@ -72,7 +72,7 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
 ---
 # Release Notes 
   
-## 07/xx/24 -  Eric Smith -     Version 4.2.2  
+## 07/22/24 -  Eric Smith -     Version 4.3.0  
 **Updates:**   
 -   Added additional output attributes for Apex Defined records (outputRemovedRowsString & outputRemainingRowsString)  
 -   Added an option to display the number of selected records in the table header 

--- a/flow_screen_components/datatable/README.md
+++ b/flow_screen_components/datatable/README.md
@@ -71,7 +71,15 @@ A Permission Set (**USF Flow Screen Component - Datatable**) is included with th
     
 ---
 # Release Notes 
-
+  
+## 07/xx/24 -  Eric Smith -     Version 4.2.2  
+**Updates:**   
+-   Added additional output attributes for Apex Defined records (outputRemovedRowsString & outputRemainingRowsString)  
+-   Added an option to display the number of selected records in the table header 
+-  
+**Bug Fixes:** 
+-   Fixed bug where first column reference was off if the remove row action was on the left 
+-  
 ## 07/09/24 -  Eric Smith -     Version 4.2.1  
 **Updates:** 
 -   New Feature: Add a Remove Row action as the first or last column in a Datatable.  

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -201,6 +201,10 @@ export default class Datatable extends LightningElement {
     get showRowNumbers() {
         return (this.cb_showRowNumbers == CB_TRUE) ? true : false;
     }
+    set showRowNumbers(value) {
+        this._showRowNumbers = value;
+    }
+    _showRowNumbers;
     @api cb_showRowNumbers;
     
     @api 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -116,6 +116,10 @@ export default class Datatable extends LightningElement {
     get isRemoveRowAction() {
         return (this.cb_isRemoveRowAction == CB_TRUE) ? true : false;
     }
+    set isRemoveRowAction(value) {
+        this._isRemoveRowAction = value;
+    }
+    _isRemoveRowAction;
     @api cb_isRemoveRowAction;
 
     // Console Log differentiation
@@ -223,6 +227,10 @@ export default class Datatable extends LightningElement {
     get singleRowSelection() {
         return (this.cb_singleRowSelection == CB_TRUE) ? true : false;
     }
+    set singleRowSelection(value) {
+        this._singleRowSelection = value;
+    }
+    _singleRowSelection;
     @api cb_singleRowSelection;
     
     @api 
@@ -304,6 +312,10 @@ export default class Datatable extends LightningElement {
     get isUserDefinedObject() {
         return (this.cb_isUserDefinedObject == CB_TRUE) ? true : false;
     }
+    set isUserDefinedObject(value) {
+        this._isUserDefinedObject = value;
+    }
+    _isUserDefinedObject;
     @api cb_isUserDefinedObject;
 
     @api get serializedRecordData() {

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1142,7 +1142,8 @@ export default class Datatable extends LightningElement {
             // Custom column processing
             this.updateColumns();
 
-            if(this.cols[0]?.fieldName.endsWith('_lookup')) {
+            const firstCol = (this.isRemoveRowAction && this.removeRowLeftOrRight == "Left") ? 1 : 0;
+            if(this.cols[firstCol]?.fieldName.endsWith('_lookup')) {
                 this.sortedBy = this.cols[0].fieldName;
                 this.doSort(this.sortedBy, 'asc');
             }

--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js-meta.xml
@@ -41,7 +41,8 @@
             <property name="outputSelectedRowsString" label="Output Selected Rows (User Defined)" type="String" role="outputOnly" description="Object Collection string variable to contain only the records that were selected in the datatable. 
                 --  NOTE: These records may not contain all of the edited values."/>
             <property name="outputEditedRowsString" label="Output Edited Rows (User Defined)" type="String" role="outputOnly" description="Object Collection string variable to contain only the records that were edited in the datatable."/>
-            
+            <property name="outputRemovedRowsString" label="Output Removed Rows (User Defined)" type="String" role="outputOnly" description="Object Collection string variable to contain only the records that were removed from the datatable."/>
+            <property name="outputRemainingRowsString" label="Output Remaining Rows (User Defined)" type="String" role="outputOnly" description="Object Collection string variable to contain all the original records that were not removed from the datatable."/>
             <!-- ============================================================================================================================- -->  
             
             <!-- Additional Output Parameters -->
@@ -108,6 +109,8 @@
             <property name="cb_showRowNumbers" type="String" role="inputOnly"/>
             <property name="showRecordCount" label="Show Record Count in Header" type="Boolean" default="false" role="inputOnly" description="Display the number of records in the table header.  This will match what is shown in a List View header."/>
             <property name="cb_showRecordCount" type="String" role="inputOnly"/>
+            <property name="showSelectedCount" label="Show Selected Record Count in Header" type="Boolean" default="false" role="inputOnly" description="Display the number of selected records in the table header."/>
+            <property name="cb_showSelectedCount" type="String" role="inputOnly"/>
             <property name="keyField" label="Key Field" type="String" default="Id" role="inputOnly" description="This is normally the Id field, but you can specify a different field if all field values are unique."/>
             <property name="matchCaseOnFilters" label="Match Case on Column Filters?" type="Boolean" default="false" role="inputOnly" description="Set to True is you want to force an exact match on case for column filter values."/>
             <property name="cb_matchCaseOnFilters" type="String" role="inputOnly"/>

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.html
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.html
@@ -225,6 +225,15 @@
     ></c-fsc_flow-checkbox>
     
     <c-fsc_flow-checkbox
+        disabled={disableSelectCountSelection}
+        name="select_showSelectedCount"
+        label={inputValues.showSelectedCount.label} 
+        checked={inputValues.cb_showSelectedCount.value} 
+        field-level-help={inputValues.showSelectedCount.helpText}
+        oncheckboxchanged={handleCheckboxChange}
+    ></c-fsc_flow-checkbox>
+
+    <c-fsc_flow-checkbox
         disabled={disableSearchBarSelection}
         name="select_isShowSearchBar"
         label={inputValues.isShowSearchBar.label}

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableCPE/ers_datatableCPE.js
@@ -288,6 +288,10 @@ export default class ers_datatableCPE extends LightningElement {
         return !this.inputValues.isDisplayHeader.value;
     }
 
+    get disableSelectCountSelection() {
+        return this.inputValues.hideCheckboxColumn.value;
+    }
+
     @api
     get wiz_columnFields() { 
         return this._wiz_columnFields;
@@ -546,7 +550,10 @@ export default class ers_datatableCPE extends LightningElement {
         cb_showRowNumbers: {value: null, valueDataType: null, isCollection: false, label: ''},    
         showRecordCount: {value: null, valueDataType: null, isCollection: false, label: 'Show Record Count in Header', 
             helpText: 'Display the number of records in the table header.  This will match what is shown in a List View header.'}, 
-        cb_showRecordCount: {value: null, valueDataType: null, isCollection: false, label: ''},         
+        cb_showRecordCount: {value: null, valueDataType: null, isCollection: false, label: ''},
+        showSelectedCount: {value: null, valueDataType: null, isCollection: false, label: 'Show Selected Count in Header', 
+            helpText: 'Display the number of selected records in the table header.'}, 
+        cb_showSelectedCount: {value: null, valueDataType: null, isCollection: false, label: ''},            
         isRequired: {value: null, valueDataType: null, isCollection: false, label: 'Require', 
             helpText: 'When this option is selected, the user will not be able to advance to the next Flow screen unless at least one row is selected in the datatable.'},
         cb_isRequired: {value: null, valueDataType: null, isCollection: false, label: ''},
@@ -657,6 +664,7 @@ export default class ers_datatableCPE extends LightningElement {
                 {name: 'showFirstLastButtons'},
                 {name: 'showRowNumbers'},
                 {name: 'showRecordCount'},
+                {name: 'showSelectedCount'},
                 {name: 'isShowSearchBar'},
                 {name: 'tableBorder'},
                 {name: defaults.customHelpDefinition, 
@@ -1096,7 +1104,14 @@ export default class ers_datatableCPE extends LightningElement {
                 if (this.isDisableSuppressBottomBar) {
                     this.updateCheckboxValue('suppressBottomBar', false);
                 }
-            }     
+            }
+            
+            // Clear Show Selected Count if Disallow Row Relection is selected
+            if (changedAttribute == 'hideCheckboxColumn') { 
+                if (event.detail.newValue) {
+                    this.updateCheckboxValue('showSelectedCount', false);
+                }
+            } 
 
         }
 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -33,7 +33,7 @@ console.log("DATATABLE: isCommunity, isFlowBuilder:", isCommunity, isFlowBuilder
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '4.2.2',           // Current Source Code Version #
+        VERSION_NUMBER : '4.3.0',           // Current Source Code Version #
         MAXROWCOUNT : 2000,                 // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,                     // Used to round off the column widths during Config Mode to nearest value
         WIZROWCOUNT : 6,                    // Number of records to display in the Column Wizard datatable
@@ -50,8 +50,8 @@ const getConstants = () => {
         REMOVE_ROW_ICON : 'utility:close',  // Default Icon for the Remove Row button
         REMOVE_ROW_COLOR : 'remove-icon',   // Default Color for the Remove Row button
         REMOVE_ROW_SIDE : 'Right',          // Default Side for the Remove Row button
-        SHOW_DEBUG_INFO : true,            // Set to true to show sensitive debug info in the console and debug logs
-        DEBUG_INFO_PREFIX : 'DATATABLE: '   // Prefix to be used for debug info in the console
+        DEBUG_INFO_PREFIX : 'DATATABLE: ',  // Prefix to be used for debug info in the console
+        SHOW_DEBUG_INFO : false             // Set to true to show sensitive debug info in the console and debug logs
     }
 }
 

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -50,7 +50,7 @@ const getConstants = () => {
         REMOVE_ROW_ICON : 'utility:close',  // Default Icon for the Remove Row button
         REMOVE_ROW_COLOR : 'remove-icon',   // Default Color for the Remove Row button
         REMOVE_ROW_SIDE : 'Right',          // Default Side for the Remove Row button
-        SHOW_DEBUG_INFO : false,            // Set to true to show sensitive debug info in the console and debug logs
+        SHOW_DEBUG_INFO : true,            // Set to true to show sensitive debug info in the console and debug logs
         DEBUG_INFO_PREFIX : 'DATATABLE: '   // Prefix to be used for debug info in the console
     }
 }

--- a/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/ers_datatableUtils/ers_datatableUtils.js
@@ -33,7 +33,7 @@ console.log("DATATABLE: isCommunity, isFlowBuilder:", isCommunity, isFlowBuilder
 
 const getConstants = () => {
     return {
-        VERSION_NUMBER : '4.2.1',           // Current Source Code Version #
+        VERSION_NUMBER : '4.2.2',           // Current Source Code Version #
         MAXROWCOUNT : 2000,                 // Limit the total number of records to be handled by this component
         ROUNDWIDTH : 5,                     // Used to round off the column widths during Config Mode to nearest value
         WIZROWCOUNT : 6,                    // Number of records to display in the Column Wizard datatable

--- a/flow_screen_components/datatable/sfdx-project.json
+++ b/flow_screen_components/datatable/sfdx-project.json
@@ -92,6 +92,7 @@
     "datatable@4.1.6": "04t5G000004XZk9QAG",
     "datatable@4.1.7": "04t5G000004XZknQAG",
     "datatable@4.2.0": "04t5G000004XZlHQAW",
-    "datatable@4.2.1": "04t5G000004fz7wQAA"
+    "datatable@4.2.1": "04t5G000004fz7wQAA",
+    "datatable@4.3.0": "04t5G000004fz81QAA"
   }
 }


### PR DESCRIPTION
Latest source code for Datatable v4.3.0.  This release adds a Remove Row action, persistent selected records and more secure Console Log and Debug information.