### PR TITLE
Api updates

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls
@@ -109,10 +109,12 @@ public with sharing class SObjectDeepClone {
 
         for (String curFieldName : fieldsToCheck) {
             if (this.sObjectFields.get(curType).containsKey(curFieldName.toLowerCase())) {
-                if (so.get(curFieldName) != null && this.sObjectFields.get(curType).get(curFieldName.toLowerCase()).getDescribe().isUpdateable()) {
-                    String curName = (String) so.get(curFieldName);
-                    so.put(curFieldName, curName + ' Clone ' + Datetime.now().format('MM/dd/yyyy H:mm'));
-                    break;
+                if (curType.getDescribe().getLabel() != 'Contact' && curFieldName != 'Name') {  // Needed for > API 43.0
+                    if (so.get(curFieldName) != null && this.sObjectFields.get(curType).get(curFieldName.toLowerCase()).getDescribe().isUpdateable()) {
+                        String curName = (String) so.get(curFieldName);
+                        so.put(curFieldName, curName + ' Clone ' + Datetime.now().format('MM/dd/yyyy H:mm'));
+                        break;
+                    }
                 }
             }
         }

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls-meta.xml
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepClone.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>42.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepCloneTests.cls-meta.xml
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/SObjectDeepCloneTests.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>42.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/CollectionProcessors/sfdx-project.json
+++ b/flow_action_components/CollectionProcessors/sfdx-project.json
@@ -44,6 +44,6 @@
     "CollectionActionsL@3.1.0": "04t5G000004J7KcQAK",
     "CollectionActionsL@3.2.0": "04t5G000004XZirQAG",
     "CollectionActionsL@3.2.1": "04t5G000004XZj6QAG",
-    "CollectionActionsL@3.2.5": "04t5G000004fzAMQAY"
+    "CollectionActionsL@3.2.5": "04t5G000004fzARQAY"
   }
 }

--- a/flow_action_components/CollectionProcessors/sfdx-project.json
+++ b/flow_action_components/CollectionProcessors/sfdx-project.json
@@ -43,6 +43,7 @@
     "CollectionActionsL@3.0.1-0": "04t5G000003rUvaQAE",
     "CollectionActionsL@3.1.0": "04t5G000004J7KcQAK",
     "CollectionActionsL@3.2.0": "04t5G000004XZirQAG",
-    "CollectionActionsL@3.2.1": "04t5G000004XZj6QAG"
+    "CollectionActionsL@3.2.1": "04t5G000004XZj6QAG",
+    "CollectionActionsL@3.2.5": "04t5G000004fzAMQAY"
   }
 }

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/HexUtil.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/HexUtil.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/Puff.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/Puff.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>43.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/RegExps.cls-meta.xml
+++ b/flow_action_components/FlowActionsBasePack/force-app/main/default/classes/RegExps.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>33.0</apiVersion>
+    <apiVersion>50.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
"We received a Sandbox Enablement Failure Email from salesforce saying that our sandbox was not enabled on the ICU locale formats as notified due to the API version below 45 used in the org."

I updated RegExps, HexUtil, Puff (Apex classes from FlowActionsBasePack) to 50.0 and I updated SObjectDeepClone & SObjectDeepCloneTests (Apex classes from CollectionActionsL) to 50.0.

@alexed1 Please build a new managed FlowActionsBasePack.  I will create the new CollectionActionsL package.