### PR TITLE
Added testproperty back to resolve upgrade errors

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickObjectAndField3/fsc_pickObjectAndField3.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickObjectAndField3/fsc_pickObjectAndField3.js
@@ -27,7 +27,9 @@ export default class fsc_pickObjectAndField extends LightningElement {
     @api hideObjectPicklist = false;
     @api hideFieldPicklist = false;
     @api displayFieldType = false;
-    //@api testproperty;        // Christopher Strecker 06/06/2024 - Removed this was not being used anywhere
+    @api testproperty;      // Christopher Strecker 09/25/2024 - This property does not do anything 
+                            // but it cannot be removed due to current managed package restrictions 
+                            // when using IsExposed is True
 
     @api allowFieldMultiselect = false;
 

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickObjectAndField3/fsc_pickObjectAndField3.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_pickObjectAndField3/fsc_pickObjectAndField3.js-meta.xml
@@ -22,8 +22,7 @@
             <property name="required" type="Boolean" role="inputOnly"> </property>
             <property name="hideFieldPicklist" type="Boolean" role="inputOnly"> </property>
             <property name="displayFieldType" type="Boolean" role="inputOnly"> </property>
-            <!-- Christopher Strecker 06/06/2024 - removed property -->
-            <!-- <property name="testproperty" type="String" role="inputOnly"> </property> -->
+            <property name="testproperty" type="String" role="inputOnly"> </property>
             <property name="DataTypeFilter" type="String" role="inputOnly"> </property>
             <property name="allowFieldMultiselect" type="Boolean" role="inputOnly"></property>
         </targetConfig>


### PR DESCRIPTION
Added _testproperty_ back to the component.  Since the component uses _IsExposed_ is _True_ properties cannot be removed.

This will resolve issue #1549 