### PR TITLE
Spring 25 Release

### DIFF
--- a/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailUcModal/sendBetterEmailUcModal.html
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/lwc/sendBetterEmailUcModal/sendBetterEmailUcModal.html
@@ -15,7 +15,6 @@
             class="
               slds-button slds-button_icon
               slds-modal__close
-              slds-button_icon-inverse
             "
             title="Close"
             onclick={closeModal}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_toastMessage/fsc_toastMessage.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_toastMessage/fsc_toastMessage.html
@@ -10,7 +10,7 @@
                     <h2 class="slds-text-heading_small ">{message}</h2>
                 </div>
                 <div class="slds-notify__close">
-                    <button class="slds-button slds-button_icon slds-button_icon-inverse" title="Close" onclick={closeModel}>
+                    <button class="slds-button slds-button_icon" title="Close" onclick={closeModel}>
                         <lightning-icon icon-name="utility:close" size="small" variant="inverse"> </lightning-icon>
                         <span class="slds-assistive-text">Close</span>
                     </button>


### PR DESCRIPTION
In release Spring 25:  To display the modal close button correctly, don't use the slds-button_icon-inverse class in your close button markup.
Link to release: https://help.salesforce.com/s/articleView?id=release-notes.rn_slds_updates.htm&release=254&type=5