### PR TITLE
Handle datatable not displaying updates reactively after column filtering

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -2204,6 +2204,7 @@ export default class Datatable extends LightningElement {
         this.dispatchEvent(new FlowAttributeChangeEvent('sortedBy', this.sortedBy));
         this.dispatchEvent(new FlowAttributeChangeEvent('sortDirection', this.sortDirection));
         this.doSort(this.sortedBy, this.sortDirection);
+        this.isUpdateTable = true;
     }
 
     doSort(sortField, sortDirection) {


### PR DESCRIPTION
Found that while passing in records dynamically, that after filtering by a column, the table ceases to reflect updated input data. Adding in ```this.isUpdateTable = true``` has fixed the issue for me.

Use case here was a standard flow text field being used as a search bar, passing that term to a dynamic query in Data Fetcher, then sending those records from data fetcher to the table to update.