### PR TITLE
inputRichTextFSC - remove html from character count in 

### DIFF
--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
@@ -1,6 +1,7 @@
 // 06/25/21    Eric Smith       Added a Required attribute and increased the bottom margin to better match standard components
 // 07/02/21    Eric Smith       Added a Required * to the Input Label if Required is True
 // 04/04/23    Clifford Beul    Added disabled categories and optional overwrite of formats
+// 01/08/24    Declan Toohey    Modified character count calculation to not include HTML characters in character count
 
 import { LightningElement, api, track } from 'lwc';
 
@@ -193,7 +194,9 @@ export default class inputRichTextFSC_LWC extends LightningElement {
             this.isValidCheck = true;
             this.richText = event.target.value;
         }
-        this.characterCount = this.richText.length;
+
+        //Regex <[^>]*> removes any HTML from the word count
+        this.characterCount = this.richText.replace(/<[^>]*>/ig, "").length;
         if(this.characterCap && this.characterCount > this.characterLimit){
             this.isValidCheck = false;
         }

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
@@ -19,7 +19,7 @@ export default class inputRichTextFSC_LWC extends LightningElement {
     @api required = false;
     @api disabledCategories = '';
     @api enabledFormats;
-    @api includeHTMLCharacterCount = false;
+    @api excludeHTMLCharacterCount = false;
 
     formats = ['font', 'size', 'bold', 'italic', 'underline',
         'strike', 'list', 'indent', 'align', 'link',
@@ -196,10 +196,10 @@ export default class inputRichTextFSC_LWC extends LightningElement {
             this.richText = event.target.value;
         }
 
-        //Regex <[^>]*> removes any HTML from the word count
-        this.characterCount = this.richText.replace(/<[^>]*>/ig, "").length;
-        if (this.includeHTMLCharacterCount) {
-            this.characterCount = this.richText.length;
+        this.characterCount = this.richText.length;
+        if (this.excludeHTMLCharacterCount) {
+            //Regex <[^>]*> removes any HTML from the word count
+            this.characterCount = this.richText.replace(/<[^>]*>/ig, "").length;
         }
 
         if(this.characterCap && this.characterCount > this.characterLimit){

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js
@@ -19,6 +19,7 @@ export default class inputRichTextFSC_LWC extends LightningElement {
     @api required = false;
     @api disabledCategories = '';
     @api enabledFormats;
+    @api includeHTMLCharacterCount = false;
 
     formats = ['font', 'size', 'bold', 'italic', 'underline',
         'strike', 'list', 'indent', 'align', 'link',
@@ -197,6 +198,10 @@ export default class inputRichTextFSC_LWC extends LightningElement {
 
         //Regex <[^>]*> removes any HTML from the word count
         this.characterCount = this.richText.replace(/<[^>]*>/ig, "").length;
+        if (this.includeHTMLCharacterCount) {
+            this.characterCount = this.richText.length;
+        }
+
         if(this.characterCap && this.characterCount > this.characterLimit){
             this.isValidCheck = false;
         }

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
@@ -18,7 +18,7 @@
             <property label="Warning Only" name="warnOnly" type="Boolean" role="inputOnly" description="Set to True if you want disallowed Symbols or Words to only alert and not block next/finish.  Default is false."/>
             <property label="Character Limit" name="characterLimit" type="Integer" role="inputOnly" description="If set, then the character count will be limited to this quantity."/>
             <property label="Required?" name="required" type="Boolean" role="inputOnly" default="false" description="Set to True if you want to require an entry for this input."/>
-            <property label="Include HTML in character count?" name="includeHTMLCharacterCount" type="Boolean" role="inputOnly" default="false" description="Set to True if you want to include HTML characters in the character count."/>
+            <property label="Exclude HTML in character count?" name="excludeHTMLCharacterCount" type="Boolean" role="inputOnly" default="false" description="Set to True if you want to exclude HTML characters in the character count."/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
+++ b/flow_screen_components/richTextInputFSC/force-app/main/default/lwc/inputRichTextFSC/inputRichTextFSC.js-meta.xml
@@ -18,6 +18,7 @@
             <property label="Warning Only" name="warnOnly" type="Boolean" role="inputOnly" description="Set to True if you want disallowed Symbols or Words to only alert and not block next/finish.  Default is false."/>
             <property label="Character Limit" name="characterLimit" type="Integer" role="inputOnly" description="If set, then the character count will be limited to this quantity."/>
             <property label="Required?" name="required" type="Boolean" role="inputOnly" default="false" description="Set to True if you want to require an entry for this input."/>
+            <property label="Include HTML in character count?" name="includeHTMLCharacterCount" type="Boolean" role="inputOnly" default="false" description="Set to True if you want to include HTML characters in the character count."/>
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>


### PR DESCRIPTION
Howdy, we found that it was confusing for users that the character count did not match what was being written.
The current character count for inputRichTextFSC was including HTML characters that were not visible to the user.
We introduced a regex that would remove anything between < and > from the character count. 

Only downside is that the field that the text area is linked to needed to be increased to handle for this change. 
For that reason, I'm not 100% sure if this is something that people have been wanting. But here it is 😄 

Maybe add a new attribute to the component to include the html characters in the character count or not?
