### PR TITLE
Quick Choice - Fixed clipping issues with visual card displays on small form factors

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.html
@@ -1,244 +1,342 @@
 <!-- sldsValidatorIgnore -->
 <template>
+    <lightning-radio-group
+        name="select_displayMode"
+        label={inputValues.displayMode.label}
+        options={displayChoicesAsOptions}
+        value={inputValues.displayMode.value}
+        type="radio"
+        onchange={handleValueChange}
+    ></lightning-radio-group>
+    <template if:true={isVisualCards}>
+        <lightning-combobox
+            name="select_numberOfColumns"
+            label={inputValues.numberOfColumns.label}
+            value={inputValues.numberOfColumns.value}
+            required={isVisualCards}
+            options={numberOfColumnOptions}
+            onchange={handleValueChange}
+        ></lightning-combobox>
+        <lightning-input
+            type="checkbox"
+            label={inputValues.includeIcons.label}
+            name="select_includeIcons"
+            checked={inputValues.includeIcons.value}
+            onchange={handleValueChange}
+        ></lightning-input>
+        <lightning-input
+            name="select_navOnSelect"
+            type="checkbox"
+            label={inputValues.navOnSelect.label}
+            checked={inputValues.navOnSelect.value}
+            onchange={handleValueChange}
+        ></lightning-input>
+        <lightning-input
+            name="select_richTextFlagString"
+            type="checkbox"
+            label={inputValues.richTextFlagString.label}
+            checked={isRichText}
+            onchange={handleValueChange}
+        ></lightning-input>
 
-        <lightning-radio-group name="select_displayMode" label={inputValues.displayMode.label}
-                options={displayChoicesAsOptions} value={inputValues.displayMode.value} type="radio"
-                onchange={handleValueChange}></lightning-radio-group>
-        <template if:true={isVisualCards}>
-                <lightning-combobox name="select_numberOfColumns" label={inputValues.numberOfColumns.label}
-                        value={inputValues.numberOfColumns.value} required={isVisualCards}
-                        options={numberOfColumnOptions} onchange={handleValueChange}></lightning-combobox>
-                <lightning-input type="checkbox" label={inputValues.includeIcons.label} name="select_includeIcons"
-                        checked={inputValues.includeIcons.value} onchange={handleValueChange}></lightning-input>
-                <lightning-input name="select_navOnSelect" type="checkbox" label={inputValues.navOnSelect.label}
-                        checked={inputValues.navOnSelect.value} onchange={handleValueChange}></lightning-input>
-                <template if:true={isSingleColumn}>
-                        <lightning-input name="select_isResponsive" type="checkbox"
-                                label={inputValues.isResponsive.label} checked={inputValues.isResponsive.value}
-                                onchange={handleValueChange}></lightning-input>
-                </template>
-                <template if:true={isDualColumn}>
-                        <lightning-input type="checkbox" label={inputValues.isSameHeight.label} name="select_isSameHeight"
-                                checked={inputValues.isSameHeight.value} onchange={handleValueChange}></lightning-input>
-                </template>
-                <lightning-input name="select_richTextFlagString" type="checkbox" label={inputValues.richTextFlagString.label}
-                        checked={isRichText} onchange={handleValueChange}></lightning-input>
-
-                <!-- </template> -->
-                <!-- <template if:true={inputValues.includeIcons.value}> -->
-                <c-fsc_flow-combobox name="select_choiceIcons" label={inputValues.choiceIcons.label}
-                        value={inputValues.choiceIcons.value} value-type={inputValues.choiceIcons.valueDataType}
-                        builder-context-filter-type="String"
-                        builder-context-filter-collection-boolean={inputValues.choiceIcons.isCollection}
-                        builder-context={_builderContext}
-                        onvaluechanged={handleFlowComboboxValueChange}
-                        automatic-output-variables={automaticOutputVariables}
-                ></c-fsc_flow-combobox>
-                <lightning-combobox
-                        name="select_iconSize"
-                        label={inputValues.iconSize.label}
-                        value={inputValues.iconSize.value}
-                        required={isVisualCards}
-                        options={iconSizeOptions}
-                        onchange={handleValueChange}
-                ></lightning-combobox>
-        </template>
-        <lightning-radio-group name="select_inputMode" label={inputValues.inputMode.label}
-                options={selectDataSourceOptions} value={inputValues.inputMode.value} type="radio"
-                onchange={handleValueChange}></lightning-radio-group>
-        <!-- disabled={isVisualCards} onchange={handleValueChange}></lightning-radio-group> -->
-        <template if:true={isDatasourcePicklist}>
-                <c-fsc_pick-object-and-field-3 field-label={inputValues.fieldName.label}
-                        object-label={inputValues.objectName.label} object-type={inputValues.objectName.value}
-                        field={inputValues.fieldName.value} onfieldselected={handlePickObjectAndFieldValueChange}
-                        field-type-filter={settings.availableFieldTypesPicklist}></c-fsc_pick-object-and-field-3>
-
-                <c-fsc_flow-combobox name="select_recordTypeId" label={inputValues.recordTypeId.label}
-                        value={inputValues.recordTypeId.value} value-type={inputValues.recordTypeId.valueDataType}
-                        builder-context-filter-type="String"
-                        builder-context-filter-collection-boolean={inputValues.recordTypeId.isCollection}
-                        builder-context={_builderContext}
-                        onvaluechanged={handleFlowComboboxValueChange}
-                        automatic-output-variables={automaticOutputVariables}
-                ></c-fsc_flow-combobox>
-                
-                <!-- Dependent Picklist Attributes -->
-                <c-fsc_flow-checkbox
-                        name="select_dependentPicklist"
-                        label={inputValues.dependentPicklist.label}
-                        checked={inputValues.cb_dependentPicklist.value}
-                        field-level-help={inputValues.dependentPicklist.helpText}
-                        oncheckboxchanged={handleCheckboxChange}
-                ></c-fsc_flow-checkbox>
-                <div lwc:if={showControllingValues}>
-                        <c-fsc_flow-combobox 
-                                name="select_controllingPicklistValue" 
-                                label={inputValues.controllingPicklistValue.label}
-                                value={inputValues.controllingPicklistValue.value} 
-                                value-type={inputValues.controllingPicklistValue.valueDataType}
-                                field-level-help="If the controlling field is a Picklist, reference the controlling value here."
-                                builder-context-filter-type="String"
-                                builder-context-filter-collection-boolean={inputValues.controllingPicklistValue.isCollection}
-                                builder-context={_builderContext}
-                                onvaluechanged={handleFlowComboboxValueChange}
-                                automatic-output-variables={automaticOutputVariables}
-                        ></c-fsc_flow-combobox>
-                        <c-fsc_flow-combobox 
-                                name="select_controllingCheckboxValue" 
-                                label={inputValues.controllingCheckboxValue.label}
-                                value={inputValues.controllingCheckboxValue.value} 
-                                value-type={inputValues.controllingCheckboxValue.valueDataType}
-                                field-level-help="If the controlling field is a Checkbox, reference the controlling value here."
-                                builder-context-filter-type="Boolean"
-                                builder-context-filter-collection-boolean={inputValues.controllingCheckboxValue.isCollection}
-                                builder-context={_builderContext}
-                                onvaluechanged={handleFlowComboboxValueChange}
-                                automatic-output-variables={automaticOutputVariables}
-                        ></c-fsc_flow-combobox>
-                </div>
-
-        </template>
-
-        <template if:true={isDatasourceDualCollection}>
-                <c-fsc_flow-combobox name="select_choiceLabels" label={inputValues.choiceLabels.label}
-                        value={inputValues.choiceLabels.value} value-type={inputValues.choiceLabels.valueDataType}
-                        builder-context-filter-type="String"
-                        builder-context-filter-collection-boolean={inputValues.choiceLabels.isCollection}
-                        builder-context={_builderContext}
-                        onvaluechanged={handleFlowComboboxValueChange}
-                        automatic-output-variables={automaticOutputVariables}
-                ></c-fsc_flow-combobox>
-        </template>
-        <template if:true={isDatasourceSingleOrDualCollection}>
-                <c-fsc_flow-combobox name="select_choiceValues" label={inputValues.choiceValues.label}
-                        value={inputValues.choiceValues.value} value-type={inputValues.choiceValues.valueDataType}
-                        builder-context-filter-type="String"
-                        builder-context-filter-collection-boolean={inputValues.choiceValues.isCollection}
-                        builder-context={_builderContext} onvaluechanged={handleFlowComboboxValueChange}
-                        automatic-output-variables={automaticOutputVariables}>  
-                </c-fsc_flow-combobox>
-        </template>
-        <template if:true={isDatasourceStaticChoices}>
-                <div class="slds-text-link pointer" onclick={handleStaticChoicesOpen}>View/edit choices</div>
-        </template>
-
-        <lightning-input class="slds-p-top_x-small" type="checkbox" label={inputValues.allowNoneToBeChosen.label}
-                name="select_allowNoneToBeChosen" checked={inputValues.allowNoneToBeChosen.value}
-                onchange={handleValueChange}></lightning-input>
-        <template if:true={isDatasourcePicklist}>
-                <lightning-input type="checkbox" label={inputValues.sortList.label} name="select_sortList"
-                        checked={inputValues.sortList.value} onchange={handleValueChange}></lightning-input>
-        </template>
-        <lightning-input type="checkbox" label={inputValues.required.label} name="select_required"
-                checked={inputValues.required.value} onchange={handleValueChange}></lightning-input>
-        <lightning-input type="text" label={inputValues.masterLabel.label} name="select_masterLabel"
-                value={inputValues.masterLabel.value} onchange={handleValueChange}></lightning-input>
-        <lightning-input type="text" label={inputValues.helpText.label} name="select_helpText"
-                value={inputValues.helpText.value} field-level-help={inputValues.helpText.helpText} onchange={handleValueChange}></lightning-input>
-        <!-- <template if:false={showControllingValues}> -->
-                <c-fsc_flow-combobox name="select_value" label={inputValues.value.label} value={inputValues.value.value}
-                        value-type={inputValues.value.valueDataType} builder-context-filter-type="String"
-                        builder-context-filter-collection-boolean={inputValues.value.isCollection}
-                        builder-context={_builderContext}
-                        onvaluechanged={handleFlowComboboxValueChange}
-                        automatic-output-variables={automaticOutputVariables}
-                ></c-fsc_flow-combobox>
         <!-- </template> -->
