### PR TITLE
Edit fsc_flowButtonBar.css to enable css variable override

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.css
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flowButtonBar/fsc_flowButtonBar.css
@@ -1,3 +1,3 @@
 .notToggle lightning-button + lightning-button {
-    padding-left: 0.25em;
+    margin-inline-start: var(--fbb-button-spacing, 0.25em);
 }


### PR DESCRIPTION
At the moment, the cssString cannot influence the padding set on the lightning-button components because of the sibling selector.

This adjustment does a few things:
1. Changes the property to margin-inline-start: futureproofs for any changes to RTL support, change to margin in keeping with the property used in slds-button css.
2. allows the margin value to be declared in the cssString component property: `--fbb-button-spacing: 0.5em;` or more appropriately `--fbb-button-spacing: var(--slds-g-spacing-1)` (or -2) matching the spacing in the SLDS approach to sibling <button> elements.

Happy to discuss whether there should be multiple fallbacks to bake in the standard salesforce spacing e.g.
```
var(--fbb-button-spacing, var(--slds-g-spacing-1, 0.25em))
```
It seems salesforce consistently has slds-g-spacing-1 and then overrides to slds-g-spacing-2
