### PR TITLE
Enhanced picklist selection when overflow is not enabled

### DIFF
--- a/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
+++ b/flow_screen_components/datatable/force-app/main/default/lwc/datatable/datatable.js
@@ -1214,7 +1214,7 @@ export default class Datatable extends LightningElement {
         this.borderClass = (this.tableBorder == true) ? 'datatable-border' : '';
 
         // Add overflow if max height is not set so the combobox will spill outside the table
-        this.borderClass += (this.allowOverflow) ? ' overflowEnabled' : '';
+        this.borderClass += (this.allowOverflow) ? ' overflowEnabled' : ' overflowDisabled ';
         
         // Generate datatable
         if (this._tableData) {

--- a/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
+++ b/flow_screen_components/datatable/force-app/main/default/staticresources/ers_customLightningDatatableStyles.css
@@ -11,6 +11,18 @@
 .overflowEnabled c-ers_custom-lightning-datatable .slds-scrollable_y {
     overflow: visible;
 }
+
+/* expands combox height within row to display more picklist values when overflow is disabled */
+.overflowDisabled .sdls-combobox, 
+.overflowDisabled .slds-combobox_container,
+.overflowDisabled .slds-dropdown {
+    position: relative !important;
+    z-index: 99 !important;
+    max-height: 200px;
+    overflow-y: scroll;
+    width: 200% !important;
+}
+
 /* stretch cell width of combobox to 100% */
 c-ers_custom-lightning-datatable lightning-primitive-cell-factory .slds-hyphenate {
     width: 100%;


### PR DESCRIPTION
This minor update allows easier picklist selection within datatables that are not allowed to overflow, especially when a small number of records are present.   I'm not a master coder by any means so I'm sure there are ways to clean it up a bit but the functionality works perfectly for my use case so I wanted to share in case you were interested.  Thanks for all the awesome things you do!


![OverflowIssueFIXED](https://github.com/user-attachments/assets/4dd5af14-a388-4007-ac8e-35ee4cc4fd57)