-        <lightning-input type="number" label={inputValues.style_width.label} name="select_style_width"
-                value={inputValues.style_width.value} onchange={handleValueChange}></lightning-input>
+        <!-- <template if:true={inputValues.includeIcons.value}> -->
+        <c-fsc_flow-combobox
+            name="select_choiceIcons"
+            label={inputValues.choiceIcons.label}
+            value={inputValues.choiceIcons.value}
+            value-type={inputValues.choiceIcons.valueDataType}
+            builder-context-filter-type="String"
+            builder-context-filter-collection-boolean={inputValues.choiceIcons.isCollection}
+            builder-context={_builderContext}
+            onvaluechanged={handleFlowComboboxValueChange}
+            automatic-output-variables={automaticOutputVariables}
+        ></c-fsc_flow-combobox>
+        <lightning-combobox
+            name="select_iconSize"
+            label={inputValues.iconSize.label}
+            value={inputValues.iconSize.value}
+            required={isVisualCards}
+            options={iconSizeOptions}
+            onchange={handleValueChange}
+        ></lightning-combobox>
+    </template>
+    <lightning-radio-group
+        name="select_inputMode"
+        label={inputValues.inputMode.label}
+        options={selectDataSourceOptions}
+        value={inputValues.inputMode.value}
+        type="radio"
+        onchange={handleValueChange}
+    ></lightning-radio-group>
+    <!-- disabled={isVisualCards} onchange={handleValueChange}></lightning-radio-group> -->
+    <template if:true={isDatasourcePicklist}>
+        <c-fsc_pick-object-and-field-3
+            field-label={inputValues.fieldName.label}
+            object-label={inputValues.objectName.label}
+            object-type={inputValues.objectName.value}
+            field={inputValues.fieldName.value}
+            onfieldselected={handlePickObjectAndFieldValueChange}
+            field-type-filter={settings.availableFieldTypesPicklist}
+        ></c-fsc_pick-object-and-field-3>
 
-        <c-fsc_lwc-modal header="Edit Static Choices" confirm-button-label="Done" onconfirm={handleStaticChoicesSave}
-                validate-on-confirm=true class={staticChoicesModalClass}>
-                <div class="slds-grid slds-wrap">
-                        <div
-                                class="columnHeaders slds-col slds-size_1-of-1 slds-p-bottom_xxx-small slds-grid slds-text-title_bold">
-                                <div class="slds-col slds-size_5-of-12 slds-p-horizontal_small">Label</div>
-                                <div class="slds-col slds-p-horizontal_x-large">Value</div>
-                        </div>
+        <c-fsc_flow-combobox
+            name="select_recordTypeId"
+            label={inputValues.recordTypeId.label}
+            value={inputValues.recordTypeId.value}
+            value-type={inputValues.recordTypeId.valueDataType}
+            builder-context-filter-type="String"
+            builder-context-filter-collection-boolean={inputValues.recordTypeId.isCollection}
+            builder-context={_builderContext}
+            onvaluechanged={handleFlowComboboxValueChange}
+            automatic-output-variables={automaticOutputVariables}
+        ></c-fsc_flow-combobox>
 
-                        <template iterator:choice={tempStaticChoices}>
-                                <!-- <c-dragndrop-dropzone index={index} key={choice.value} list={tempStaticChoices}
+        <!-- Dependent Picklist Attributes -->
+        <c-fsc_flow-checkbox
+            name="select_dependentPicklist"
+            label={inputValues.dependentPicklist.label}
+            checked={inputValues.cb_dependentPicklist.value}
+            field-level-help={inputValues.dependentPicklist.helpText}
+            oncheckboxchanged={handleCheckboxChange}
+        ></c-fsc_flow-checkbox>
+        <div lwc:if={showControllingValues}>
+            <c-fsc_flow-combobox
+                name="select_controllingPicklistValue"
+                label={inputValues.controllingPicklistValue.label}
+                value={inputValues.controllingPicklistValue.value}
+                value-type={inputValues.controllingPicklistValue.valueDataType}
+                field-level-help="If the controlling field is a Picklist, reference the controlling value here."
+                builder-context-filter-type="String"
+                builder-context-filter-collection-boolean={inputValues.controllingPicklistValue.isCollection}
+                builder-context={_builderContext}
+                onvaluechanged={handleFlowComboboxValueChange}
+                automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                name="select_controllingCheckboxValue"
+                label={inputValues.controllingCheckboxValue.label}
+                value={inputValues.controllingCheckboxValue.value}
+                value-type={inputValues.controllingCheckboxValue.valueDataType}
+                field-level-help="If the controlling field is a Checkbox, reference the controlling value here."
+                builder-context-filter-type="Boolean"
+                builder-context-filter-collection-boolean={inputValues.controllingCheckboxValue.isCollection}
+                builder-context={_builderContext}
+                onvaluechanged={handleFlowComboboxValueChange}
+                automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+        </div>
+    </template>
+
+    <template if:true={isDatasourceDualCollection}>
+        <c-fsc_flow-combobox
+            name="select_choiceLabels"
+            label={inputValues.choiceLabels.label}
+            value={inputValues.choiceLabels.value}
+            value-type={inputValues.choiceLabels.valueDataType}
+            builder-context-filter-type="String"
+            builder-context-filter-collection-boolean={inputValues.choiceLabels.isCollection}
+            builder-context={_builderContext}
+            onvaluechanged={handleFlowComboboxValueChange}
+            automatic-output-variables={automaticOutputVariables}
+        ></c-fsc_flow-combobox>
+    </template>
+    <template if:true={isDatasourceSingleOrDualCollection}>
+        <c-fsc_flow-combobox
+            name="select_choiceValues"
+            label={inputValues.choiceValues.label}
+            value={inputValues.choiceValues.value}
+            value-type={inputValues.choiceValues.valueDataType}
+            builder-context-filter-type="String"
+            builder-context-filter-collection-boolean={inputValues.choiceValues.isCollection}
+            builder-context={_builderContext}
+            onvaluechanged={handleFlowComboboxValueChange}
+            automatic-output-variables={automaticOutputVariables}
+        >
+        </c-fsc_flow-combobox>
+    </template>
+    <template if:true={isDatasourceStaticChoices}>
+        <div class="slds-text-link pointer" onclick={handleStaticChoicesOpen}>View/edit choices</div>
+    </template>
+
+    <lightning-input
+        class="slds-p-top_x-small"
+        type="checkbox"
+        label={inputValues.allowNoneToBeChosen.label}
+        name="select_allowNoneToBeChosen"
+        checked={inputValues.allowNoneToBeChosen.value}
+        onchange={handleValueChange}
+    ></lightning-input>
+    <template if:true={isDatasourcePicklist}>
+        <lightning-input
+            type="checkbox"
+            label={inputValues.sortList.label}
+            name="select_sortList"
+            checked={inputValues.sortList.value}
+            onchange={handleValueChange}
+        ></lightning-input>
+    </template>
+    <lightning-input
+        type="checkbox"
+        label={inputValues.required.label}
+        name="select_required"
+        checked={inputValues.required.value}
+        onchange={handleValueChange}
+    ></lightning-input>
+    <lightning-input
+        type="text"
+        label={inputValues.masterLabel.label}
+        name="select_masterLabel"
+        value={inputValues.masterLabel.value}
+        onchange={handleValueChange}
+    ></lightning-input>
+    <lightning-input
+        type="text"
+        label={inputValues.helpText.label}
+        name="select_helpText"
+        value={inputValues.helpText.value}
+        field-level-help={inputValues.helpText.helpText}
+        onchange={handleValueChange}
+    ></lightning-input>
+    <!-- <template if:false={showControllingValues}> -->
+    <c-fsc_flow-combobox
+        name="select_value"
+        label={inputValues.value.label}
+        value={inputValues.value.value}
+        value-type={inputValues.value.valueDataType}
+        builder-context-filter-type="String"
+        builder-context-filter-collection-boolean={inputValues.value.isCollection}
+        builder-context={_builderContext}
+        onvaluechanged={handleFlowComboboxValueChange}
+        automatic-output-variables={automaticOutputVariables}
+    ></c-fsc_flow-combobox>
+    <!-- </template> -->
+    <lightning-input
+        type="number"
+        label={inputValues.style_width.label}
+        name="select_style_width"
+        value={inputValues.style_width.value}
+        onchange={handleValueChange}
+    ></lightning-input>
+
+    <c-fsc_lwc-modal
+        header="Edit Static Choices"
+        confirm-button-label="Done"
+        onconfirm={handleStaticChoicesSave}
+        validate-on-confirm="true"
+        class={staticChoicesModalClass}
+    >
+        <div class="slds-grid slds-wrap">
+            <div class="columnHeaders slds-col slds-size_1-of-1 slds-p-bottom_xxx-small slds-grid slds-text-title_bold">
+                <div class="slds-col slds-size_5-of-12 slds-p-horizontal_small">Label</div>
+                <div class="slds-col slds-p-horizontal_x-large">Value</div>
+            </div>
+
+            <template iterator:choice={tempStaticChoices}>
+                <!-- <c-dragndrop-dropzone index={index} key={choice.value} list={tempStaticChoices}
                                                 colour="#005fb2" ondropzonedrop={handleDropzoneDrop}></c-dragndrop-dropzone>
                                         <c-dragndrop-row index={index} key={choice}> -->
 
-                                <div class="staticChoiceRow slds-col slds-size_1-of-1 slds-grid slds-p-vertical_xx-small"
-                                        key={choice.value.value}>
-                                        <div class="slds-col">
-                                                <lightning-input variant="label-hidden" label="Label"
-                                                        placeholder="Label" value={choice.value.label}
-                                                        data-index={choice.index} data-property="label"
-                                                        oncommit={handleStaticChoiceChange}
-                                                        onfocus={handleStaticChoiceFocus} required>
-                                                </lightning-input>
-                                        </div>
+                <div
+                    class="staticChoiceRow slds-col slds-size_1-of-1 slds-grid slds-p-vertical_xx-small"
+                    key={choice.value.value}
+                >
+                    <div class="slds-col">
+                        <lightning-input
+                            variant="label-hidden"
+                            label="Label"
+                            placeholder="Label"
+                            value={choice.value.label}
+                            data-index={choice.index}
+                            data-property="label"
+                            oncommit={handleStaticChoiceChange}
+                            onfocus={handleStaticChoiceFocus}
+                            required
+                        >
+                        </lightning-input>
+                    </div>
 
-                                        <div class="slds-col">
-                                                <lightning-input variant="label-hidden" label="Value"
-                                                        placeholder="Value" value={choice.value.value}
-                                                        data-index={choice.index} data-property="value"
-                                                        oncommit={handleStaticChoiceChange}
-                                                        onfocus={handleStaticChoiceFocus} class="slds-p-left_small"
-                                                        required>
-                                                </lightning-input>
-                                        </div>
+                    <div class="slds-col">
+                        <lightning-input
+                            variant="label-hidden"
+                            label="Value"
+                            placeholder="Value"
+                            value={choice.value.value}
+                            data-index={choice.index}
+                            data-property="value"
+                            oncommit={handleStaticChoiceChange}
+                            onfocus={handleStaticChoiceFocus}
+                            class="slds-p-left_small"
+                            required
+                        >
+                        </lightning-input>
+                    </div>
 
