### PR TITLE
Fix Reset isError and errorMessage when reinserting a file

### DIFF
--- a/flow_screen_components/ConvertCSVToRecords_LWC/force-app/main/default/lwc/lwcConvertCSVToRecords/lwcConvertCSVToRecords.js
+++ b/flow_screen_components/ConvertCSVToRecords_LWC/force-app/main/default/lwc/lwcConvertCSVToRecords/lwcConvertCSVToRecords.js
@@ -235,6 +235,8 @@ export default class lwcConvertCSVToRecords extends LightningElement {
 		this.skipEmptyLines = true;
 		
 		if(event.detail.files.length > 0){
+				this._isError = false;
+				this._errorMessage = null;
 				this._isLoading = true;
 				const file = event.detail.files[0];
 				this.loading = true;


### PR DESCRIPTION
**Summary**
Enhance the unofficial Salesforce package’s file-upload UX so error messages clear appropriately.

**Current behavior**

When a user uploads a malformed file, an error message is shown.

If the user then selects a valid file, the prior error message remains visible.

**Desired behavior**

When a new file is selected and passes validation, any existing error message should be cleared/hidden automatically.