-                                        <!-- lightning-button-icons that trigger row-level actions. Styling makes them mostly transparent until their row is hovered on-->
-                                        <div
-                                                class="actionColumn slds-grid slds-grid_vertical-align-center slds-p-left_xxx-small">
-                                                <div class="slds-col slds-size_1-of-2 slds-p-horizontal_xxx-small">
-
-                                                        <lightning-button-icon icon-name="utility:delete"
-                                                                data-index={choice.index}
-                                                                onclick={handleStaticChoiceDelete} title="Delete"
-                                                                variant="bare">
-                                                        </lightning-button-icon>
-                                                </div>
-                                                <div class="slds-col slds-size_1-of-2 slds-p-horizontal_xxx-small">
-                                                        <ul>
-                                                                <template if:false={choice.first}>
-                                                                        <li>
-                                                                                <lightning-button-icon
-                                                                                        icon-name="utility:up"
-                                                                                        data-index={choice.index}
-                                                                                        onclick={handleStaticChoiceMoveUp}
-                                                                                        title="Move up in list"
-                                                                                        variant="bare" size="small"
-                                                                                        class="slds-p-around_none slds-m-around_none">
-                                                                                </lightning-button-icon>
-                                                                        </li>
-                                                                </template>
-                                                                <template if:false={choice.last}>
-                                                                        <li>
-                                                                                <lightning-button-icon
-                                                                                        icon-name="utility:down"
-                                                                                        data-index={choice.index}
-                                                                                        onclick={handleStaticChoiceMoveDown}
-                                                                                        title="Move down in list"
-                                                                                        variant="bare" size="small"
-                                                                                        class="slds-p-around_none slds-m-around_none">
-                                                                                </lightning-button-icon>
-                                                                        </li>
-                                                                </template>
-                                                        </ul>
-                                                </div>
-                                        </div>
-                                </div>
-                                <!-- </c-dragndrop-row> -->
-                        </template>
-                        <!-- <c-dragndrop-dropzone index={tempStaticChoices.length} list={tempStaticChoices}
-                                        colour="#005fb2" ondropzonedrop={handleDropzoneDrop}></c-dragndrop-dropzone> -->
-                        <div class="listButtons slds-col slds-size_1-of-1 slds-p-top_small">
-                                <lightning-button label="Add new choice" icon-name="utility:add"
-                                        onmouseup={handleAddChoiceClick}>
-                                </lightning-button>
-                                <lightning-button label="Clear all" icon-name="utility:clear" class="slds-p-left_small"
-                                        variant="destructive-text" onmouseup={handleClearAllChoicesClick}>
-                                </lightning-button>
-
+                    <!-- lightning-button-icons that trigger row-level actions. Styling makes them mostly transparent until their row is hovered on-->
+                    <div class="actionColumn slds-grid slds-grid_vertical-align-center slds-p-left_xxx-small">
+                        <div class="slds-col slds-size_1-of-2 slds-p-horizontal_xxx-small">
+                            <lightning-button-icon
+                                icon-name="utility:delete"
+                                data-index={choice.index}
+                                onclick={handleStaticChoiceDelete}
+                                title="Delete"
+                                variant="bare"
+                            >
+                            </lightning-button-icon>
                         </div>
+                        <div class="slds-col slds-size_1-of-2 slds-p-horizontal_xxx-small">
+                            <ul>
+                                <template if:false={choice.first}>
+                                    <li>
+                                        <lightning-button-icon
+                                            icon-name="utility:up"
+                                            data-index={choice.index}
+                                            onclick={handleStaticChoiceMoveUp}
+                                            title="Move up in list"
+                                            variant="bare"
+                                            size="small"
+                                            class="slds-p-around_none slds-m-around_none"
+                                        >
+                                        </lightning-button-icon>
+                                    </li>
+                                </template>
+                                <template if:false={choice.last}>
+                                    <li>
+                                        <lightning-button-icon
+                                            icon-name="utility:down"
+                                            data-index={choice.index}
+                                            onclick={handleStaticChoiceMoveDown}
+                                            title="Move down in list"
+                                            variant="bare"
+                                            size="small"
+                                            class="slds-p-around_none slds-m-around_none"
+                                        >
+                                        </lightning-button-icon>
+                                    </li>
+                                </template>
+                            </ul>
+                        </div>
+                    </div>
                 </div>
-        </c-fsc_lwc-modal>
-        <div class="slds-text-title slds-text-align_right slds-m-top_xx-small slds-p-bottom_small slds-text-color_success">
-                QuickChoice Version #: {versionNumber}
+                <!-- </c-dragndrop-row> -->
+            </template>
+            <!-- <c-dragndrop-dropzone index={tempStaticChoices.length} list={tempStaticChoices}
+                                        colour="#005fb2" ondropzonedrop={handleDropzoneDrop}></c-dragndrop-dropzone> -->
+            <div class="listButtons slds-col slds-size_1-of-1 slds-p-top_small">
+                <lightning-button label="Add new choice" icon-name="utility:add" onmouseup={handleAddChoiceClick}>
+                </lightning-button>
+                <lightning-button
+                    label="Clear all"
+                    icon-name="utility:clear"
+                    class="slds-p-left_small"
+                    variant="destructive-text"
+                    onmouseup={handleClearAllChoicesClick}
+                >
+                </lightning-button>
+            </div>
         </div>
+    </c-fsc_lwc-modal>
+    <div class="slds-text-title slds-text-align_right slds-m-top_xx-small slds-p-bottom_small slds-text-color_success">
+        QuickChoice Version #: {versionNumber}
+    </div>
 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js
@@ -1,103 +1,139 @@
-import { api, track, LightningElement } from 'lwc';
+import { api, track, LightningElement } from "lwc";
 
-const CB_TRUE = 'CB_TRUE';            // Used with fsc_flowCheckbox component
-const CB_FALSE = 'CB_FALSE';          // Used with fsc_flowCheckbox component
-const CB_ATTRIB_PREFIX = 'cb_';       // Used with fsc_flowCheckbox component
+const CB_TRUE = "CB_TRUE"; // Used with fsc_flowCheckbox component
+const CB_FALSE = "CB_FALSE"; // Used with fsc_flowCheckbox component
+const CB_ATTRIB_PREFIX = "cb_"; // Used with fsc_flowCheckbox component
 
 export default class QuickChoiceCpe extends LightningElement {
     static delegatesFocus = true;
-    versionNumber = '2.46';
-    staticChoicesModalClass = 'staticChoicesModal';
+    versionNumber = "2.47";
+    staticChoicesModalClass = "staticChoicesModal";
     _builderContext;
     _values;
 
     @api staticChoicesString;
 
     @track inputValues = {
-        displayMode: { value: null, valueDataType: null, isCollection: false, label: 'Display the choices as:' },
-        isSameHeight: { value: null, valueDataType: null, isCollection: false, label: 'Display Columns As Same Height' },
-        isResponsive: { value: null, valueDataType: null, isCollection: false, label: 'Make Card Size Responsive' },
-        inputMode: { value: null, valueDataType: null, isCollection: false, label: 'Select datasource:' },
-        allowNoneToBeChosen: { value: null, valueDataType: null, isCollection: false, label: 'Add a \'None\' choice' },
-        sortList: { value: null, valueDataType: null, isCollection: false, label: 'Sort Picklist by Label' },
-        required: { value: null, valueDataType: null, isCollection: false, label: 'Required' },
-        masterLabel: { value: null, valueDataType: null, isCollection: false, label: 'Master Label' },
-        helpText: { value: null, valueDataType: null, isCollection: false, label: 'Help Text',
-            helpText: 'Optional help text to show with the Master Label' },
-        value: { value: null, valueDataType: null, isCollection: false, label: 'Value (Default or Existing)' },
-        style_width: { value: null, valueDataType: null, isCollection: false, label: 'Width (Pixels)' },
-        numberOfColumns: { value: null, valueDataType: null, isCollection: false, label: 'Number of Columns' },
-        includeIcons: { value: null, valueDataType: null, isCollection: false, label: 'Show Icons' },
-        navOnSelect: { value: false, valueDataType: null, isCollection: false, label: 'InstantNavigation Mode' },
-        choiceIcons: { value: null, valueDataType: null, isCollection: true, label: 'Choice Icons [Card Icons]' },
-        iconSize: { value: null, valueDataType: null, isCollection: false, label: 'Icon Size' },
-        objectName: { value: null, valueDataType: null, isCollection: false, label: 'Select Object' },
-        fieldName: { value: null, valueDataType: null, isCollection: false, label: 'Select Field' },
-        recordTypeId: { value: null, valueDataType: null, isCollection: false, label: 'Filter on Record Type ID:' },
-        dependentPicklist: { value: null, valueDataType: null, isCollection: false, label: 'Is this a Dependent Picklist?', 
-            helpText: 'Check this box if this is a dependent picklist and you will be defining a controlling value.  The controlling value can either be a picklist field value or a checkbox field value' },
-        cb_dependentPicklist: {value: null, valueDataType: null, isCollection: false, label: ''},
-        controllingPicklistValue: { value: null, valueDataType: null, isCollection: false, label: 'Controlling Value (Picklist Field):' },
-        controllingCheckboxValue: { value: null, valueDataType: null, isCollection: false, label: 'Controlling Value (Checkbox Field):' },
-        choiceLabels: { value: null, valueDataType: null, isCollection: true, label: 'Choice Labels [Card Titles]' },
-        choiceValues: { value: null, valueDataType: null, isCollection: true, label: 'Choice Values [Card Descriptions]' },
-        staticChoicesString: { value: null, valueDataType: null, isCollection: false, label: 'String of Static Choice (JSON)' },
-        richTextFlagString: { value: null, valueDataType: null, isCollection: false, label: 'Use Rich Text for Descriptions?' }
+        displayMode: { value: null, valueDataType: null, isCollection: false, label: "Display the choices as:" },
+        inputMode: { value: null, valueDataType: null, isCollection: false, label: "Select datasource:" },
+        allowNoneToBeChosen: { value: null, valueDataType: null, isCollection: false, label: "Add a 'None' choice" },
+        sortList: { value: null, valueDataType: null, isCollection: false, label: "Sort Picklist by Label" },
+        required: { value: null, valueDataType: null, isCollection: false, label: "Required" },
+        masterLabel: { value: null, valueDataType: null, isCollection: false, label: "Master Label" },
+        helpText: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "Help Text",
+            helpText: "Optional help text to show with the Master Label"
+        },
+        value: { value: null, valueDataType: null, isCollection: false, label: "Value (Default or Existing)" },
+        style_width: { value: null, valueDataType: null, isCollection: false, label: "Width (Pixels)" },
+        numberOfColumns: { value: null, valueDataType: null, isCollection: false, label: "Number of Columns" },
+        includeIcons: { value: null, valueDataType: null, isCollection: false, label: "Show Icons" },
+        navOnSelect: { value: false, valueDataType: null, isCollection: false, label: "InstantNavigation Mode" },
+        choiceIcons: { value: null, valueDataType: null, isCollection: true, label: "Choice Icons [Card Icons]" },
+        iconSize: { value: null, valueDataType: null, isCollection: false, label: "Icon Size" },
+        objectName: { value: null, valueDataType: null, isCollection: false, label: "Select Object" },
+        fieldName: { value: null, valueDataType: null, isCollection: false, label: "Select Field" },
+        recordTypeId: { value: null, valueDataType: null, isCollection: false, label: "Filter on Record Type ID:" },
+        dependentPicklist: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "Is this a Dependent Picklist?",
+            helpText:
+                "Check this box if this is a dependent picklist and you will be defining a controlling value.  The controlling value can either be a picklist field value or a checkbox field value"
+        },
+        cb_dependentPicklist: { value: null, valueDataType: null, isCollection: false, label: "" },
+        controllingPicklistValue: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "Controlling Value (Picklist Field):"
+        },
+        controllingCheckboxValue: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "Controlling Value (Checkbox Field):"
+        },
+        choiceLabels: { value: null, valueDataType: null, isCollection: true, label: "Choice Labels [Card Titles]" },
+        choiceValues: {
+            value: null,
+            valueDataType: null,
+            isCollection: true,
+            label: "Choice Values [Card Descriptions]"
+        },
+        staticChoicesString: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "String of Static Choice (JSON)"
+        },
+        richTextFlagString: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: "Use Rich Text for Descriptions?"
+        }
     };
 
     settings = {
-        displayModeVisualCards: 'Visual',
-        displayModePicklist: 'Picklist',
-        displayModeRadio: 'Radio',
-        inputModePicklist: 'Picklist Field',
-        inputModeDualCollection: 'Dual String Collections',
-        inputModeSingleCollection: 'Single String Collection',
-        inputModeStaticChoices: 'Static Choices',
-        inputValueRecordTypeId: 'recordTypeId',
-        choiceLabelsPicklistLabelsLabel: 'Choice Labels',
-        choiceLabelsPicklistValuesLabel: 'Choice Values',
-        choiceLabelsCardLabelsLabel: 'Card Titles (Labels)',
-        choiceLabelsCardValuesLabel: 'Card Descriptions (Values)',
-        attributeObjectName: 'objectName',
-        attributeFieldName: 'fieldName',
-        attributeInputMode: 'inputMode',
-        flowDataTypeString: 'String',
-        availableFieldTypesPicklist: 'Picklist',
-        inputAttributePrefix: 'select_',
-        singleColumn: '1'
-    }
+        displayModeVisualCards: "Visual",
+        displayModePicklist: "Picklist",
+        displayModeRadio: "Radio",
+        inputModePicklist: "Picklist Field",
+        inputModeDualCollection: "Dual String Collections",
+        inputModeSingleCollection: "Single String Collection",
+        inputModeStaticChoices: "Static Choices",
+        inputValueRecordTypeId: "recordTypeId",
+        choiceLabelsPicklistLabelsLabel: "Choice Labels",
+        choiceLabelsPicklistValuesLabel: "Choice Values",
+        choiceLabelsCardLabelsLabel: "Card Titles (Labels)",
+        choiceLabelsCardValuesLabel: "Card Descriptions (Values)",
+        attributeObjectName: "objectName",
+        attributeFieldName: "fieldName",
+        attributeInputMode: "inputMode",
+        flowDataTypeString: "String",
+        availableFieldTypesPicklist: "Picklist",
+        inputAttributePrefix: "select_",
+        singleColumn: "1"
+    };
 
     displayChoicesAsOptions = [
-        { label: 'Picklist', value: 'Picklist' },
-        { label: 'Radio Button Group', value: 'Radio' },
-        { label: 'Visual Cards', value: 'Visual' }
+        { label: "Picklist", value: "Picklist" },
+        { label: "Radio Button Group", value: "Radio" },
+        { label: "Visual Cards", value: "Visual" }
     ];
 
     numberOfColumnOptions = [
-        { label: '1', value: '1' },
-        { label: '2', value: '2' }
+        { label: "1", value: "1" },
+        { label: "2", value: "2" }
     ];
 
     iconSizeOptions = [
-        { label: 'x-small', value: 'x-small' },
-        { label: 'small', value: 'small' },
-        { label: 'medium', value: 'medium' },
-        { label: 'large', value: 'large' }
+        { label: "x-small", value: "x-small" },
+        { label: "small", value: "small" },
+        { label: "medium", value: "medium" },
+        { label: "large", value: "large" }
     ];
 
     selectDataSourceOptions = [
-        { label: 'A Picklist field', value: this.settings.inputModePicklist },
-        { label: 'Two String Collections (Labels and Values)', value: this.settings.inputModeDualCollection },
-        { label: 'One String Collection (Values)', value: this.settings.inputModeSingleCollection },
-        { label: 'Static Choices', value: this.settings.inputModeStaticChoices }
+        { label: "A Picklist field", value: this.settings.inputModePicklist },
+        { label: "Two String Collections (Labels and Values)", value: this.settings.inputModeDualCollection },
+        { label: "One String Collection (Values)", value: this.settings.inputModeSingleCollection },
+        { label: "Static Choices", value: this.settings.inputModeStaticChoices }
     ];
 
     useValuesOptions = [
-        { label: 'Yes', value: 'true' },
-        { label: 'No', value: null }
-    ]
+        { label: "Yes", value: "true" },
+        { label: "No", value: null }
+    ];
     useValues;
-    get disableLabels() { return !this.useValues; }
+    get disableLabels() {
+        return !this.useValues;
+    }
     handleUseValuesClick(event) {
         this.useValues = event.detail.value;
     }
@@ -118,31 +154,23 @@ export default class QuickChoiceCpe extends LightningElement {
         this._values = value;
         this.initializeValues();
     }
-    
-    @api get automaticOutputVariables () {
-        console.log('automaticvars: ' + JSON.stringify(this._automaticOutputVariables));
+
+    @api get automaticOutputVariables() {
+        console.log("automaticvars: " + JSON.stringify(this._automaticOutputVariables));
         return this._automaticOutputVariables;
     }
 
-    set automaticOutputVariables (value) {
+    set automaticOutputVariables(value) {
         this._automaticOutputVariables = value;
     }
 
-	_automaticOutputVariables;
+    _automaticOutputVariables;
 
     @track staticChoices = [this.newChoice()];
     @track tempStaticChoices = [];
 
     get isVisualCards() {
         return this.inputValues.displayMode.value === this.settings.displayModeVisualCards;
-    }
-
-    get isSingleColumn() {
-        return this.inputValues.numberOfColumns.value === this.settings.singleColumn;
-    }
-
-    get isDualColumn() {
-        return this.inputValues.numberOfColumns.value != this.settings.singleColumn;
     }
 
     get isDatasourcePicklist() {
@@ -158,7 +186,10 @@ export default class QuickChoiceCpe extends LightningElement {
     }
 
     get isDatasourceSingleOrDualCollection() {
-        return this.inputValues.inputMode.value === this.settings.inputModeSingleCollection || this.inputValues.inputMode.value === this.settings.inputModeDualCollection;
+        return (
+            this.inputValues.inputMode.value === this.settings.inputModeSingleCollection ||
+            this.inputValues.inputMode.value === this.settings.inputModeDualCollection
+        );
     }
 
     get isDatasourceStaticChoices() {
@@ -166,30 +197,28 @@ export default class QuickChoiceCpe extends LightningElement {
     }
 
     get staticChoicesModal() {
-        return this.template.querySelector('.' + this.staticChoicesModalClass);
+        return this.template.querySelector("." + this.staticChoicesModalClass);
     }
 
     get isRichText() {
-        return this.inputValues.richTextFlagString.value === 'RICHTEXT';
+        return this.inputValues.richTextFlagString.value === "RICHTEXT";
     }
 
     get showControllingValues() {
         return this.inputValues.cb_dependentPicklist.value === CB_TRUE;
     }
-    
-    initializeValues(value) {
-        console.log('automaticvars init: ' + JSON.stringify(this._automaticOutputVariables));
-        if (this._values && this._values.length) {
 
-            this._values.forEach(curInputParam => {
+    initializeValues(value) {
+        console.log("automaticvars init: " + JSON.stringify(this._automaticOutputVariables));
+        if (this._values && this._values.length) {
+            this._values.forEach((curInputParam) => {
                 if (curInputParam.name && this.inputValues[curInputParam.name]) {
                     this.inputValues[curInputParam.name].value = curInputParam.value;
                     this.inputValues[curInputParam.name].valueDataType = curInputParam.valueDataType;
-                    if (curInputParam.name === 'staticChoicesString') {
+                    if (curInputParam.name === "staticChoicesString") {
                         // console.log('The current input param is staticChoicesString, so we parse it into our staticChoices variable. '+ curInputParam.value);
                         this.staticChoices = JSON.parse(curInputParam.value);
                     }
-
                 }
             });
         }
@@ -198,13 +227,17 @@ export default class QuickChoiceCpe extends LightningElement {
     }
 
     setChoiceLabels() {
-        if (this.inputValues.displayMode.value === this.settings.displayModeVisualCards &&
-            this.inputValues.choiceLabels.label !== this.settings.choiceLabelsCardLabelsLabel) {
+        if (
+            this.inputValues.displayMode.value === this.settings.displayModeVisualCards &&
+            this.inputValues.choiceLabels.label !== this.settings.choiceLabelsCardLabelsLabel
+        ) {
             this.inputValues.choiceLabels.label = this.settings.choiceLabelsCardLabelsLabel;
             this.inputValues.choiceValues.label = this.settings.choiceLabelsCardValuesLabel;
         }
-        if (this.inputValues.displayMode.value !== this.settings.displayModeVisualCards &&
-            this.inputValues.choiceLabels.label !== this.settings.choiceLabelsPicklistLabelsLabel) {
+        if (
+            this.inputValues.displayMode.value !== this.settings.displayModeVisualCards &&
+            this.inputValues.choiceLabels.label !== this.settings.choiceLabelsPicklistLabelsLabel
+        ) {
             this.inputValues.choiceLabels.label = this.settings.choiceLabelsPicklistLabelsLabel;
             this.inputValues.choiceValues.label = this.settings.choiceLabelsPicklistValuesLabel;
         }
@@ -219,32 +252,39 @@ export default class QuickChoiceCpe extends LightningElement {
     newChoice(label, value) {
         return {
             label: label,
-            value: value,
-        }
+            value: value
+        };
     }
 
     handlePickObjectAndFieldValueChange(event) {
         if (event.detail) {
-            this.dispatchFlowValueChangeEvent(this.settings.attributeObjectName, event.detail.objectType, this.settings.flowDataTypeString);
-            this.dispatchFlowValueChangeEvent(this.settings.attributeFieldName, event.detail.fieldName, this.settings.flowDataTypeString);
+            this.dispatchFlowValueChangeEvent(
+                this.settings.attributeObjectName,
+                event.detail.objectType,
+                this.settings.flowDataTypeString
+            );
+            this.dispatchFlowValueChangeEvent(
+                this.settings.attributeFieldName,
+                event.detail.fieldName,
+                this.settings.flowDataTypeString
+            );
         }
     }
 
     handleFlowComboboxValueChange(event) {
         if (event.target && event.detail) {
-
-            let curAttributeName = event.target.name.replace(this.settings.inputAttributePrefix, '');
+            let curAttributeName = event.target.name.replace(this.settings.inputAttributePrefix, "");
             let curAttributeValue = event.detail.newValue;
             let curAttributeType = event.detail.newValueDataType;
 
-            if (curAttributeName == 'controllingPicklistValue') {
+            if (curAttributeName == "controllingPicklistValue") {
                 this.inputValues.controllingCheckboxValue.value = null;
-                this.dispatchFlowValueChangeEvent('controllingCheckboxValue', null, curAttributeType);
+                this.dispatchFlowValueChangeEvent("controllingCheckboxValue", null, curAttributeType);
             }
 
-            if (curAttributeName == 'controllingCheckboxValue') {
+            if (curAttributeName == "controllingCheckboxValue") {
                 this.inputValues.controllingPicklistValue.value = null;
-                this.dispatchFlowValueChangeEvent('controllingPicklistValue', null, curAttributeType);
+                this.dispatchFlowValueChangeEvent("controllingPicklistValue", null, curAttributeType);
             }
 
             this.dispatchFlowValueChangeEvent(curAttributeName, curAttributeValue, curAttributeType);
@@ -253,37 +293,48 @@ export default class QuickChoiceCpe extends LightningElement {
 
     handleValueChange(event) {
         if (event.target) {
-            let curAttributeName = event.target.name ? event.target.name.replace(this.settings.inputAttributePrefix, '') : null;
-            let curAttributeValue = event.target.type === 'checkbox' ? event.target.checked : event.detail.value;
+            let curAttributeName = event.target.name
+                ? event.target.name.replace(this.settings.inputAttributePrefix, "")
+                : null;
+            let curAttributeValue = event.target.type === "checkbox" ? event.target.checked : event.detail.value;
             let curAttributeType;
             switch (event.target.type) {
                 case "checkbox":
-                    curAttributeType = 'Boolean';
+                    curAttributeType = "Boolean";
                     break;
                 case "number":
-                    curAttributeType = 'Number';
+                    curAttributeType = "Number";
                     break;
                 default:
-                    curAttributeType = 'String';
+                    curAttributeType = "String";
             }
 
-            if (curAttributeName == 'richTextFlagString') {
-                curAttributeValue = (event.target.checked) ? 'RICHTEXT' : null
-                curAttributeType = 'String';
+            if (curAttributeName == "richTextFlagString") {
+                curAttributeValue = event.target.checked ? "RICHTEXT" : null;
+                curAttributeType = "String";
                 this.inputValues.richTextFlagString.value = curAttributeValue;
             }
 
-            console.log('The current attribute name is ' + curAttributeName + ' and the current attribute value is ' + curAttributeValue);
-            console.log('The current attribute type is ' + curAttributeType);
+            console.log(
+                "The current attribute name is " +
+                    curAttributeName +
+                    " and the current attribute value is " +
+                    curAttributeValue
+            );
+            console.log("The current attribute type is " + curAttributeType);
             this.dispatchFlowValueChangeEvent(curAttributeName, curAttributeValue, curAttributeType);
         }
     }
 
     handleCheckboxChange(event) {
         if (event.target && event.detail) {
-            let changedAttribute = event.target.name.replace(this.settings.inputAttributePrefix, '');
+            let changedAttribute = event.target.name.replace(this.settings.inputAttributePrefix, "");
             this.dispatchFlowValueChangeEvent(changedAttribute, event.detail.newValue, event.detail.newValueDataType);
-            this.dispatchFlowValueChangeEvent(CB_ATTRIB_PREFIX+changedAttribute, event.detail.newStringValue, 'String');
+            this.dispatchFlowValueChangeEvent(
+                CB_ATTRIB_PREFIX + changedAttribute,
+                event.detail.newStringValue,
+                "String"
+            );
         }
     }
 
@@ -316,29 +367,35 @@ export default class QuickChoiceCpe extends LightningElement {
         const index = event.currentTarget.dataset.index;
         const value = event.currentTarget.value;
         let propertyName = event.currentTarget.dataset.property;
-        console.log('We are setting the "' + propertyName + '" property on choice with index #' + index + ' to: ' + value);
+        console.log(
+            'We are setting the "' + propertyName + '" property on choice with index #' + index + " to: " + value
+        );
         this.tempStaticChoices[index][propertyName] = value;
     }
 
     handleAddChoiceClick() {
         this.tempStaticChoices.push(this.newChoice());
-        this.staticChoicesModal.focusSelectorString = '.staticChoiceRow lightning-input[data-index="' + (this.tempStaticChoices.length - 1) + '"]';
+        this.staticChoicesModal.focusSelectorString =
+            '.staticChoiceRow lightning-input[data-index="' + (this.tempStaticChoices.length - 1) + '"]';
     }
 
     handleClearAllChoicesClick() {
         this.tempStaticChoices = [this.newChoice()];
-        this.staticChoices.focusSelectorString = '.staticChoiceRow lightning-input';
+        this.staticChoices.focusSelectorString = ".staticChoiceRow lightning-input";
     }
 
     handleStaticChoicesOpen() {
         // Create a clone of the list of static choices to use as temp values while the modal is open
-        this.tempStaticChoices = this.staticChoices.map(choice => { return Object.assign({}, choice); });
+        this.tempStaticChoices = this.staticChoices.map((choice) => {
+            return Object.assign({}, choice);
+        });
         this.staticChoicesModal.open();
     }
 
     handleStaticChoiceMoveUp(event) {
         let index = event.currentTarget.dataset.index;
-        if (index) {// this excludes index of 0, which can't be moved up
+        if (index) {
+            // this excludes index of 0, which can't be moved up
             const movingChoice = this.tempStaticChoices.splice(index, 1);
             this.tempStaticChoices.splice(index - 1, 0, ...movingChoice);
         }
@@ -346,30 +403,33 @@ export default class QuickChoiceCpe extends LightningElement {
 
     handleStaticChoiceMoveDown(event) {
         let index = event.currentTarget.dataset.index;
-        if (index && this.index != this.tempStaticChoices.length - 1) { // this includes the final index, which can't be moved down
+        if (index && this.index != this.tempStaticChoices.length - 1) {
+            // this includes the final index, which can't be moved down
             const movingChoice = this.tempStaticChoices.splice(index, 1);
             this.tempStaticChoices.splice(Number(index) + 1, 0, ...movingChoice);
         }
     }
 
-
     handleStaticChoicesSave() {
-        console.log('in handleStaticChoicesSave');
+        console.log("in handleStaticChoicesSave");
         // We used to handle validation here, but now that's been offloaded to the modal
-        
-            // Clone the updated tempStaticChoices into staticChoices, then delete the temps
-            this.staticChoices = this.tempStaticChoices.map(choice => {
-                return { label: choice.label, value: choice.value }
-            })
-            this.tempStaticChoices = [];
-            
-            this.staticChoicesModal.close();
-            // Stringify the new saved list of choices, and dispatch that value. This will be parsed in initializeValues() when the component is next loaded 
-            this.inputValues.staticChoicesString.value = JSON.stringify(this.staticChoices);
-            // let labels = this.staticChoices.map(choice => { return choice.label });
-            // let values = this.staticChoices.map(choice => { return choice.value });
-            this.dispatchFlowValueChangeEvent('staticChoicesString', this.inputValues.staticChoicesString.value, this.settings.flowDataTypeString);
-        
+
+        // Clone the updated tempStaticChoices into staticChoices, then delete the temps
+        this.staticChoices = this.tempStaticChoices.map((choice) => {
+            return { label: choice.label, value: choice.value };
+        });
+        this.tempStaticChoices = [];
+
+        this.staticChoicesModal.close();
+        // Stringify the new saved list of choices, and dispatch that value. This will be parsed in initializeValues() when the component is next loaded
+        this.inputValues.staticChoicesString.value = JSON.stringify(this.staticChoices);
+        // let labels = this.staticChoices.map(choice => { return choice.label });
+        // let values = this.staticChoices.map(choice => { return choice.value });
+        this.dispatchFlowValueChangeEvent(
+            "staticChoicesString",
+            this.inputValues.staticChoicesString.value,
+            this.settings.flowDataTypeString
+        );
     }
 
     handleStaticChoiceDelete(event) {
@@ -380,9 +440,8 @@ export default class QuickChoiceCpe extends LightningElement {
         }
     }
 
-
     dispatchFlowValueChangeEvent(id, newValue, newValueDataType) {
-        const valueChangedEvent = new CustomEvent('configuration_editor_input_value_changed', {
+        const valueChangedEvent = new CustomEvent("configuration_editor_input_value_changed", {
             bubbles: true,
             cancelable: false,
             composed: true,

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceCpe/fsc_quickChoiceCpe.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Quick Choice Cpe</description>
     <isExposed>true</isExposed>
     <masterLabel>Quick Choice Cpe</masterLabel>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.html
@@ -18,6 +18,12 @@ Additional components packaged with this LWC:
                                                 GetRecordTypeInfobyObjectTest
                                                 QuickChoiceMockHttpResponseGenerator
 
+08/08/25 - Tyler Raguseo - Version 2.47
+                            Fixed clipping issues with visual card displays on smaller form factors
+                            Force 1 column display for visual cards on mobile devices, even if user selects 2 columns
+                            Visual cards are now always responsive
+                            Dual column visual cards now always have the same height
+
 4/14/25 -   Eric Smith -    Version 2.46
                             Support a Picklist field for Visual Cards
 
@@ -108,11 +114,12 @@ Additional components packaged with this LWC:
     <template if:true={showPicklist}>
         <!-- Display Visual Card Pickers -->
         <template if:true={showVisual}>
-            <fieldset class="slds-form-element" style="margin-right:1rem;">
+            <fieldset class="slds-form-element" style="margin-right: 1rem">
                 <div class="slds-grid">
                     <div class="slds-col slds-grow-none">
                         <label class="slds-form-element__legend slds-form-element__label">
-                            <abbr class="slds-required" title="required">{requiredSymbol}</abbr>{masterLabel}</label>
+                            <abbr class="slds-required" title="required">{requiredSymbol}</abbr>{masterLabel}</label
+                        >
                     </div>
                     <div class={showHelpText}>
                         <div class="slds-col">
@@ -123,27 +130,46 @@ Additional components packaged with this LWC:
                 <div class={gridClass} style={gridStyle}>
                     <template for:each={items} for:item="item">
                         <div key={item.name} class={columnClass} style={responsiveSize}>
-                            <input type="radio" id={item.name} value={item.name} name={radioGroup} data-id={item.name} onclick={handleChange} />
-                            <label for={item.name}>
-
+                            <input
+                                type="radio"
+                                id={item.name}
+                                value={item.name}
+                                name={radioGroup}
+                                data-id={item.name}
+                                onclick={handleChange}
+                            />
+                            <label for={item.name} style="height: 100%">
                                 <!-- Display Visual Card Pickers with Icons-->
                                 <template if:true={includeIcons}>
                                     <span
                                         class="slds-visual-picker__figure slds-visual-picker__text slds-box slds-box_link slds-box_x-small slds-media"
-                                        style={cardSize}>
+                                        style={cardSize}
+                                    >
                                         <div
-                                            class="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center slds-m-left_xx-small">
-                                            <lightning-avatar size={iconSize} src={item.icon} fallback-icon-name={item.icon}></lightning-avatar>
+                                            class="slds-media__figure slds-media__figure_fixed-width slds-align_absolute-center slds-m-left_xx-small"
+                                        >
+                                            <lightning-avatar
+                                                size={iconSize}
+                                                src={item.icon}
+                                                fallback-icon-name={item.icon}
+                                            ></lightning-avatar>
                                             <!-- <span class="slds-icon_container">
                                                 <lightning-icon icon-name={item.icon} size={iconSize}>
                                                 </lightning-icon>
                                             </span> -->
                                         </div>
                                         <div
-                                            class="slds-media__body slds-border_left slds-p-left_small slds-p-top_xxx-small">
-                                            <span class="slds-text-heading_medium slds-m-bottom_x-small">{item.name}</span>
+                                            class="slds-media__body slds-border_left slds-p-left_small slds-p-top_xxx-small"
+                                        >
+                                            <span class="slds-text-heading_medium slds-m-bottom_x-small wrapped-content"
+                                                >{item.name}</span
+                                            >
                                             <template lwc:if={showAsRichText}>
-                                                <span class="slds-text-title"><lightning-formatted-rich-text value={item.description}></lightning-formatted-rich-text></span>
+                                                <span class="slds-text-title wrapped-content"
+                                                    ><lightning-formatted-rich-text
+                                                        value={item.description}
+                                                    ></lightning-formatted-rich-text
+                                                ></span>
                                             </template>
                                             <template lwc:else>
                                                 <span class="slds-text-title wrapped-content">{item.description}</span>
@@ -152,18 +178,22 @@ Additional components packaged with this LWC:
                                     </span>
                                 </template>
 
-                                <!-- Display Visual Card Pickers without Icons-->                            
+                                <!-- Display Visual Card Pickers without Icons-->
                                 <template if:false={includeIcons}>
-                                    <span
-                                        class="slds-visual-picker__figure slds-visual-picker__text"
-                                        style={cardSize}>
+                                    <span class="slds-visual-picker__figure slds-visual-picker__text" style={cardSize}>
                                         <span>
-                                            <span class="slds-text-heading_medium slds-m-bottom_x-small">{item.name}</span>
+                                            <span class="slds-text-heading_medium slds-m-bottom_x-small wrapped-content"
+                                                >{item.name}</span
+                                            >
                                             <template lwc:if={showAsRichText}>
-                                                <span class="slds-text-title"><lightning-formatted-rich-text value={item.description}></lightning-formatted-rich-text></span>
+                                                <span class="slds-text-title wrapped-content"
+                                                    ><lightning-formatted-rich-text
+                                                        value={item.description}
+                                                    ></lightning-formatted-rich-text
+                                                ></span>
                                             </template>
                                             <template lwc:else>
-                                                <span class="slds-text-title">{item.description}</span>
+                                                <span class="slds-text-title wrapped-content">{item.description}</span>
                                             </template>
                                         </span>
                                     </span>
@@ -181,20 +211,20 @@ Additional components packaged with this LWC:
         </template>
 
         <template if:false={showVisual}>
-
             <!-- Display Radio Buttons -->
             <template if:true={showRadio}>
                 <div style={inputStyle} class={inputClass}>
                     <div class="slds-grid">
                         <div class="slds-col slds-grow-none">
-                            <lightning-radio-group 
-                                name={radioGroup} 
-                                label={masterLabel} 
+                            <lightning-radio-group
+                                name={radioGroup}
+                                label={masterLabel}
                                 value={selectedValue}
                                 options={options}
-                                required={required} 
-                                onchange={handleChange} 
-                                type="radio">
+                                required={required}
+                                onchange={handleChange}
+                                type="radio"
+                            >
                             </lightning-radio-group>
                         </div>
                         <div class={showHelpText}>
@@ -209,18 +239,18 @@ Additional components packaged with this LWC:
             <!-- Display Picklist -->
             <template if:false={showRadio}>
                 <div style={inputStyle} class={inputClass}>
-                    <lightning-combobox 
-                        name={masterLabel} 
-                        label={masterLabel} 
+                    <lightning-combobox
+                        name={masterLabel}
+                        label={masterLabel}
                         value={selectedValue}
                         options={options}
-                        required={required} 
+                        required={required}
                         field-level-help={helpText}
-                        onchange={handleChange}>
+                        onchange={handleChange}
+                    >
                     </lightning-combobox>
                 </div>
             </template>
-
         </template>
     </template>
 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js
@@ -1,21 +1,21 @@
-import {LightningElement, api, track, wire} from "lwc";
-import {FlowAttributeChangeEvent, FlowNavigationNextEvent} from "lightning/flowSupport";
-import {getPicklistValues} from "lightning/uiObjectInfoApi";
-import Quickchoice_Images from '@salesforce/resourceUrl/fsc_Quickchoice_Images';	//Static Resource containing images for Visual Cards
+import { LightningElement, api, track, wire } from "lwc";
+import { FlowAttributeChangeEvent, FlowNavigationNextEvent } from "lightning/flowSupport";
+import { getPicklistValues } from "lightning/uiObjectInfoApi";
+import Quickchoice_Images from "@salesforce/resourceUrl/fsc_Quickchoice_Images"; //Static Resource containing images for Visual Cards
+import formFactor from "@salesforce/client/formFactor"; //Used to determine if the device is a phone or not
 
 /* eslint-disable no-alert */
 /* eslint-disable no-console */
 
-const CB_TRUE = 'CB_TRUE';
+const CB_TRUE = "CB_TRUE";
 
 export default class QuickChoiceFSC extends LightningElement {
-
-    bottomPadding = 'slds-p-bottom_x-small';
+    bottomPadding = "slds-p-bottom_x-small";
 
     @api
     availableActions = [];
 
-    @api 
+    @api
     get masterLabel() {
         return this._masterLabel;
     }
@@ -26,10 +26,10 @@ export default class QuickChoiceFSC extends LightningElement {
 
     @api helpText;
     get showHelpText() {
-        return (this.helpText?.length > 0) ? "slds-show" : "slds-hide";
+        return this.helpText?.length > 0 ? "slds-show" : "slds-hide";
     }
 
-    @api 
+    @api
     get choiceLabels() {
         return this._choiceLabels;
     }
@@ -43,7 +43,7 @@ export default class QuickChoiceFSC extends LightningElement {
     }
     _choiceLabels = [];
 
-    @api 
+    @api
     get choiceValues() {
         return this._choiceValues;
     }
@@ -63,24 +63,25 @@ export default class QuickChoiceFSC extends LightningElement {
 
     @api richTextFlagString; //Show Visual Card descriptions as RichText if value = RICHTEXT
     get showAsRichText() {
-        return this.richTextFlagString == 'RICHTEXT';
+        return this.richTextFlagString == "RICHTEXT";
     }
 
     //-------------For inputMode = Picklist
     @api allowNoneToBeChosen; //For picklist field only
-    @api sortList;          //used for picklist fields
+    @api sortList; //used for picklist fields
 
-    @api 
-    get recordTypeId() {    //used for picklist fields
+    @api
+    get recordTypeId() {
+        //used for picklist fields
         return this._recordTypeId;
     }
     set recordTypeId(rtvalue) {
-        this._recordTypeId = (!rtvalue) ? this.masterRecordTypeId : rtvalue;
+        this._recordTypeId = !rtvalue ? this.masterRecordTypeId : rtvalue;
     }
     _recordTypeId;
 
-    @api objectName;        //used for picklist fields
-    @api fieldName;         //used for picklist fields
+    @api objectName; //used for picklist fields
+    @api fieldName; //used for picklist fields
 
     _controllingPicklistValue;
     _controllingCheckboxValue;
@@ -89,13 +90,13 @@ export default class QuickChoiceFSC extends LightningElement {
     picklistFieldDetails;
     isControlledByCheckbox = false;
     priorOptions = [];
-    firstPassCompleted = false; 
+    firstPassCompleted = false;
     isConnected = false;
     @api isRendered = false;
 
     @api
     get dependentPicklist() {
-        return (this.cb_dependentPicklist == CB_TRUE) ? true : false;
+        return this.cb_dependentPicklist == CB_TRUE ? true : false;
     }
     set dependentPicklist(value) {}
 
@@ -113,7 +114,8 @@ export default class QuickChoiceFSC extends LightningElement {
             if (value != this.priorControllingValue) {
                 this.priorControllingValue = value;
                 this.setPicklistSelections(this.picklistFieldDetails);
-                if (this.isConnected) { // Don't clear default value of dependent picklist on initial load v2.45
+                if (this.isConnected) {
+                    // Don't clear default value of dependent picklist on initial load v2.45
                     this.clearSelectedValue();
                 }
             }
@@ -132,20 +134,22 @@ export default class QuickChoiceFSC extends LightningElement {
             if (value != this.priorControllingValue) {
                 this.priorControllingValue = value;
                 this.setPicklistSelections(this.picklistFieldDetails);
-                if (this.isConnected) { // Don't clear default value of dependent picklist on initial load v2.45
+                if (this.isConnected) {
+                    // Don't clear default value of dependent picklist on initial load v2.45
                     this.clearSelectedValue();
                 }
             }
         }
     }
 
-    clearSelectedValue() {  // v2.45 Clear current selected value if controlling value changes
+    clearSelectedValue() {
+        // v2.45 Clear current selected value if controlling value changes
         this.selectedValue = "";
-        this.dispatchFlowAttributeChangedEvent('value', this._selectedValue);
+        this.dispatchFlowAttributeChangedEvent("value", this._selectedValue);
     }
 
     //-------------For inputMode = Visual Text Box (Card)
-    @api 
+    @api
     get choiceIcons() {
         return this._choiceIcons;
     }
@@ -162,8 +166,10 @@ export default class QuickChoiceFSC extends LightningElement {
     @api includeIcons;
     @api iconSize;
     @api navOnSelect;
-    @api isResponsive;
+    //deprecated as of v2.47
     @api isSameHeight;
+    //deprecated as of v2.47
+    @api isResponsive;
 
     //-------------For displayMode = Picklist or Radio
     @api style_width = 320;
@@ -185,14 +191,14 @@ export default class QuickChoiceFSC extends LightningElement {
         return this._staticChoices || [];
     }
     set staticChoices(choices) {
-        console.log(this._masterLabel + ": ", 'setting staticChoices to '+ JSON.stringify(choices));
+        console.log(this._masterLabel + ": ", "setting staticChoices to " + JSON.stringify(choices));
         if (choices != null) {
             this._staticChoices = choices;
             this._choiceValues = [];
             this._choiceLabels = [];
             for (let choice of choices) {
                 this._choiceValues.push(choice.value);
-                this._choiceLabels.push(choice.label);        
+                this._choiceLabels.push(choice.label);
             }
         }
     }
@@ -200,7 +206,7 @@ export default class QuickChoiceFSC extends LightningElement {
 
     masterRecordTypeId = "012000000000000AAA"; //if a recordTypeId is not provided, use this one
 
-    @api 
+    @api
     get inputMode() {
         return this._inputMode;
     }
@@ -214,7 +220,7 @@ export default class QuickChoiceFSC extends LightningElement {
 
     // @track selectedValue;
     _selectedValue = null;
-    @api 
+    @api
     get selectedValue() {
         return this._selectedValue;
     }
@@ -250,11 +256,11 @@ export default class QuickChoiceFSC extends LightningElement {
         this._picklistOptions = data;
     }
 
-    @api 
+    @api
     get showPicklist() {
         // Show if not controlled or if controlled that there are available picklist values
-        this._controllingPicklistValue
-        return (!this._isControlled || this._picklistOptions.length > 0 || this.isControlledByCheckbox);
+        this._controllingPicklistValue;
+        return !this._isControlled || this._picklistOptions.length > 0 || this.isControlledByCheckbox;
     }
 
     set showPicklist(value) {
@@ -270,7 +276,7 @@ export default class QuickChoiceFSC extends LightningElement {
         this._isControlled = value;
     }
 
-    @api 
+    @api
     get value() {
         return this._selectedValue;
     }
@@ -311,9 +317,9 @@ export default class QuickChoiceFSC extends LightningElement {
     set radioGroup(value) {
         this.radioGroup = value;
     }
-    
+
     get requiredSymbol() {
-        return this.required ? '*' : '';
+        return this.required ? "*" : "";
     }
 
     //possibility master record type only works if there aren't other record types?
@@ -321,7 +327,7 @@ export default class QuickChoiceFSC extends LightningElement {
         recordTypeId: "$recordTypeId",
         fieldApiName: "$calculatedObjectAndFieldName"
     })
-    picklistValues({error, data}) {
+    picklistValues({ error, data }) {
         if (data) {
             console.log(this._masterLabel + ": ", "getPicklistValues returned data", data);
             this.setPicklistSelections(data);
@@ -333,12 +339,12 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     get calculatedObjectAndFieldName() {
-        console.log(this._masterLabel + ": ", 'in getter: objectApiName is: ' + this.objectName);
-        console.log(this._masterLabel + ": ", 'in getter: fieldApiName is: ' + this.fieldName);
-        console.log(this._masterLabel + ": ", 'in getter: _recordTypeId is: ' + this._recordTypeId);
+        console.log(this._masterLabel + ": ", "in getter: objectApiName is: " + this.objectName);
+        console.log(this._masterLabel + ": ", "in getter: fieldApiName is: " + this.fieldName);
+        console.log(this._masterLabel + ": ", "in getter: _recordTypeId is: " + this._recordTypeId);
 
-        if ((this.objectName) && (this.fieldName)) {
-            console.log(this._masterLabel + ": ", 'satisfied calculatedObjectAndFieldName test');
+        if (this.objectName && this.fieldName) {
+            console.log(this._masterLabel + ": ", "satisfied calculatedObjectAndFieldName test");
             return `${this.objectName}.${this.fieldName}`;
         }
         return undefined;
@@ -351,7 +357,7 @@ export default class QuickChoiceFSC extends LightningElement {
             this._allValues = [];
             this._allLabels = [];
             if (this.allowNoneToBeChosen) {
-                this._picklistOptions.push({label: "--None--", value: "None"});
+                this._picklistOptions.push({ label: "--None--", value: "None" });
             }
 
             // Set isControlled only if a controlling value was provided and there are available controller values
@@ -360,15 +366,18 @@ export default class QuickChoiceFSC extends LightningElement {
             if (Object.keys(data.controllerValues).length > 0) {
                 this._isControlled = true;
                 this._showPicklist = true;
-                this.isControlledByCheckbox = ((Object.keys(data.controllerValues)[0] === 'false') && (Object.keys(data.controllerValues).length = 2)) ? true : false;
-                if ((this.controllingValue == undefined) && this.isControlledByCheckbox) {
-                    this.controllingValue = 'false';    // Start checkbox controlled picklists with a controlling value of false
+                this.isControlledByCheckbox =
+                    Object.keys(data.controllerValues)[0] === "false" && (Object.keys(data.controllerValues).length = 2)
+                        ? true
+                        : false;
+                if (this.controllingValue == undefined && this.isControlledByCheckbox) {
+                    this.controllingValue = "false"; // Start checkbox controlled picklists with a controlling value of false
                 }
                 controllingIndex = data.controllerValues[this.controllingValue];
             }
 
             // Picklist values
-            data.values.forEach(key => {
+            data.values.forEach((key) => {
                 if (!this._isControlled || key.validFor.includes(controllingIndex)) {
                     this._picklistOptions.push({
                         label: key.label,
@@ -377,7 +386,7 @@ export default class QuickChoiceFSC extends LightningElement {
                     if (this.displayMode === "Card" || this.displayMode === "Visual") {
                         this._choiceLabels.push(key.label);
                         this._choiceValues.push(key.value);
-                        this.items.push({name: key.label, description: null, icon: null});
+                        this.items.push({ name: key.label, description: null, icon: null });
                     }
                     this._allLabels.push(key.label);
                     this._allValues.push(key.value);
@@ -391,8 +400,8 @@ export default class QuickChoiceFSC extends LightningElement {
                 this.setPicklistOptions();
             }
             if (this._allValues && this._allValues.length) {
-                this.dispatchFlowAttributeChangedEvent('allValues', this._allValues);
-                this.dispatchFlowAttributeChangedEvent('allLabels', this._allLabels);
+                this.dispatchFlowAttributeChangedEvent("allValues", this._allValues);
+                this.dispatchFlowAttributeChangedEvent("allLabels", this._allLabels);
             }
         }
     }
@@ -411,43 +420,44 @@ export default class QuickChoiceFSC extends LightningElement {
         if (!sortFlag) {
             return value;
         }
-        let fieldValue = row => row['label'] || '';
-        return [...value.sort(
-            (a,b)=>(a=fieldValue(a).toUpperCase(),b=fieldValue(b).toUpperCase(),((a>b)-(b>a)))
-        )];                
+        let fieldValue = (row) => row["label"] || "";
+        return [
+            ...value.sort(
+                (a, b) => ((a = fieldValue(a).toUpperCase()), (b = fieldValue(b).toUpperCase()), (a > b) - (b > a))
+            )
+        ];
     }
 
     get gridClass() {
-        return (this.dualColumns ? 'slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center slds-grid_vertical-stretch ' : 'slds-form-element__control ') + this.bottomPadding;
+        return (
+            (this.dualColumns
+                ? "slds-form-element__control slds-grid slds-gutters_medium slds-wrap slds-grid_vertical-align-center slds-grid_vertical-stretch "
+                : "slds-form-element__control ") + this.bottomPadding
+        );
     }
 
     get gridStyle() {
-        return this.dualColumns ? 'width: auto;' : '';
+        return this.dualColumns ? "width: auto;" : "";
     }
 
     get columnClass() {
-        return this.dualColumns ? 'slds-visual-picker slds-visual-picker_vertical slds-col slds-size_1-of-2 paddingFix' : 'slds-visual-picker slds-visual-picker_vertical';
+        return this.dualColumns
+            ? "slds-visual-picker slds-visual-picker_vertical slds-col slds-size_1-of-2 paddingFix"
+            : "slds-visual-picker slds-visual-picker_vertical slds-col slds-size_1-of-1 paddingFix";
     }
 
     get cardSize() {
-        if (this.isSameHeight && ( this.dualColumns || !this.isResponsive)) {
-            return 'min-height: calc(25vh - 8rem); width: auto !important';
-        } else if (this.dualColumns || this.isResponsive) {
-            return 'height: min-content; width: auto !important';
-        } else {
-            return 'min-height: var(--lwc-sizeXxSmall,6rem) !important; height: auto !important; width: inherit !important;';
-        }
-
+        return "min-height: min-content; height: 100% !important; width: auto !important";
     }
 
     get responsiveSize() {
-        return (this.dualColumns || !this.isResponsive) ? '' : 'max-width: var(--lwc-sizeLarge,25rem); width: auto !important;';
+        return this.dualColumns ? "" : "max-width: var(--lwc-sizeLarge,25rem); width: auto !important;";
     }
 
     _handleChoiceCollections() {
         console.log(this._masterLabel + ": ", "entering _handleChoiceCollections");
         // Visual Card Selection
-        let items = [];	//parameters for visual picker selection
+        let items = []; //parameters for visual picker selection
         let index = 0;
         if (this.displayMode === "Card" || this.displayMode === "Visual") {
             this.showVisual = true;
@@ -458,21 +468,25 @@ export default class QuickChoiceFSC extends LightningElement {
                 this._choiceIcons = this._choiceLabels;
             }
             if (this.numberOfColumns === "2") {
-                this.dualColumns = true;
+                if (formFactor === "Small") {
+                    this.dualColumns = false;
+                } else {
+                    this.dualColumns = true;
+                }
             }
 
             //User passes in Label collection of string for box header and Value collection of strings for box description
             console.log(this._masterLabel + ": ", "entering input mode Visual Text Box");
             console.log(this._masterLabel + ": ", "_choiceLabels is: " + this._choiceLabels);
-            this._choiceLabels.forEach(label => {
+            this._choiceLabels.forEach((label) => {
                 //Add the correct path to custom images
-                if (this._choiceIcons[index].includes(':')) {
-                    items.push({name: label, description: this._choiceValues[index], icon: this._choiceIcons[index]});
+                if (this._choiceIcons[index].includes(":")) {
+                    items.push({ name: label, description: this._choiceValues[index], icon: this._choiceIcons[index] });
                 } else {
                     items.push({
                         name: label,
                         description: this._choiceValues[index],
-                        icon: Quickchoice_Images + '/' + this._choiceIcons[index]
+                        icon: Quickchoice_Images + "/" + this._choiceIcons[index]
                     });
                 }
                 console.log(this._masterLabel + ": ", "items is: " + items);
@@ -483,10 +497,9 @@ export default class QuickChoiceFSC extends LightningElement {
         // console.log(this._masterLabel + ": ", "initializing QuickChoice. inputMode is: " + this._inputMode);
         let options = [];
         if (this.legitInputModes.includes(this._inputMode)) {
-
             // v2.42 Allow "Add a 'None' Choice" option for all valid picklist methods
             if (this.allowNoneToBeChosen) {
-                options.push({label: "--None--", value: "None"});
+                options.push({ label: "--None--", value: "None" });
             }
 
             switch (this._inputMode) {
@@ -497,9 +510,9 @@ export default class QuickChoiceFSC extends LightningElement {
                     //console.log ('splitting choice values would be: ' + this._choiceValues.split(','));
                     //let values = this._choiceValues.split(';');
 
-                    this._choiceValues.forEach(value => {
+                    this._choiceValues.forEach((value) => {
                         console.log(this._masterLabel + ": ", "value is: " + value);
-                        options.push({label: value, value: value});
+                        options.push({ label: value, value: value });
                         console.log(this._masterLabel + ": ", "options is: " + options);
                     });
                     break;
@@ -509,8 +522,8 @@ export default class QuickChoiceFSC extends LightningElement {
                 case "Static Choices":
                     console.log(this._masterLabel + ": ", "entering input mode Dual String Collections");
                     console.log(this._masterLabel + ": ", "_choiceValues is: " + this._choiceValues);
-                    for (let i=0; i<this._choiceLabels.length; i++) {
-                        options.push({label: this._choiceLabels[i], value: this._choiceValues[i]});
+                    for (let i = 0; i < this._choiceLabels.length; i++) {
+                        options.push({ label: this._choiceLabels[i], value: this._choiceValues[i] });
                     }
                     break;
 
@@ -522,16 +535,16 @@ export default class QuickChoiceFSC extends LightningElement {
 
             // v2.42 Clear the selected value if the options change on a reactive screen
             if (this.firstPassCompleted && options != this.priorOptions) {
-                this.dispatchFlowAttributeChangedEvent('value', null);
+                this.dispatchFlowAttributeChangedEvent("value", null);
             }
             this.priorOptions = options;
-            this.firstPassCompleted = true;     
-
+            this.firstPassCompleted = true;
         } else {
             console.log(this._masterLabel + ": ", "QuickChoiceFSC: Need a valid Input Mode value. Didn't get one");
-            throw new Error("QuickChoiceFSC: Need a valid Input Mode value. Didn't get one.  If this component has conditional visibility, you should set the Advanced option to 'Refresh inputs to incorporate changes elsewhere in the flow'.");
+            throw new Error(
+                "QuickChoiceFSC: Need a valid Input Mode value. Didn't get one.  If this component has conditional visibility, you should set the Advanced option to 'Refresh inputs to incorporate changes elsewhere in the flow'."
+            );
         }
-
     }
 
     connectedCallback() {
@@ -559,14 +572,14 @@ export default class QuickChoiceFSC extends LightningElement {
 
         // Output default value for reactivity
         if (this._selectedValue != null) {
-            this.dispatchFlowAttributeChangedEvent('value', this._selectedValue);
+            this.dispatchFlowAttributeChangedEvent("value", this._selectedValue);
         }
         this.isRendered = true;
     }
 
     @api
     validate() {
-    	//If the component is invalid, return the isValid parameter as false and return an error message.
+        //If the component is invalid, return the isValid parameter as false and return an error message.
         console.log(this._masterLabel + ": ", "entering validate: required=" + this.required + " value=" + this.value);
         let errorMessage = "You must make a selection in: " + this._masterLabel + " to continue";
 
@@ -581,11 +594,11 @@ export default class QuickChoiceFSC extends LightningElement {
     }
 
     handleChange(event) {
-        console.log(this._masterLabel + ": ", 'EVENT', event);
-        this._selectedValue = (this.showVisual) ? event.target.value : event.detail.value;
-        this.dispatchFlowAttributeChangedEvent('value', this._selectedValue);
+        console.log(this._masterLabel + ": ", "EVENT", event);
+        this._selectedValue = this.showVisual ? event.target.value : event.detail.value;
+        this.dispatchFlowAttributeChangedEvent("value", this._selectedValue);
         console.log(this._masterLabel + ": ", "selected value is: " + this._selectedValue);
-        if (this.navOnSelect && this.availableActions.find(action => action === 'NEXT')) {
+        if (this.navOnSelect && this.availableActions.find((action) => action === "NEXT")) {
             const navigateNextEvent = new FlowNavigationNextEvent();
             this.dispatchEvent(navigateNextEvent);
         }
@@ -593,31 +606,27 @@ export default class QuickChoiceFSC extends LightningElement {
 
     setSelectedLabel() {
         if (this.options && this.options.length) {
-            let selectedOption = this.options.find(curOption => curOption.value === this._selectedValue);
+            let selectedOption = this.options.find((curOption) => curOption.value === this._selectedValue);
             if (selectedOption && selectedOption.label) {
                 this._selectedLabel = selectedOption.label;
-                this.dispatchFlowAttributeChangedEvent('selectedLabel', this._selectedLabel)
+                this.dispatchFlowAttributeChangedEvent("selectedLabel", this._selectedLabel);
             }
         }
     }
 
     dispatchFlowAttributeChangedEvent(attributeName, attributeValue) {
-        const attributeChangeEvent = new FlowAttributeChangeEvent(
-            attributeName,
-            attributeValue
-        );
+        const attributeChangeEvent = new FlowAttributeChangeEvent(attributeName, attributeValue);
         this.dispatchEvent(attributeChangeEvent);
     }
 
     get inputStyle() {
         if (this.style_width) {
-            return 'max-width: ' + this.style_width + 'px';
+            return "max-width: " + this.style_width + "px";
         }
-        return ''
+        return "";
     }
 
     get inputClass() {
         return this.bottomPadding;
     }
-
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_quickChoiceFSC/fsc_quickChoiceFSC.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>57.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Quick Choice</masterLabel>
     <targets>
@@ -16,16 +16,16 @@
             <property name="choiceLabels" label="Choice Labels (String Collection)" type="String[]" description="The labels of your choices"/>
             <property name="choiceIcons" label="Card Mode - Choice Icons (String Collection)" type="String[]" description="Icon names or image names"/>
             <property name="includeIcons" label="Card Mode - Include Icons in Display Box?" type="Boolean" description="Display the provided icons in the visual card when set to True"/>
-            <property name="isSameHeight" label="Is Cards Same Height" type="Boolean" description="Display both cards the same height regardless of the content. This may cause unexpected issues"/>
-            <property name="navOnSelect" label="Button Mode" type="Boolean" role="inputonly" description="Navigate to next flow element on card selection"/>
+            <property name="isSameHeight" label="Is Cards Same Height (DEPRECATED v2.47)" type="Boolean" description="(DEPRECATED v2.47) Display both cards the same height regardless of the content. This may cause unexpected issues"/>
+            <property name="navOnSelect" label="Button Mode" type="Boolean" role="inputOnly" description="Navigate to next flow element on card selection"/>
             <property name="iconSize" label="Card Mode - Icon Size" type="String" description="Options include x-small, small, medium, or large. This value defaults to medium."/>
-            <property name="numberOfColumns" label="Card Mode - Number of Display Box Columns (1 or 2)" type="String" description="1 or blank (default) for a single column or 2 for dual columns"/>
+            <property name="numberOfColumns" label="Card Mode - Number of Display Box Columns (1 or 2)" type="String" description="1 or blank (default) for a single column or 2 for dual columns. Small form factors are always 1 column."/>
             <property name="inputMode" label="Input Mode" type="String" description="“Single String Collection”, “Dual String Collections”, “Picklist Field”, or ” Visual Text Box ” are currently supported"/>
             <property name="masterLabel" label="Master Label" type="String" description="The main label for the picklist or radio button group"/>
             <property name="helpText" label="Help Text" type="String" description="Optional help text to show with the Master Label"/>
             <property name="required" label="Required" type="Boolean" default="false" description="Will prevent transition if set to {!$GlobalConstant.True}"/>
             <property name="displayMode" label="Display Mode" type="String" description="Either “Visual”, “Picklist” or “Radio”, depending on which control you want"/>
-            <property name="isResponsive" label="Make Width Responsive?" type="Boolean" default="false" description="Set this to true to adjust the size of single column visual cards to fit the screen and the amount of text."/>
+            <property name="isResponsive" label="Make Width Responsive? (DEPRECATED v2.47)" type="Boolean" default="false" description="(DEPRECATED v2.47) Set this to true to adjust the size of single column visual cards to fit the screen and the amount of text."/>
             <property name="recordTypeId" label="Record Type Id" type="String" description="Record Type Id (for Picklist Field)"/>
             <property name="objectName" label="Object Name" type="String" description="Object Name (for Picklist Field)"/>
             <property name="fieldName" label="Field Name" type="String" description="Field Name (for Picklist Field)"/>


### PR DESCRIPTION
Had a requirement to use dual column Visual Cards on large/medium form factors, but still have the flow be friendly and usable on smaller form factors. There were some clipping and reactivity issues with the visual cards on smaller form factors when using dual columns, so I made the following fixes/changes:

1. Fixed clipping issues with visual card displays on small form factors
2. Force 1 column display for visual cards on small form factors, even if user selects 2 columns
3. Visual cards are now always responsive, the isResponsive selector has been removed from the CPE
4. Dual column visual cards now always have the same height, the isSameHeight selector has been removed from the CPE

I couldn't think of any scenarios where having non-responsive single column cards or varied height cards in a dual column layout would be desirable, so I deprecated those configuration options and removed them from the CPE. Please correct me if I'm making a bad assumption here!

Before (mobile):
<img width="374" height="192" alt="quickChoiceBeforeClippingFix" src="https://github.com/user-attachments/assets/4e46477a-a5b3-4607-9fc3-4b1950de7327" />

After (mobile):
<img width="443" height="429" alt="quickChoiceAfterClippingFix" src="https://github.com/user-attachments/assets/31225132-7668-4b86-9d4a-31eff19e572f" />

Noticed after the fact that prettier ran on this, there wasn't a .prettierrc in the repo though so figured I'd send the PR anyway. First time contributing here so let me know if anything needs adjusted.