### PR TITLE
feat: Add picklist support to dual list box components

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.html
@@ -15,6 +15,7 @@
                                    disable-reordering={disableReordering}
                                    size={size}
                                    all-options={_options}
+                                   required={required}
                                    required-options={requiredOptions}
                                    selected-options={_selectedValues}
                                    use-object-value-as-output>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js
@@ -1,268 +1,625 @@
-import {LightningElement, api, track, wire} from 'lwc';
-import {FlowAttributeChangeEvent} from "lightning/flowSupport";
-import {getObjectInfo} from "lightning/uiObjectInfoApi";
+import { LightningElement, api, track, wire } from "lwc";
+import { FlowAttributeChangeEvent } from "lightning/flowSupport";
+import { getObjectInfo } from "lightning/uiObjectInfoApi";
 import getPicklistValues from "@salesforce/apex/usf3.FieldPickerController.getPicklistValues";
 import {
-    defaults,
-    inputTypeToOutputAttributeName,
-    inputTypeToInputAttributeName
-} from 'c/fsc_dualListBoxUtils';
+  defaults,
+  inputTypeToOutputAttributeName,
+  inputTypeToInputAttributeName,
+} from "c/fsc_dualListBoxUtils";
 
 export default class dualListBoxFSC extends LightningElement {
+  @api label;
+  @api sourceLabel;
+  @api fieldLevelHelp;
+  @api selectedLabel;
 
-    @api label;
-    @api sourceLabel;
-    @api fieldLevelHelp;
-    @api selectedLabel;
+  @api min;
+  @api max;
+  @api disableReordering;
+  @api size;
+  @api required;
+  @api requiredOptions;
+  @api useWhichObjectKeyForData = defaults.valueField;
+  @api useWhichObjectKeyForLabel = defaults.labelField;
+  @api useWhichObjectKeyForSort;
+  @api useObjectValueAsOutput = false;
 
-    @api min;
-    @api max;
-    @api disableReordering;
-    @api size;
-    @api required;
-    @api requiredOptions;
-    @api useWhichObjectKeyForData = defaults.valueField;
-    @api useWhichObjectKeyForLabel = defaults.labelField;
-    @api useWhichObjectKeyForSort;
-    @api useObjectValueAsOutput = false;
+  // New properties for picklist integration
+  @api objectApiName;
+  @api fieldApiName;
+  @api usePicklistValues = false;
 
-    // New properties for picklist integration
-    @api objectApiName;
-    @api fieldApiName;
-    @api usePicklistValues = false;
+  _allOptionsStringFormat;
+  @track selectedValuesStringFormat;
+  @track _options = [];
+  @track _selectedValues = [];
+  @track optionValues = {};
+  @track picklistValues = [];
+  @track isLoading = false;
+  @track errorMessage;
+  @track _values = []; // Internal selected values storage
 
-    _allOptionsStringFormat;
-    @track selectedValuesStringFormat;
-    @track _options = [];
-    @track _selectedValues = [];
-    @track optionValues = {};
-    @track picklistValues = [];
-    @track isLoading = false;
-    @track errorMessage;
-    
-
-    set allOptionsStringFormat(value) {
-
-        this._allOptionsStringFormat = value;
-        //TODO: ask if we need to have this as a separate list of types of output parameters
-
-        this.selectedValuesStringFormat = value;
-        if (inputTypeToInputAttributeName[value] && this.optionValues[inputTypeToInputAttributeName[value]]) {
-            this._options = this.optionValues[inputTypeToInputAttributeName[value]];
+  get STORAGE_KEY() {
+    // Extract field name from fieldApiName (could be object or string)
+    let fieldName = "noField";
+    if (this.fieldApiName) {
+      if (typeof this.fieldApiName === "string") {
+        try {
+          const parsed = JSON.parse(this.fieldApiName);
+          fieldName = parsed[0]?.name || parsed.name || "noField";
+        } catch (e) {
+          fieldName = this.fieldApiName;
         }
-        if (!this._selectedValues && inputTypeToOutputAttributeName[value] && this.optionValues[inputTypeToOutputAttributeName[value]]) {
-            this._selectedValues = this.optionValues[inputTypeToOutputAttributeName[value]];
+      } else if (this.fieldApiName.name) {
+        fieldName = this.fieldApiName.name;
+      }
+    }
+
+    return `dualListBox:${this.objectApiName || "noObject"}:${fieldName}`;
+  }
+
+  connectedCallback() {
+    console.log("connectedCallback called");
+    console.log("Initial _selectedValues:", this._selectedValues);
+    console.log(
+      "Initial selectedOptionsPicklist:",
+      this.selectedOptionsPicklist
+    );
+    this.restoreSelectedValues();
+  }
+
+  disconnectedCallback() {
+    // Only clear storage if we're not in the middle of validation
+    // Validation might cause temporary disconnection, so we'll keep the storage
+    console.log("disconnectedCallback called - keeping storage for validation");
+    // window.sessionStorage.removeItem(this.STORAGE_KEY);
+  }
+
+  renderedCallback() {
+    // Restore values after re-render (e.g., after validation fails)
+    if (!this._selectedValues || this._selectedValues.length === 0) {
+      this.restoreSelectedValues();
+    }
+  }
+
+  restoreSelectedValues() {
+    console.log("restoreSelectedValues called");
+    console.log("STORAGE_KEY:", this.STORAGE_KEY);
+    console.log("selectedValuesStringFormat:", this.selectedValuesStringFormat);
+    console.log("allOptionsStringFormat:", this.allOptionsStringFormat);
+    console.log("Current _selectedValues:", this._selectedValues);
+    console.log(
+      "Current selectedOptionsPicklist:",
+      this.selectedOptionsPicklist
+    );
+
+    const cached = window.sessionStorage.getItem(this.STORAGE_KEY);
+    console.log("cached value:", cached);
+
+    // Don't restore if we don't have the format set yet
+    if (!this.selectedValuesStringFormat) {
+      console.log(
+        "selectedValuesStringFormat not set yet, skipping restoration"
+      );
+      return;
+    }
+
+    // Check if we already have values from Flow Builder
+    if (this._selectedValues && this._selectedValues.length > 0) {
+      console.log(
+        "Already have selected values from Flow Builder:",
+        this._selectedValues
+      );
+      return;
+    }
+
+    // If _selectedValues is explicitly set to empty array, don't restore
+    if (
+      Array.isArray(this._selectedValues) &&
+      this._selectedValues.length === 0
+    ) {
+      console.log("Values explicitly cleared - not restoring from storage");
+      return;
+    }
+
+    if (cached) {
+      try {
+        const selectedValues = JSON.parse(cached);
+        console.log("parsed selectedValues:", JSON.stringify(selectedValues));
+
+        if (selectedValues && selectedValues.length > 0) {
+          this._selectedValues = [...selectedValues];
+          console.log(
+            "Restored selected values:",
+            JSON.stringify(this._selectedValues)
+          );
+
+          // Force a re-render by triggering a property change
+          this._selectedValues = [...this._selectedValues];
+
+          // Also dispatch to Flow to update the output
+          const outputAttribute =
+            inputTypeToOutputAttributeName[this.allOptionsStringFormat];
+          let flowValue = this._selectedValues;
+
+          if (
+            this.allOptionsStringFormat === defaults.picklist ||
+            this.allOptionsStringFormat === defaults.csv
+          ) {
+            flowValue = this._selectedValues.join(",");
+          }
+
+          this.dispatchEvent(
+            new FlowAttributeChangeEvent(outputAttribute, flowValue)
+          );
+          console.log(
+            "Dispatched restored values to Flow:",
+            JSON.stringify(flowValue)
+          );
         }
-        if (this._allOptionsStringFormat === defaults.csv && (!this._selectedValues || !this._selectedValues.length)) {
-            this._selectedValues = '';
+      } catch (e) {
+        console.error("Error parsing cached values:", e);
+      }
+    } else {
+      console.log("No cached values found");
+    }
+  }
+
+  saveSelectedValues() {
+    console.log("saveSelectedValues called");
+    console.log("_selectedValues:", JSON.stringify(this._selectedValues));
+    console.log("STORAGE_KEY:", this.STORAGE_KEY);
+
+    if (this._selectedValues && this._selectedValues.length > 0) {
+      const valueToSave = JSON.stringify(this._selectedValues);
+      window.sessionStorage.setItem(this.STORAGE_KEY, valueToSave);
+      console.log(
+        "Saved selected values to sessionStorage:",
+        JSON.stringify(valueToSave)
+      );
+    } else {
+      console.log("No values to save");
+    }
+  }
+
+  _pushToFlow() {
+    console.log("_pushToFlow called");
+    console.log("_values:", this._values);
+    this._selectedValues = [...this._values];
+    console.log("_selectedValues:", this._selectedValues);
+    const outputAttribute =
+      inputTypeToOutputAttributeName[this.allOptionsStringFormat];
+    console.log("outputAttribute:", outputAttribute);
+    let value = this._values;
+
+    // Convert to appropriate format for the output attribute
+    if (
+      this.allOptionsStringFormat === defaults.picklist ||
+      this.allOptionsStringFormat === defaults.csv
+    ) {
+      value = this._values.join(",");
+    }
+    console.log("value to dispatch:", value);
+
+    this.dispatchEvent(new FlowAttributeChangeEvent(outputAttribute, value));
+    window.sessionStorage.setItem(
+      this.STORAGE_KEY,
+      JSON.stringify(this._values)
+    );
+    console.log(
+      "Saved to sessionStorage:",
+      this.STORAGE_KEY,
+      JSON.stringify(this._values)
+    );
+  }
+
+  set allOptionsStringFormat(value) {
+    this._allOptionsStringFormat = value;
+    //TODO: ask if we need to have this as a separate list of types of output parameters
+
+    this.selectedValuesStringFormat = value;
+    if (
+      inputTypeToInputAttributeName[value] &&
+      this.optionValues[inputTypeToInputAttributeName[value]]
+    ) {
+      this._options = this.optionValues[inputTypeToInputAttributeName[value]];
+    }
+    if (
+      !this._selectedValues &&
+      inputTypeToOutputAttributeName[value] &&
+      this.optionValues[inputTypeToOutputAttributeName[value]]
+    ) {
+      this._selectedValues =
+        this.optionValues[inputTypeToOutputAttributeName[value]];
+    }
+
+    // Handle picklist selected values specifically
+    if (value === defaults.picklist && this.selectedOptionsCSV) {
+      this._selectedValues = this.selectedOptionsCSV
+        .split(",")
+        .map((item) => item.trim());
+    }
+
+    // Restore values from sessionStorage when format changes
+    const cached = window.sessionStorage.getItem(this.STORAGE_KEY);
+    if (cached) {
+      const fromCache = JSON.parse(cached);
+      if (fromCache && fromCache.length) {
+        this._values = [...fromCache];
+        this._selectedValues = [...fromCache];
+      }
+    }
+    if (
+      this._allOptionsStringFormat === defaults.csv &&
+      (!this._selectedValues || !this._selectedValues.length)
+    ) {
+      this._selectedValues = "";
+    }
+  }
+
+  set allOptionsFieldDescriptorList(value) {
+    this.setOptions(inputTypeToInputAttributeName.object, value);
+  }
+
+  set allOptionsStringCollection(value) {
+    this.setOptions(inputTypeToInputAttributeName.list, value);
+  }
+
+  set allOptionsStringCollectionLabels(value) {
+    this.setOptions(inputTypeToInputAttributeName.twoLists, value);
+  }
+
+  set allOptionsCSV(value) {
+    this.setOptions(inputTypeToInputAttributeName.csv, value);
+  }
+
+  set selectedOptionsStringList(value) {
+    this.setOptions(inputTypeToOutputAttributeName.list, value);
+  }
+
+  set selectedOptionsCSV(value) {
+    this.setOptions(inputTypeToOutputAttributeName.csv, value);
+  }
+
+  set selectedOptionsPicklist(value) {
+    console.log("selectedOptionsPicklist setter called with:", value);
+    console.log("Value type:", typeof value);
+    console.log("Is array:", Array.isArray(value));
+
+    // For picklist format, value should be an array of selected values
+    if (Array.isArray(value)) {
+      this._selectedValues = [...value];
+      console.log("Set picklist selected values:", this._selectedValues);
+
+      // If values are cleared (empty array), clear sessionStorage too
+      if (value.length === 0) {
+        console.log("Values cleared - removing from sessionStorage");
+        window.sessionStorage.removeItem(this.STORAGE_KEY);
+      } else {
+        // Save to sessionStorage
+        this.saveSelectedValues();
+      }
+    } else if (typeof value === "string" && value.includes(",")) {
+      // Handle CSV string input for backward compatibility
+      const selectedArray = value.split(",").map((item) => item.trim());
+      this._selectedValues = selectedArray;
+      console.log("Converted CSV string to picklist array:", selectedArray);
+      this.saveSelectedValues();
+    } else if (value) {
+      // Handle single value
+      this._selectedValues = [value];
+      console.log("Set single picklist value:", this._selectedValues);
+      this.saveSelectedValues();
+    } else {
+      console.log("No picklist values provided - clearing selection");
+      this._selectedValues = [];
+      // Clear sessionStorage when no values provided
+      window.sessionStorage.removeItem(this.STORAGE_KEY);
+    }
+  }
+
+  set selectedOptionsFieldDescriptorList(value) {
+    this.setOptions(inputTypeToOutputAttributeName.object, value);
+  }
+
+  @api
+  get allOptionsStringFormat() {
+    return this._allOptionsStringFormat;
+  }
+
+  @api
+  get allOptionsFieldDescriptorList() {
+    return this.getOptions(defaults.originalObject);
+  }
+
+  @api
+  get allOptionsStringCollection() {
+    return this.getOptions(defaults.list);
+  }
+
+  @api
+  get allOptionsStringCollectionLabels() {
+    return this.getOptions(defaults.twoLists);
+  }
+
+  @api
+  get allOptionsCSV() {
+    return this.getOptions(defaults.csv);
+  }
+
+  @api
+  get selectedOptionsStringList() {
+    return this.getValues(defaults.list);
+  }
+
+  @api
+  get selectedOptionsCSV() {
+    return this.getValues(defaults.csv);
+  }
+
+  @api
+  get selectedOptionsPicklist() {
+    return this.getValues(defaults.picklist);
+  }
+
+  @api
+  get selectedOptionsFieldDescriptorList() {
+    return this.getValues(defaults.originalObject);
+  }
+
+  get isDataSet() {
+    const result =
+      this.isPicklistMode ||
+      (this.allOptionsStringFormat &&
+        this.useWhichObjectKeyForData &&
+        this.useWhichObjectKeyForLabel);
+    console.log("isDataSet:", result);
+    console.log("isPicklistMode:", this.isPicklistMode);
+    console.log("allOptionsStringFormat:", this.allOptionsStringFormat);
+    console.log("useWhichObjectKeyForData:", this.useWhichObjectKeyForData);
+    console.log("useWhichObjectKeyForLabel:", this.useWhichObjectKeyForLabel);
+    return result;
+  }
+
+  get isPicklistMode() {
+    return !!(
+      this.usePicklistValues &&
+      this.objectApiName &&
+      this.fieldApiName
+    );
+  }
+
+  get fieldApiNameString() {
+    if (!this.fieldApiName) return null;
+
+    try {
+      // If it's a JSON string, parse it
+      if (typeof this.fieldApiName === "string") {
+        const parsed = JSON.parse(this.fieldApiName);
+        // If it's an array, get the first field object
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed[0].name;
         }
-    }
-
-    set allOptionsFieldDescriptorList(value) {
-        this.setOptions(inputTypeToInputAttributeName.object, value);
-    }
-
-    set allOptionsStringCollection(value) {
-        this.setOptions(inputTypeToInputAttributeName.list, value);
-    }
-
-    set allOptionsStringCollectionLabels(value) {
-        this.setOptions(inputTypeToInputAttributeName.twoLists, value);
-    }
-
-    set allOptionsCSV(value) {
-        this.setOptions(inputTypeToInputAttributeName.csv, value);
-    }
-
-    set selectedOptionsStringList(value) {
-        this.setOptions(inputTypeToOutputAttributeName.list, value);
-    }
-
-    set selectedOptionsCSV(value) {
-        this.setOptions(inputTypeToOutputAttributeName.csv, value);
-    }
-
-    set selectedOptionsFieldDescriptorList(value) {
-        this.setOptions(inputTypeToOutputAttributeName.object, value);
-    }
-
-    @api
-    get allOptionsStringFormat() {
-        return this._allOptionsStringFormat;
-    }
-
-    @api
-    get allOptionsFieldDescriptorList() {
-        return this.getOptions(defaults.originalObject);
-    }
-
-    @api
-    get allOptionsStringCollection() {
-        return this.getOptions(defaults.list);
-    }
-
-    @api
-    get allOptionsStringCollectionLabels() {
-        return this.getOptions(defaults.twoLists);
-    }
-
-    @api
-    get allOptionsCSV() {
-        return this.getOptions(defaults.csv);
-    }
-
-    @api
-    get selectedOptionsStringList() {
-        return this.getValues(defaults.list);
-    }
-
-    @api
-    get selectedOptionsCSV() {
-        return this.getValues(defaults.csv);
-    }
-
-    @api
-    get selectedOptionsFieldDescriptorList() {
-        return this.getValues(defaults.originalObject);
-    }
-
-    get isDataSet() {
-        return this.allOptionsStringFormat && this.useWhichObjectKeyForData && this.useWhichObjectKeyForLabel;
-    }
-
-    get isPicklistMode() {
-        return this.usePicklistValues && this.objectApiName && this.fieldApiName;
-    }
-
-    // Wire to get object info for field validation
-    @wire(getObjectInfo, { objectApiName: "$objectApiName" })
-    objectInfo;
-
-    // Wire to get picklist values
-    @wire(getPicklistValues, {
-        objectApiName: "$objectApiName",
-        fieldName: "$fieldApiName",
-    })
-    wiredPicklistValues({ error, data }) {
-        if (data) {
-            this.picklistValues = data;
-            this.updateOptionsFromPicklist();
-        } else if (error) {
-            console.error("Error loading picklist values:", error);
-            this.errorMessage =
-                "Error loading picklist values: " + error.body.message;
+        // If it's a single field object
+        if (parsed && parsed.name) {
+          return parsed.name;
         }
+      }
+      // If it's already an object, get the name directly
+      if (typeof this.fieldApiName === "object" && this.fieldApiName.name) {
+        return this.fieldApiName.name;
+      }
+      // If it's already a string field name, return as-is
+      return this.fieldApiName;
+    } catch (error) {
+      console.error("Error parsing fieldApiName:", error);
+      return this.fieldApiName;
+    }
+  }
+
+  // Wire to get object info for field validation
+  @wire(getObjectInfo, { objectApiName: "$objectApiName" })
+  objectInfo;
+
+  // Wire to get picklist values
+  @wire(getPicklistValues, {
+    objectApiName: "$objectApiName",
+    fieldName: "$fieldApiNameString",
+  })
+  wiredPicklistValues({ error, data }) {
+    if (data) {
+      console.log("picklistValues: " + JSON.stringify(data));
+      this.picklistValues = data;
+      this.updateOptionsFromPicklist();
+    } else if (error) {
+      console.error("Error loading picklist values:", JSON.stringify(error));
+      this.errorMessage =
+        "Error loading picklist values: " + error.body.message;
+    }
+  }
+
+  setOptions(optionName, optionValue) {
+    this.optionValues[optionName] = optionValue;
+    if (
+      this._allOptionsStringFormat &&
+      inputTypeToInputAttributeName[this._allOptionsStringFormat] ===
+        optionName &&
+      this._allOptionsStringFormat !== defaults.twoLists
+    ) {
+      this._options = optionValue;
+    } else if (
+      this._allOptionsStringFormat &&
+      inputTypeToOutputAttributeName[this._allOptionsStringFormat] ===
+        optionName
+    ) {
+      this._selectedValues = optionValue;
+    }
+    if (
+      this._allOptionsStringFormat === defaults.twoLists &&
+      this.optionValues[inputTypeToInputAttributeName.list] &&
+      this.optionValues[inputTypeToInputAttributeName.twoLists]
+    ) {
+      this.setDualListOptions();
+    }
+  }
+
+  setDualListOptions() {
+    this._options = [];
+    let values = this.optionValues[inputTypeToInputAttributeName.list];
+    let labels = this.optionValues[inputTypeToInputAttributeName.twoLists];
+    if (labels.length === values.length) {
+      for (let i = 0; i < values.length; i++) {
+        this._options.push({ label: labels[i], value: values[i] });
+      }
+    }
+  }
+
+  updateOptionsFromPicklist() {
+    console.log("updateOptionsFromPicklist called");
+    console.log("isPicklistMode:", this.isPicklistMode);
+    console.log("usePicklistValues:", JSON.stringify(this.usePicklistValues));
+    console.log("objectApiName:", JSON.stringify(this.objectApiName));
+    console.log("fieldApiName:", JSON.stringify(this.fieldApiName));
+    console.log("picklistValues:", JSON.stringify(this.picklistValues));
+
+    if (
+      this.isPicklistMode &&
+      this.picklistValues &&
+      this.picklistValues.length > 0
+    ) {
+      this._options = this.picklistValues.map((picklistValue) => ({
+        label: picklistValue.label,
+        value: picklistValue.value,
+      }));
+
+      // Set the format to picklist for proper option processing
+      if (!this._allOptionsStringFormat) {
+        this._allOptionsStringFormat = defaults.picklist;
+      }
+
+      console.log("Updated _options:", JSON.stringify(this._options));
+
+      // Restore values after options are loaded
+      this.restoreSelectedValues();
+    } else {
+      console.log("updateOptionsFromPicklist: conditions not met");
+    }
+  }
+
+  getValues(valueType) {
+    let listBox = this.template.querySelector(
+      "c-fsc_extended-base-dual-list-box"
+    );
+    if (listBox) {
+      return listBox.getValues(valueType);
+    }
+  }
+
+  getOptions(valueType) {
+    let listBox = this.template.querySelector(
+      "c-fsc_extended-base-dual-list-box"
+    );
+    if (listBox) {
+      return listBox.getOptions(valueType);
+    }
+  }
+
+  handleValueChanged(event) {
+    console.log("=== handleValueChanged called ===");
+    console.log("event.detail.value:", JSON.stringify(event.detail.value));
+
+    let value = event.detail.value;
+
+    // Convert to array format for selected values
+    if (Array.isArray(value)) {
+      this._selectedValues = [...value];
+    } else if (typeof value === "string" && value.includes(",")) {
+      this._selectedValues = value.split(",").map((item) => item.trim());
+    } else {
+      this._selectedValues = value ? [value] : [];
     }
 
-    setOptions(optionName, optionValue) {
-        this.optionValues[optionName] = optionValue;
-        if (this._allOptionsStringFormat && inputTypeToInputAttributeName[this._allOptionsStringFormat] === optionName && this._allOptionsStringFormat !== defaults.twoLists) {
-            this._options = optionValue;
-        } else if (this._allOptionsStringFormat && inputTypeToOutputAttributeName[this._allOptionsStringFormat] === optionName) {
-            this._selectedValues = optionValue;
-        }
-        if (this._allOptionsStringFormat === defaults.twoLists && this.optionValues[inputTypeToInputAttributeName.list] && this.optionValues[inputTypeToInputAttributeName.twoLists]) {
-            this.setDualListOptions();
-        }
+    console.log("Updated _selectedValues:", this._selectedValues);
+
+    // Save to sessionStorage
+    this.saveSelectedValues();
+
+    // Dispatch to Flow
+    const outputAttribute =
+      inputTypeToOutputAttributeName[this.allOptionsStringFormat];
+    let flowValue = this._selectedValues;
+
+    if (
+      this.allOptionsStringFormat === defaults.picklist ||
+      this.allOptionsStringFormat === defaults.csv
+    ) {
+      flowValue = this._selectedValues.join(",");
     }
 
-    setDualListOptions() {
-        this._options = [];
-        let values = this.optionValues[inputTypeToInputAttributeName.list];
-        let labels = this.optionValues[inputTypeToInputAttributeName.twoLists];
-        if (labels.length === values.length) {
-            for (let i = 0; i < values.length; i++) {
-                this._options.push({label: labels[i], value: values[i]});
-            }
-        }
+    this.dispatchEvent(
+      new FlowAttributeChangeEvent(outputAttribute, flowValue)
+    );
+  }
+
+  dispatchFlowAttributeChangedEvent(attributeName, attributeValue) {
+    console.log(attributeName, attributeValue);
+    const attributeChangeEvent = new FlowAttributeChangeEvent(
+      attributeName,
+      attributeValue
+    );
+    this.dispatchEvent(attributeChangeEvent);
+  }
+
+  // Event handlers for picklist properties
+  handleObjectChange(event) {
+    this.objectApiName = event.detail.value;
+    this.fieldApiName = null; // Clear field when object changes
+    this.picklistValues = []; // Clear picklist values
+    this._options = []; // Clear options
+    this.dispatchFlowAttributeChangedEvent("objectApiName", this.objectApiName);
+  }
+
+  handleFieldChange(event) {
+    this.fieldApiName = event.detail.value;
+    console.log("fieldApiName: " + JSON.stringify(this.fieldApiName));
+    this.dispatchFlowAttributeChangedEvent("fieldApiName", this.fieldApiName);
+  }
+
+  handleUsePicklistChange(event) {
+    this.usePicklistValues = event.detail.checked;
+    this.dispatchFlowAttributeChangedEvent(
+      "usePicklistValues",
+      this.usePicklistValues
+    );
+
+    if (!this.usePicklistValues) {
+      this.picklistValues = [];
+      this._options = [];
     }
+  }
 
-    updateOptionsFromPicklist() {
-        if (
-            this.isPicklistMode &&
-            this.picklistValues &&
-            this.picklistValues.length > 0
-        ) {
-            this._options = this.picklistValues.map((picklistValue) => ({
-                label: picklistValue.label,
-                value: picklistValue.value,
-            }));
+  @api
+  validate() {
+    console.log("entering validate");
+    console.log(
+      "entering validate: required=" +
+        this.required +
+        " values=" +
+        JSON.stringify(this._selectedValues)
+    );
 
-            // Set the format to list if not already set
-            if (!this._allOptionsStringFormat) {
-                this._allOptionsStringFormat = defaults.list;
-            }
-        }
+    if (
+      this.required == true &&
+      (this._selectedValues == [] || this._selectedValues == "")
+    ) {
+      console.log("validate reporting false");
+      return {
+        isValid: false,
+        errorMessage: "At least one value must be selected.",
+      };
+    } else {
+      return { isValid: true };
     }
-
-    getValues(valueType) {
-        let listBox = this.template.querySelector('c-fsc_extended-base-dual-list-box');
-        if (listBox) {
-            return listBox.getValues(valueType);
-        }
-    }
-
-    getOptions(valueType) {
-        let listBox = this.template.querySelector('c-fsc_extended-base-dual-list-box');
-        if (listBox) {
-            return listBox.getOptions(valueType);
-        }
-    }
-
-    handleValueChanged(event) {
-        this.dispatchFlowAttributeChangedEvent(inputTypeToOutputAttributeName[this.allOptionsStringFormat], event.detail.value);
-    }
-
-    dispatchFlowAttributeChangedEvent(attributeName, attributeValue) {
-        console.log(attributeName, attributeValue);
-        const attributeChangeEvent = new FlowAttributeChangeEvent(
-            attributeName,
-            attributeValue
-        );
-        this.dispatchEvent(attributeChangeEvent);
-    }
-
-    // Event handlers for picklist properties
-    handleObjectChange(event) {
-        this.objectApiName = event.detail.value;
-        this.fieldApiName = null; // Clear field when object changes
-        this.picklistValues = []; // Clear picklist values
-        this._options = []; // Clear options
-        this.dispatchFlowAttributeChangedEvent("objectApiName", this.objectApiName);
-    }
-
-    handleFieldChange(event) {
-        this.fieldApiName = event.detail.value;
-        this.dispatchFlowAttributeChangedEvent("fieldApiName", this.fieldApiName);
-    }
-
-    handleUsePicklistChange(event) {
-        this.usePicklistValues = event.detail.checked;
-        this.dispatchFlowAttributeChangedEvent(
-            "usePicklistValues",
-            this.usePicklistValues
-        );
-
-        if (!this.usePicklistValues) {
-            this.picklistValues = [];
-            this._options = [];
-        }
-    }
-
-    @api
-    validate() {
-        console.log('entering validate');
-        console.log("entering validate: required=" + this.required + " values=" + this._selectedValues);
-
-        if(this.required == true && (this._selectedValues == [] || this._selectedValues == '')) { 
-            console.log('validate reporting false');
-            return { 
-                isValid: false, 
-                errorMessage: 'At least one value must be selected.' 
-                }; 
-            } 
-        else { 
-            return { isValid: true }; 
-        } 
-    }
+  }
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Dual List Box v3</description>
     <isExposed>true</isExposed>
     <masterLabel>Dual List Box v3</masterLabel>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBox3/fsc_dualListBox3.js-meta.xml
@@ -8,29 +8,35 @@
         <target>lightning__FlowScreen</target>
     </targets>
     <targetConfigs>
-        <targetConfig targets="lightning__FlowScreen" configurationEditor="c-fsc_dual-list-box-c-p-e" category="Input">
-            <property name="label" type="String" role="inputOnly"/>
-            <property name="sourceLabel" type="String" role="inputOnly"/>
-            <property name="fieldLevelHelp" type="String" role="inputOnly"/>
-            <property name="selectedLabel" type="String" role="inputOnly"/>
-            <property name="min" type="Integer" role="inputOnly"/>
-            <property name="max" type="Integer" role="inputOnly"/>
-            <property name="disableReordering" type="Boolean" role="inputOnly"/>
-            <property name="size" type="Integer" role="inputOnly"/>
-            <property name="required" type="Boolean" role="inputOnly"/>
-            <property name="requiredOptions" type="String" role="inputOnly"/>
-            <property name="useObjectValueAsOutput" type="Boolean" role="inputOnly"/>
-            <property name="useWhichObjectKeyForData" type="String" role="inputOnly"/>
-            <property name="useWhichObjectKeyForLabel" type="String" role="inputOnly"/>
-            <property name="useWhichObjectKeyForSort" type="String" role="inputOnly"/>
-            <property name="allOptionsFieldDescriptorList" type="apex://usf3.FieldDescriptor[]" role="inputOnly"/>
-            <property name="allOptionsCSV" type="String" role="inputOnly"/>
-            <property name="allOptionsStringCollection" type="String[]" role="inputOnly"/>
-            <property name="allOptionsStringCollectionLabels" type="String[]" role="inputOnly"/>
-            <property name="allOptionsStringFormat" type="String" role="inputOnly"/>
-            <property name="selectedOptionsFieldDescriptorList" type="apex://usf3.FieldDescriptor[]"/>
-            <property name="selectedOptionsCSV" type="String"/>
-            <property name="selectedOptionsStringList" type="String[]"/>
+        <targetConfig targets="lightning__FlowScreen"
+            configurationEditor="c-fsc_dual-list-box-c-p-e" category="Input">
+            <property name="label" type="String" role="inputOnly" />
+            <property name="sourceLabel" type="String" role="inputOnly" />
+            <property name="fieldLevelHelp" type="String" role="inputOnly" />
+            <property name="selectedLabel" type="String" role="inputOnly" />
+            <property name="min" type="Integer" role="inputOnly" />
+            <property name="max" type="Integer" role="inputOnly" />
+            <property name="disableReordering" type="Boolean" role="inputOnly" />
+            <property name="size" type="Integer" role="inputOnly" />
+            <property name="required" type="Boolean" role="inputOnly" />
+            <property name="requiredOptions" type="String" role="inputOnly" />
+            <property name="useObjectValueAsOutput" type="Boolean" role="inputOnly" />
+            <property name="useWhichObjectKeyForData" type="String" role="inputOnly" />
+            <property name="useWhichObjectKeyForLabel" type="String" role="inputOnly" />
+            <property name="useWhichObjectKeyForSort" type="String" role="inputOnly" />
+            <property name="allOptionsFieldDescriptorList" type="apex://usf3.FieldDescriptor[]"
+                role="inputOnly" />
+            <property name="allOptionsCSV" type="String" role="inputOnly" />
+            <property name="allOptionsStringCollection" type="String[]" role="inputOnly" />
+            <property name="allOptionsStringCollectionLabels" type="String[]" role="inputOnly" />
+            <property name="allOptionsStringFormat" type="String" role="inputOnly" />
+            <property name="usePicklistValues" type="Boolean" role="inputOnly" />
+            <property name="objectApiName" type="String" role="inputOnly" />
+            <property name="fieldApiName" type="String" role="inputOnly" />
+            <property name="selectedOptionsFieldDescriptorList" type="apex://usf3.FieldDescriptor[]" />
+            <property name="selectedOptionsCSV" type="String" />
+            <property name="selectedOptionsStringList" type="String[]" />
+            <property name="selectedOptionsPicklist" type="String[]" />
         </targetConfig>
     </targetConfigs>
 </LightningComponentBundle>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.html
@@ -70,6 +70,30 @@
             automatic-output-variables={automaticOutputVariables}
     ></c-fsc_flow-combobox>
 
+    <!-- Picklist Configuration Section -->
+    <template if:true={isPicklist}>
+        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Picklist Configuration</div>
+        <c-fsc_pick-object-and-field-3
+                name="objectApiName"
+                object-label="Object"
+                object-type={objectApiNameValue}
+                hide-field-picklist=true
+                builder-context={_builderContext}
+                onfieldselected={handleObjectChange}>
+        </c-fsc_pick-object-and-field-3>
+        <template if:true={objectApiNameValue}>
+            <c-fsc_field-selector-3 
+                    name="fieldApiName" 
+                    object-name={objectApiNameValue} 
+                    public-style="width:100%"
+                    onfieldupdate={handleFieldChange} 
+                    selected-fields={fieldApiNameValue}
+                    field-type-filter="multipicklist"
+                    required>
+            </c-fsc_field-selector-3>
+        </template>
+    </template>
+
     <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Values</div>
     <div class="border-bottom-2px slds-p-bottom_small">
         <c-fsc_flow-combobox

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.html
@@ -1,220 +1,234 @@
 <template>
-    <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">
-        {inputValues.allOptionsStringFormat.label}
-    </div>
-    <lightning-radio-group
-            name="select_allOptionsStringFormat"
-            options={selectDataSourceOptions}
-            value={inputValues.allOptionsStringFormat.value}
-            type="radio"
-            onchange={handleValueChange}
-    ></lightning-radio-group>
-    <lightning-input
-            class="slds-p-top_small"
-            type="checkbox" label={inputValues.disableReordering.label} name="select_disableReordering"
-            checked={inputValues.disableReordering.value}
-            onblur={handleValueChange}
-    ></lightning-input>
-    <lightning-input
-            type="checkbox" label={inputValues.required.label} name="select_required"
-            checked={inputValues.required.value}
-            onblur={handleValueChange}
-    ></lightning-input>
-
-    <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">All Options</div>
-    <c-fsc_flow-combobox
-            if:true={isObject}
-            name="select_allOptionsFieldDescriptorList"
-            label={inputValues.allOptionsFieldDescriptorList.label}
-            value={inputValues.allOptionsFieldDescriptorList.value}
-            value-type={inputValues.allOptionsFieldDescriptorList.valueDataType}
-            builder-context-filter-collection-boolean={inputValues.allOptionsFieldDescriptorList.isCollection}
-            builder-context={_builderContext}
-            onvaluechanged={handleFlowComboboxValueChange}
-            automatic-output-variables={automaticOutputVariables}
-    ></c-fsc_flow-combobox>
-    <c-fsc_flow-combobox
-            if:true={isTwoLists}
-            name="select_allOptionsStringCollectionLabels"
-            label={inputValues.allOptionsStringCollectionLabels.label}
-            value={inputValues.allOptionsStringCollectionLabels.value}
-            value-type={inputValues.allOptionsStringCollectionLabels.valueDataType}
-            builder-context-filter-type="String"
-            builder-context-filter-collection-boolean={inputValues.allOptionsStringCollectionLabels.isCollection}
-            builder-context={_builderContext}
-            onvaluechanged={handleFlowComboboxValueChange}
-            automatic-output-variables={automaticOutputVariables}
-    ></c-fsc_flow-combobox>
-    <c-fsc_flow-combobox
-            if:true={isLists}
-            name="select_allOptionsStringCollection"
-            label={inputValues.allOptionsStringCollection.label}
-            value={inputValues.allOptionsStringCollection.value}
-            value-type={inputValues.allOptionsStringCollection.valueDataType}
-            builder-context-filter-type="String"
-            builder-context-filter-collection-boolean={inputValues.allOptionsStringCollection.isCollection}
-            builder-context={_builderContext}
-            onvaluechanged={handleFlowComboboxValueChange}
-            automatic-output-variables={automaticOutputVariables}
-    ></c-fsc_flow-combobox>
-    <c-fsc_flow-combobox
-            if:true={isCSV}
-            name="select_allOptionsCSV"
-            label={inputValues.allOptionsCSV.label}
-            value={inputValues.allOptionsCSV.value}
-            value-type={inputValues.allOptionsCSV.valueDataType}
-            builder-context-filter-type="String"
-            builder-context-filter-collection-boolean={inputValues.allOptionsCSV.isCollection}
-            builder-context={_builderContext}
-            onvaluechanged={handleFlowComboboxValueChange}
-            automatic-output-variables={automaticOutputVariables}
-    ></c-fsc_flow-combobox>
-
-    <!-- Picklist Configuration Section -->
-    <template if:true={isPicklist}>
-        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Picklist Configuration</div>
-        <c-fsc_pick-object-and-field-3
-                name="objectApiName"
-                object-label="Object"
-                object-type={objectApiNameValue}
-                hide-field-picklist=true
+        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">
+            {inputValues.allOptionsStringFormat.label}
+        </div>
+        <lightning-radio-group
+                name="select_allOptionsStringFormat"
+                options={selectDataSourceOptions}
+                value={inputValues.allOptionsStringFormat.value}
+                type="radio"
+                onchange={handleValueChange}
+        ></lightning-radio-group>
+        <lightning-input
+                class="slds-p-top_small"
+                type="checkbox" label={inputValues.disableReordering.label} name="select_disableReordering"
+                checked={inputValues.disableReordering.value}
+                onblur={handleValueChange}
+        ></lightning-input>
+        <lightning-input
+                type="checkbox" label={inputValues.required.label} name="select_required"
+                checked={inputValues.required.value}
+                onblur={handleValueChange}
+        ></lightning-input>
+    
+        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">All Options</div>
+        <c-fsc_flow-combobox
+                if:true={isObject}
+                name="select_allOptionsFieldDescriptorList"
+                label={inputValues.allOptionsFieldDescriptorList.label}
+                value={inputValues.allOptionsFieldDescriptorList.value}
+                value-type={inputValues.allOptionsFieldDescriptorList.valueDataType}
+                builder-context-filter-collection-boolean={inputValues.allOptionsFieldDescriptorList.isCollection}
                 builder-context={_builderContext}
-                onfieldselected={handleObjectChange}>
-        </c-fsc_pick-object-and-field-3>
-        <template if:true={objectApiNameValue}>
-            <c-fsc_field-selector-3 
-                    name="fieldApiName" 
-                    object-name={objectApiNameValue} 
-                    public-style="width:100%"
-                    onfieldupdate={handleFieldChange} 
-                    selected-fields={fieldApiNameValue}
-                    field-type-filter="multipicklist"
-                    required>
-            </c-fsc_field-selector-3>
-        </template>
-    </template>
-
-    <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Values</div>
-    <div class="border-bottom-2px slds-p-bottom_small">
+                onvaluechanged={handleFlowComboboxValueChange}
+                automatic-output-variables={automaticOutputVariables}
+        ></c-fsc_flow-combobox>
+        <c-fsc_flow-combobox
+                if:true={isTwoLists}
+                name="select_allOptionsStringCollectionLabels"
+                label={inputValues.allOptionsStringCollectionLabels.label}
+                value={inputValues.allOptionsStringCollectionLabels.value}
+                value-type={inputValues.allOptionsStringCollectionLabels.valueDataType}
+                builder-context-filter-type="String"
+                builder-context-filter-collection-boolean={inputValues.allOptionsStringCollectionLabels.isCollection}
+                builder-context={_builderContext}
+                onvaluechanged={handleFlowComboboxValueChange}
+                automatic-output-variables={automaticOutputVariables}
+        ></c-fsc_flow-combobox>
         <c-fsc_flow-combobox
                 if:true={isLists}
-                name="select_selectedOptionsStringList"
-                label={inputValues.selectedOptionsStringList.label}
-                value={inputValues.selectedOptionsStringList.value}
-                value-type={inputValues.selectedOptionsStringList.valueDataType}
+                name="select_allOptionsStringCollection"
+                label={inputValues.allOptionsStringCollection.label}
+                value={inputValues.allOptionsStringCollection.value}
+                value-type={inputValues.allOptionsStringCollection.valueDataType}
                 builder-context-filter-type="String"
-                builder-context-filter-collection-boolean={inputValues.selectedOptionsStringList.isCollection}
+                builder-context-filter-collection-boolean={inputValues.allOptionsStringCollection.isCollection}
                 builder-context={_builderContext}
                 onvaluechanged={handleFlowComboboxValueChange}
                 automatic-output-variables={automaticOutputVariables}
         ></c-fsc_flow-combobox>
         <c-fsc_flow-combobox
                 if:true={isCSV}
-                name="select_selectedOptionsCSV"
-                label={inputValues.selectedOptionsCSV.label}
-                value={inputValues.selectedOptionsCSV.value}
-                value-type={inputValues.selectedOptionsCSV.valueDataType}
+                name="select_allOptionsCSV"
+                label={inputValues.allOptionsCSV.label}
+                value={inputValues.allOptionsCSV.value}
+                value-type={inputValues.allOptionsCSV.valueDataType}
                 builder-context-filter-type="String"
-                builder-context-filter-collection-boolean={inputValues.selectedOptionsCSV.isCollection}
+                builder-context-filter-collection-boolean={inputValues.allOptionsCSV.isCollection}
                 builder-context={_builderContext}
                 onvaluechanged={handleFlowComboboxValueChange}
                 automatic-output-variables={automaticOutputVariables}
         ></c-fsc_flow-combobox>
-        <c-fsc_flow-combobox
-                if:true={isObject}
-                name="select_selectedOptionsFieldDescriptorList"
-                label={inputValues.selectedOptionsFieldDescriptorList.label}
-                value={inputValues.selectedOptionsFieldDescriptorList.value}
-                value-type={inputValues.selectedOptionsFieldDescriptorList.valueDataType}
-                builder-context-filter-collection-boolean={inputValues.selectedOptionsFieldDescriptorList.isCollection}
-                builder-context={_builderContext}
-                onvaluechanged={handleFlowComboboxValueChange}
-                automatic-output-variables={automaticOutputVariables}
-        ></c-fsc_flow-combobox>
-        <template if:true={isObject}>
-            <lightning-input
-                    type="text"
-                    label={inputValues.useWhichObjectKeyForLabel.label}
-                    name="select_useWhichObjectKeyForLabel"
-                    value={inputValues.useWhichObjectKeyForLabel.value}
-                    onblur={handleValueChange}
-            ></lightning-input>
-            <lightning-input
-                    type="text"
-                    label={inputValues.useWhichObjectKeyForData.label}
-                    name="select_useWhichObjectKeyForData"
-                    value={inputValues.useWhichObjectKeyForData.value}
-                    onblur={handleValueChange}
-            ></lightning-input>
-            <lightning-input
-                type="text"
-                label={inputValues.useWhichObjectKeyForSort.label}
-                name="select_useWhichObjectKeyForSort"
-                value={inputValues.useWhichObjectKeyForSort.value}
-                onblur={handleValueChange}
-            ></lightning-input>
+    
+        <!-- Picklist Configuration Section -->
+        <template if:true={isPicklist}>
+            <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Picklist Configuration</div>
+            <c-fsc_pick-object-and-field-3
+                    name="objectApiName"
+                    object-label={inputValues.objectApiName.label}
+                    object-type={inputValues.objectApiName.value}
+                    hide-field-picklist=true
+                    builder-context={_builderContext}
+                    onfieldselected={handleObjectChange}>
+            </c-fsc_pick-object-and-field-3>
+            <template if:true={inputValues.objectApiName.value}>
+                <c-fsc_field-selector-3 
+                        name="fieldApiName" 
+                        label={inputValues.fieldApiName.label}
+                        object-name={inputValues.objectApiName.value}
+                        public-style="width:100%"
+                        onfieldupdate={handleValueChange} 
+                        selected-fields={inputValues.fieldApiName.value}
+                        field-type-filter="multipicklist"
+                        allow-multiselect=false
+                        required>
+                </c-fsc_field-selector-3>
+            </template>
         </template>
-    </div>
-    <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Labels</div>
-    <div class="border-bottom-2px slds-p-bottom_small">
-        <c-fsc_flow-combobox
-                name="select_label"
-                label={inputValues.label.label}
-                value={inputValues.label.value}
-                value-type={inputValues.label.valueDataType}
-                builder-context-filter-type="String"
-                builder-context-filter-collection-boolean={inputValues.label.isCollection}
-                builder-context={_builderContext}
-                onvaluechanged={handleFlowComboboxValueChange}
-                automatic-output-variables={automaticOutputVariables}
-        ></c-fsc_flow-combobox>
-        <c-fsc_flow-combobox
-                name="select_sourceLabel"
-                label={inputValues.sourceLabel.label}
-                value={inputValues.sourceLabel.value}
-                value-type={inputValues.sourceLabel.valueDataType}
-                builder-context-filter-type="String"
-                builder-context-filter-collection-boolean={inputValues.sourceLabel.isCollection}
-                builder-context={_builderContext}
-                onvaluechanged={handleFlowComboboxValueChange}
-                automatic-output-variables={automaticOutputVariables}
-        ></c-fsc_flow-combobox>
-        <c-fsc_flow-combobox
-                name="select_selectedLabel"
-                label={inputValues.selectedLabel.label}
-                value={inputValues.selectedLabel.value}
-                value-type={inputValues.selectedLabel.valueDataType}
-                builder-context-filter-type="String"
-                builder-context-filter-collection-boolean={inputValues.selectedLabel.isCollection}
-                builder-context={_builderContext}
-                onvaluechanged={handleFlowComboboxValueChange}
-                automatic-output-variables={automaticOutputVariables}
-        ></c-fsc_flow-combobox>
-    </div>
-    <div class="slds-grid slds-wrap">
-        <div class="slds-col slds-size_1-of-1 slds-panel__header-title slds-text-heading_small slds-p-top_small">
-            Number of Selections
-        </div>
-        <div class="slds-col slds-size_1-of-2">
-            <lightning-input
-                    type="number" label={inputValues.min.label} name="select_min"
-                    value={inputValues.min.value}
+    
+        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Values</div>
+        <div class="border-bottom-2px slds-p-bottom_small">
+            <c-fsc_flow-combobox
+                    if:true={isLists}
+                    name="select_selectedOptionsStringList"
+                    label={inputValues.selectedOptionsStringList.label}
+                    value={inputValues.selectedOptionsStringList.value}
+                    value-type={inputValues.selectedOptionsStringList.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.selectedOptionsStringList.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                    if:true={isCSV}
+                    name="select_selectedOptionsCSV"
+                    label={inputValues.selectedOptionsCSV.label}
+                    value={inputValues.selectedOptionsCSV.value}
+                    value-type={inputValues.selectedOptionsCSV.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.selectedOptionsCSV.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                    if:true={isPicklist}
+                    name="select_selectedOptionsPicklist"
+                    label={inputValues.selectedOptionsPicklist.label}
+                    value={inputValues.selectedOptionsPicklist.value}
+                    value-type={inputValues.selectedOptionsPicklist.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.selectedOptionsPicklist.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                    if:true={isObject}
+                    name="select_selectedOptionsFieldDescriptorList"
+                    label={inputValues.selectedOptionsFieldDescriptorList.label}
+                    value={inputValues.selectedOptionsFieldDescriptorList.value}
+                    value-type={inputValues.selectedOptionsFieldDescriptorList.valueDataType}
+                    builder-context-filter-collection-boolean={inputValues.selectedOptionsFieldDescriptorList.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <template if:true={isObject}>
+                <lightning-input
+                        type="text"
+                        label={inputValues.useWhichObjectKeyForLabel.label}
+                        name="select_useWhichObjectKeyForLabel"
+                        value={inputValues.useWhichObjectKeyForLabel.value}
+                        onblur={handleValueChange}
+                ></lightning-input>
+                <lightning-input
+                        type="text"
+                        label={inputValues.useWhichObjectKeyForData.label}
+                        name="select_useWhichObjectKeyForData"
+                        value={inputValues.useWhichObjectKeyForData.value}
+                        onblur={handleValueChange}
+                ></lightning-input>
+                <lightning-input
+                    type="text"
+                    label={inputValues.useWhichObjectKeyForSort.label}
+                    name="select_useWhichObjectKeyForSort"
+                    value={inputValues.useWhichObjectKeyForSort.value}
                     onblur={handleValueChange}
-            ></lightning-input>
+                ></lightning-input>
+            </template>
         </div>
-        <div class="slds-col slds-size_1-of-2 slds-p-left_x-small">
-            <lightning-input
-                    type="number" label={inputValues.max.label} name="select_max"
-                    value={inputValues.max.value}
-                    onblur={handleValueChange}
-            ></lightning-input>
+        <div class="slds-panel__header-title slds-text-heading_small slds-p-top_small">Labels</div>
+        <div class="border-bottom-2px slds-p-bottom_small">
+            <c-fsc_flow-combobox
+                    name="select_label"
+                    label={inputValues.label.label}
+                    value={inputValues.label.value}
+                    value-type={inputValues.label.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.label.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                    name="select_sourceLabel"
+                    label={inputValues.sourceLabel.label}
+                    value={inputValues.sourceLabel.value}
+                    value-type={inputValues.sourceLabel.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.sourceLabel.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
+            <c-fsc_flow-combobox
+                    name="select_selectedLabel"
+                    label={inputValues.selectedLabel.label}
+                    value={inputValues.selectedLabel.value}
+                    value-type={inputValues.selectedLabel.valueDataType}
+                    builder-context-filter-type="String"
+                    builder-context-filter-collection-boolean={inputValues.selectedLabel.isCollection}
+                    builder-context={_builderContext}
+                    onvaluechanged={handleFlowComboboxValueChange}
+                    automatic-output-variables={automaticOutputVariables}
+            ></c-fsc_flow-combobox>
         </div>
-        <div class="slds-col slds-size_1-of-1">
-            <lightning-input
-                    type="number" label={inputValues.size.label} name="select_size"
-                    value={inputValues.size.value}
-                    onblur={handleValueChange}
-            ></lightning-input>
+        <div class="slds-grid slds-wrap">
+            <div class="slds-col slds-size_1-of-1 slds-panel__header-title slds-text-heading_small slds-p-top_small">
+                Number of Selections
+            </div>
+            <div class="slds-col slds-size_1-of-2">
+                <lightning-input
+                        type="number" label={inputValues.min.label} name="select_min"
+                        value={inputValues.min.value}
+                        onblur={handleValueChange}
+                ></lightning-input>
+            </div>
+            <div class="slds-col slds-size_1-of-2 slds-p-left_x-small">
+                <lightning-input
+                        type="number" label={inputValues.max.label} name="select_max"
+                        value={inputValues.max.value}
+                        onblur={handleValueChange}
+                ></lightning-input>
+            </div>
+            <div class="slds-col slds-size_1-of-1">
+                <lightning-input
+                        type="number" label={inputValues.size.label} name="select_size"
+                        value={inputValues.size.value}
+                        onblur={handleValueChange}
+                ></lightning-input>
+            </div>
         </div>
-    </div>
 </template>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js
@@ -60,7 +60,26 @@ export default class DualListBoxCpe extends LightningElement {
             valueDataType: null,
             isCollection: true,
             label: 'Select Field Descriptor Values'
-        }
+        },
+        // New picklist properties
+        usePicklistValues: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: 'Use Picklist Values',
+        },
+        objectApiName: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: 'Object API Name',
+        },
+        fieldApiName: {
+            value: null,
+            valueDataType: null,
+            isCollection: false,
+            label: 'Field API Name',
+        },
     };
 
     selectDataSourceOptions = [
@@ -83,7 +102,15 @@ export default class DualListBoxCpe extends LightningElement {
             label: 'FieldDescriptor Collection (use with Get Field Information action)',
             value: defaults.originalObject,
             allowedAttributes: [inputTypeToOutputAttributeName.object, inputTypeToInputAttributeName.object]
-        }
+        },
+        {
+            label: 'Picklist Values (from Salesforce field)',
+            value: defaults.picklist,
+            allowedAttributes: [
+                inputTypeToOutputAttributeName.picklist,
+                inputTypeToInputAttributeName.picklist,
+            ],
+        },
     ];
 
 
@@ -114,6 +141,7 @@ export default class DualListBoxCpe extends LightningElement {
     }
 
 	_automaticOutputVariables;
+	rendered;
 
     initializeValues(value) {
         if (this._values && this._values.length) {
@@ -125,6 +153,28 @@ export default class DualListBoxCpe extends LightningElement {
             });
         }
         this.handleDefaultAttributes();
+    }
+
+    renderedCallback() {
+        console.log("renderedCallback called, rendered:", this.rendered);
+        if (!this.rendered) {
+            this.rendered = true;
+            const flowComboboxes = this.template.querySelectorAll(
+                "c-fsc_flow-combobox"
+            );
+            console.log("Found flow comboboxes:", flowComboboxes.length);
+            console.log("builderContext:", JSON.stringify(this.builderContext));
+            console.log(
+                "automaticOutputVariables:",
+                JSON.stringify(this.automaticOutputVariables)
+            );
+
+            for (let flowCombobox of flowComboboxes) {
+                console.log("Setting context for flow combobox:", flowCombobox);
+                flowCombobox.builderContext = this.builderContext;
+                flowCombobox.automaticOutputVariables = this.automaticOutputVariables;
+            }
+        }
     }
 
     handleDefaultAttributes() {
@@ -177,6 +227,29 @@ export default class DualListBoxCpe extends LightningElement {
 
     }
 
+    handleObjectChange(event) {
+        console.log(
+            "handleObjectChange called with:",
+            JSON.stringify(event.detail)
+        );
+        if (event.target && event.detail) {
+            let typeValue = event.detail.objectType;
+            console.log("Setting objectApiName to:", typeValue);
+            this.inputValues.objectApiName.value = typeValue;
+            this.dispatchFlowValueChangeEvent("objectApiName", typeValue, "String");
+        }
+    }
+
+    handleFieldChange(event) {
+        console.log("handleFieldChange called with:", JSON.stringify(event.detail));
+        if (event.detail && event.currentTarget.name) {
+            let newValue = event.detail.value;
+            console.log("Setting fieldApiName to:", newValue);
+            this.inputValues.fieldApiName.value = newValue;
+            this.dispatchFlowValueChangeEvent("fieldApiName", newValue, "String");
+        }
+    }
+
     dispatchFlowValueChangeEvent(id, newValue, newValueDataType) {
         const valueChangedEvent = new CustomEvent('configuration_editor_input_value_changed', {
             bubbles: true,
@@ -226,6 +299,26 @@ export default class DualListBoxCpe extends LightningElement {
             return this.inputValues.allOptionsStringFormat.value === defaults.originalObject;
         }
 
+    }
+
+    get isPicklist() {
+        if (this.inputValues.allOptionsStringFormat) {
+            return (
+                this.inputValues.allOptionsStringFormat.value === defaults.picklist
+            );
+        }
+    }
+
+    get objectApiNameValue() {
+        return this.inputValues.objectApiName
+            ? this.inputValues.objectApiName.value
+            : null;
+    }
+
+    get fieldApiNameValue() {
+        return this.inputValues.fieldApiName
+            ? this.inputValues.fieldApiName.value
+            : null;
     }
 
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js
@@ -1,324 +1,515 @@
-import {LightningElement, track, api} from 'lwc';
+import { LightningElement, track, api } from "lwc";
 import {
-    defaults, inputTypeToOutputAttributeName, inputTypeToInputAttributeName
-} from 'c/fsc_dualListBoxUtils';
+  defaults,
+  inputTypeToOutputAttributeName,
+  inputTypeToInputAttributeName,
+} from "c/fsc_dualListBoxUtils";
+
+const DATA_TYPE = {
+  STRING: "String",
+  BOOLEAN: "Boolean",
+  NUMBER: "Number",
+  INTEGER: "Integer",
+};
 
 export default class DualListBoxCpe extends LightningElement {
+  @api automaticOutputVariables;
+  typeValue;
+  _builderContext = {};
+  _values = [];
+  _flowVariables = [];
+  _typeMappings = [];
+  rendered;
 
-    _builderContext;
-    _values;
+  @track inputValues = {
+    label: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Master Label",
+    },
+    allOptionsStringFormat: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Select datasource",
+    },
+    sourceLabel: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Available Choices Label",
+    },
+    fieldLevelHelp: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Add a 'None' choice",
+    },
+    selectedLabel: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Selected Chocies Label",
+    },
+    min: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Min",
+    },
+    max: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Max",
+    },
+    disableReordering: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Disable Reordering",
+    },
+    size: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Vertical Size of List Box (visible items)",
+    },
+    required: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Required",
+    },
+    requiredOptions: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Datasource for Choice Icons:",
+    },
+    useWhichObjectKeyForData: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Use Which Object Key For Data",
+    },
+    useWhichObjectKeyForLabel: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Use Which Object Key For Label",
+    },
+    useWhichObjectKeyForSort: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Use Which Object Key For Sort",
+    },
+    useObjectValueAsOutput: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Select Field",
+    },
+    allOptionsFieldDescriptorList: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Field Descriptors",
+    },
+    allOptionsStringCollection: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Values",
+    },
+    allOptionsStringCollectionLabels: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Labels",
+    },
+    allOptionsCSV: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "CSV String",
+    },
+    selectedOptionsStringList: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Select List Values",
+    },
+    selectedOptionsCSV: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Selected CSV Values",
+    },
+    selectedOptionsPicklist: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,      
+      label: "Selected Picklist Values",
+    },
+    selectedOptionsFieldDescriptorList: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Select Field Descriptor Values",
+    },
+    // New picklist properties
+    usePicklistValues: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Use Picklist Values",
+    },
+    objectApiName: {
+      value: null,
+      valueDataType: null,
+      isCollection: false,
+      label: "Object Name",
+    },
+    fieldApiName: {
+      value: null,
+      valueDataType: null,
+      isCollection: true,
+      label: "Show which fields?",
+      serialized: true,
+    },
+  };
 
-    @track inputValues = {
-        label: {value: null, valueDataType: null, isCollection: false, label: 'Master Label'},
-        allOptionsStringFormat: {value: null, valueDataType: null, isCollection: false, label: 'Select datasource'},
-        sourceLabel: {value: null, valueDataType: null, isCollection: false, label: 'Available Choices Label'},
-        fieldLevelHelp: {value: null, valueDataType: null, isCollection: false, label: 'Add a \'None\' choice'},
-        selectedLabel: {value: null, valueDataType: null, isCollection: false, label: 'Selected Chocies Label'},
-        min: {value: null, valueDataType: null, isCollection: false, label: 'Min'},
-        max: {value: null, valueDataType: null, isCollection: false, label: 'Max'},
-        disableReordering: {value: null, valueDataType: null, isCollection: false, label: 'Disable Reordering'},
-        size: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Vertical Size of List Box (visible items)'
-        },
-        required: {value: null, valueDataType: null, isCollection: false, label: 'Required'},
-        requiredOptions: {value: null, valueDataType: null, isCollection: true, label: 'Datasource for Choice Icons:'},
-        useWhichObjectKeyForData: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Use Which Object Key For Data'
-        },
-        useWhichObjectKeyForLabel: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Use Which Object Key For Label'
-        },
-        useWhichObjectKeyForSort: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Use Which Object Key For Sort'
-        },
-        useObjectValueAsOutput: {value: null, valueDataType: null, isCollection: false, label: 'Select Field'},
-        allOptionsFieldDescriptorList: {
-            value: null,
-            valueDataType: null,
-            isCollection: true,
-            label: 'Field Descriptors'
-        },
-        allOptionsStringCollection: {value: null, valueDataType: null, isCollection: true, label: 'Values'},
-        allOptionsStringCollectionLabels: {value: null, valueDataType: null, isCollection: true, label: 'Labels'},
-        allOptionsCSV: {value: null, valueDataType: null, isCollection: false, label: 'CSV String'},
-        selectedOptionsStringList: {value: null, valueDataType: null, isCollection: true, label: 'Select List Values'},
-        selectedOptionsCSV: {value: null, valueDataType: null, isCollection: false, label: 'Selected CSV Values'},
-        selectedOptionsFieldDescriptorList: {
-            value: null,
-            valueDataType: null,
-            isCollection: true,
-            label: 'Select Field Descriptor Values'
-        },
-        // New picklist properties
-        usePicklistValues: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Use Picklist Values',
-        },
-        objectApiName: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Object API Name',
-        },
-        fieldApiName: {
-            value: null,
-            valueDataType: null,
-            isCollection: false,
-            label: 'Field API Name',
-        },
-    };
+  selectDataSourceOptions = [
+    {
+      label: "CSV String",
+      value: defaults.csv,
+      allowedAttributes: [
+        inputTypeToOutputAttributeName.csv,
+        inputTypeToInputAttributeName.csv,
+      ],
+    },
+    {
+      label: "Two String Collections",
+      value: defaults.twoLists,
+      allowedAttributes: [
+        inputTypeToOutputAttributeName.list,
+        inputTypeToInputAttributeName.list,
+        inputTypeToInputAttributeName.twoLists,
+      ],
+    },
+    {
+      label: "One String Collections",
+      value: defaults.list,
+      allowedAttributes: [
+        inputTypeToOutputAttributeName.list,
+        inputTypeToInputAttributeName.list,
+      ],
+    },
+    {
+      label:
+        "FieldDescriptor Collection (use with Get Field Information action)",
+      value: defaults.originalObject,
+      allowedAttributes: [
+        inputTypeToOutputAttributeName.object,
+        inputTypeToInputAttributeName.object,
+      ],
+    },
+    {
+      label: "Picklist Values (from Salesforce field)",
+      value: defaults.picklist,
+      allowedAttributes: [
+        inputTypeToOutputAttributeName.picklist,
+        inputTypeToInputAttributeName.picklist,
+        "objectApiName",
+        "fieldApiName",
+      ],
+    },
+  ];
 
-    selectDataSourceOptions = [
-        {
-            label: 'CSV String',
-            value: defaults.csv,
-            allowedAttributes: [inputTypeToOutputAttributeName.csv, inputTypeToInputAttributeName.csv]
-        },
-        {
-            label: 'Two String Collections',
-            value: defaults.twoLists,
-            allowedAttributes: [inputTypeToOutputAttributeName.list, inputTypeToInputAttributeName.list, inputTypeToInputAttributeName.twoLists]
-        },
-        {
-            label: 'One String Collections',
-            value: defaults.list,
-            allowedAttributes: [inputTypeToOutputAttributeName.list, inputTypeToInputAttributeName.list]
-        },
-        {
-            label: 'FieldDescriptor Collection (use with Get Field Information action)',
-            value: defaults.originalObject,
-            allowedAttributes: [inputTypeToOutputAttributeName.object, inputTypeToInputAttributeName.object]
-        },
-        {
-            label: 'Picklist Values (from Salesforce field)',
-            value: defaults.picklist,
-            allowedAttributes: [
-                inputTypeToOutputAttributeName.picklist,
-                inputTypeToInputAttributeName.picklist,
-            ],
-        },
-    ];
+  @api get builderContext() {
+    return this._builderContext;
+  }
 
+  set builderContext(value) {
+    this._builderContext = value;
+  }
 
-    @api get builderContext() {
-        return this._builderContext;
-    }
+  @api get inputVariables() {
+    return this._values;
+  }
 
-    set builderContext(value) {
-        this._builderContext = value;
-    }
+  set inputVariables(value) {
+    this._values = value;
+    this.initializeValues();
+  }
 
-    @api get inputVariables() {
-        return this._values;
-    }
+  @api get genericTypeMappings() {
+    return this._genericTypeMappings;
+  }
+  set genericTypeMappings(value) {
+    this._typeMappings = value;
+    this.initializeTypeMappings();
+  }
 
-    set inputVariables(value) {
-
-        this._values = value;
-        this.initializeValues();
-    }
-
-    @api get automaticOutputVariables () {
-        return this._automaticOutputVariables;
-    }
-
-    set automaticOutputVariables (value) {
-        this._automaticOutputVariables = value;
-    }
-
-	_automaticOutputVariables;
-	rendered;
-
-    initializeValues(value) {
-        if (this._values && this._values.length) {
-            this._values.forEach(curInputParam => {
-                if (curInputParam.name && this.inputValues[curInputParam.name]) {
-                    this.inputValues[curInputParam.name].value = curInputParam.value;
-                    this.inputValues[curInputParam.name].valueDataType = curInputParam.valueDataType;
-                }
-            });
-        }
-        this.handleDefaultAttributes();
-    }
-
-    renderedCallback() {
-        console.log("renderedCallback called, rendered:", this.rendered);
-        if (!this.rendered) {
-            this.rendered = true;
-            const flowComboboxes = this.template.querySelectorAll(
-                "c-fsc_flow-combobox"
+  initializeValues(value) {
+    console.log("initializeValues called with:", JSON.stringify(this._values));
+    if (this._values && this._values.length) {
+      this._values.forEach((curInputParam) => {
+        if (curInputParam.name && this.inputValues[curInputParam.name]) {
+          console.log(
+            "in initializeValues: " +
+              curInputParam.name +
+              " = " +
+              JSON.stringify(curInputParam.value)
+          );
+          console.log("in initializeValues: " + JSON.stringify(curInputParam));
+          if (this.inputValues[curInputParam.name].serialized) {
+            this.inputValues[curInputParam.name].value = JSON.parse(
+              curInputParam.value
             );
-            console.log("Found flow comboboxes:", flowComboboxes.length);
-            console.log("builderContext:", JSON.stringify(this.builderContext));
-            console.log(
-                "automaticOutputVariables:",
-                JSON.stringify(this.automaticOutputVariables)
-            );
-
-            for (let flowCombobox of flowComboboxes) {
-                console.log("Setting context for flow combobox:", flowCombobox);
-                flowCombobox.builderContext = this.builderContext;
-                flowCombobox.automaticOutputVariables = this.automaticOutputVariables;
-            }
+          } else {
+            this.inputValues[curInputParam.name].value = curInputParam.value;
+          }
+          this.inputValues[curInputParam.name].valueDataType =
+            curInputParam.valueDataType;
         }
+      });
+
+      // Set usePicklistValues based on the data source format
+      if (
+        this.inputValues.allOptionsStringFormat &&
+        this.inputValues.allOptionsStringFormat.value === defaults.picklist
+      ) {
+        this.inputValues.usePicklistValues.value = true;
+        this.dispatchFlowValueChangeEvent("usePicklistValues", true, "Boolean");
+      }
     }
+  }
 
-    handleDefaultAttributes() {
-        let isChanged = false;
-        if (this.isObject) {
-            if (this.inputValues.useWhichObjectKeyForData.value !== defaults.fieldDescriptorValueAttribute) {
-                this.inputValues.useWhichObjectKeyForData.value = defaults.fieldDescriptorValueAttribute;
-                isChanged = true;
-            }
+  @api
+  validate() {
+    let validity = [];
+    // Add validation logic here if needed
+    return validity;
+  }
 
-        } else {
-            if (this.inputValues.useWhichObjectKeyForData.value !== defaults.defaultValueAttribute) {
-                this.inputValues.useWhichObjectKeyForData.value = defaults.defaultValueAttribute;
-                isChanged = true;
-            }
-        }
-        if (isChanged) {
-            this.dispatchFlowValueChangeEvent(defaults.useWhichObjectKeyForData, this.inputValues.useWhichObjectKeyForData.value, defaults.typeString);
-        }
+  renderedCallback() {
+    if (!this.rendered) {
+      this.rendered = true;
+      for (let flowCombobox of this.template.querySelectorAll(
+        "c-fsc_flow-combobox"
+      )) {
+        flowCombobox.builderContext = this.builderContext;
+        flowCombobox.automaticOutputVariables = this.automaticOutputVariables;
+      }
     }
+  }
 
-    handleValueChange(event) {
-        if (event.target) {
-            let curAttributeName = event.target.name ? event.target.name.replace(defaults.inputAttributePrefix, '') : null;
-            let value = event.detail ? event.detail.value : event.target.value
-            let curAttributeValue = event.target.type === 'checkbox' ? event.target.checked : value;
-            let curAttributeType;
-            switch (event.target.type) {
-                case "checkbox":
-                    curAttributeType = 'Boolean';
-                    break;
-                case "number":
-                    curAttributeType = 'Number';
-                    break;
-                default:
-                    curAttributeType = 'String';
-            }
-            this.dispatchFlowValueChangeEvent(curAttributeName, curAttributeValue, curAttributeType);
-            if (curAttributeName === defaults.attributeNameAllOptionsStringFormat) {
-                this.clearUnusedAttributes(curAttributeValue);
-            }
-        }
+  handleValueChange(event) {
+    console.log("handleValueChange called with:", JSON.stringify(event.detail));
+    console.log("event.target.name:", event.target?.name);
+    if (event.currentTarget) {
+      let curAttributeName = event.currentTarget.name
+        ? event.currentTarget.name.replace(defaults.inputAttributePrefix, "")
+        : null;
+      let value = event.detail ? event.detail.value : event.currentTarget.value;
+      let curAttributeValue =
+        event.currentTarget.type === "checkbox"
+          ? event.currentTarget.checked
+          : value;
+      let curAttributeType;
+      switch (event.currentTarget.type) {
+        case "checkbox":
+          curAttributeType = "Boolean";
+          break;
+        case "number":
+          curAttributeType = "Number";
+          break;
+        default:
+          curAttributeType = "String";
+      }
+      console.log(
+        "Dispatching flow value change:",
+        curAttributeName,
+        JSON.stringify(curAttributeValue)
+      );
+      this.dispatchFlowValueChangeEvent(
+        curAttributeName,
+        curAttributeValue,
+        curAttributeType
+      );
+      if (curAttributeName === defaults.attributeNameAllOptionsStringFormat) {
+        this.clearUnusedAttributes(curAttributeValue);
+      }
     }
+  }
 
-    handleFlowComboboxValueChange(event) {
-        if (event.target && event.detail) {
-            let changedAttribute = event.target.name.replace(defaults.inputAttributePrefix, '');
-            this.dispatchFlowValueChangeEvent(changedAttribute, event.detail.newValue, event.detail.newValueDataType);
-        }
-
+  handleFlowComboboxValueChange(event) {
+    if (event.target && event.detail) {
+      let changedAttribute = event.target.name.replace(
+        defaults.inputAttributePrefix,
+        ""
+      );
+      this.dispatchFlowValueChangeEvent(
+        changedAttribute,
+        event.detail.newValue,
+        event.detail.newValueDataType
+      );
     }
+  }
 
-    handleObjectChange(event) {
+  initializeTypeMappings() {
+    this._typeMappings.forEach((typeMapping) => {
+      // console.log(JSON.stringify(typeMapping));
+      if (typeMapping.name && typeMapping.value) {
+        this.typeValue = typeMapping.value;
+      }
+    });
+  }
+
+  handleObjectChange(event) {
+    if (event.target && event.detail) {
+      console.log("handling a dynamic type mapping");
+      console.log("event is " + JSON.stringify(event));
+      console.log("event.detail is " + JSON.stringify(event.detail));
+      console.log("event.detail.objectType is " + event.detail.objectType);
+      console.log("event.currentTarget.name is " + event.currentTarget.name);
+      let typeValue = event.detail.objectType;
+      const typeName = "T";
+      const dynamicTypeMapping = new CustomEvent(
+        "configuration_editor_input_value_changed",
+        {
+          composed: true,
+          cancelable: false,
+          bubbles: true,
+          detail: {
+            name: event.currentTarget.name,
+            newValue: event.detail.objectType,
+            newValueDataType: typeName,
+          },
+        }
+      );
+      try {
+        this.dispatchEvent(dynamicTypeMapping);
+      } catch (error) {
         console.log(
-            "handleObjectChange called with:",
-            JSON.stringify(event.detail)
+          "Error dispatching dynamicTypeMapping:",
+          JSON.stringify(error)
         );
-        if (event.target && event.detail) {
-            let typeValue = event.detail.objectType;
-            console.log("Setting objectApiName to:", typeValue);
-            this.inputValues.objectApiName.value = typeValue;
-            this.dispatchFlowValueChangeEvent("objectApiName", typeValue, "String");
-        }
+      }
+      console.log("typeValue is " + typeValue);
+
+      // Set the value first, then dispatch
+      this.inputValues.objectApiName.value = typeValue;
+      this.dispatchFlowValueChangeEvent(
+        event.currentTarget.name,
+        typeValue,
+        "String"
+      );
+    }
+  }
+
+  dispatchFlowValueChangeEvent(id, newValue, newValueDataType) {
+    // Serialize the value if the input is marked as serialized
+    console.log(
+      "in dispatchFlowValueChangeEvent: " + id,
+      JSON.stringify(newValue),
+      newValueDataType
+    );
+    if (this.inputValues[id] && this.inputValues[id].serialized) {
+      console.log("serializing value");
+      newValue = JSON.stringify(newValue);
     }
 
-    handleFieldChange(event) {
-        console.log("handleFieldChange called with:", JSON.stringify(event.detail));
-        if (event.detail && event.currentTarget.name) {
-            let newValue = event.detail.value;
-            console.log("Setting fieldApiName to:", newValue);
-            this.inputValues.fieldApiName.value = newValue;
-            this.dispatchFlowValueChangeEvent("fieldApiName", newValue, "String");
-        }
+    const valueChangedEvent = new CustomEvent(
+      "configuration_editor_input_value_changed",
+      {
+        bubbles: true,
+        cancelable: false,
+        composed: true,
+        detail: {
+          name: id,
+          newValue: newValue ? newValue : null,
+          newValueDataType: newValueDataType,
+        },
+      }
+    );
+    this.dispatchEvent(valueChangedEvent);
+  }
+
+  clearUnusedAttributes(newInputFormat) {
+    let allAttributesToCheck = [
+      ...Object.values(inputTypeToOutputAttributeName),
+      ...Object.values(inputTypeToInputAttributeName),
+    ];
+    let curDataSourceOptions = this.selectDataSourceOptions.find(
+      (curDataSource) => curDataSource.value === newInputFormat
+    );
+    allAttributesToCheck.forEach((curAttribute) => {
+      if (
+        this.inputValues[curAttribute].value &&
+        (!curDataSourceOptions ||
+          !curDataSourceOptions.allowedAttributes.includes(curAttribute))
+      ) {
+        this.inputValues[curAttribute].value = null;
+        this.dispatchFlowValueChangeEvent(
+          curAttribute,
+          null,
+          defaults.typeString
+        );
+      }
+    });
+
+    // Automatically set usePicklistValues based on data source selection
+    if (newInputFormat === defaults.picklist) {
+      this.inputValues.usePicklistValues.value = true;
+      this.dispatchFlowValueChangeEvent("usePicklistValues", true, "Boolean");
+    } else {
+      this.inputValues.usePicklistValues.value = false;
+      this.dispatchFlowValueChangeEvent("usePicklistValues", false, "Boolean");
     }
+  }
 
-    dispatchFlowValueChangeEvent(id, newValue, newValueDataType) {
-        const valueChangedEvent = new CustomEvent('configuration_editor_input_value_changed', {
-            bubbles: true,
-            cancelable: false,
-            composed: true,
-            detail: {
-                name: id,
-                newValue: newValue ? newValue : null,
-                newValueDataType: newValueDataType
-            }
-        });
-        this.dispatchEvent(valueChangedEvent);
+  get isLists() {
+    if (this.inputValues.allOptionsStringFormat) {
+      return (
+        this.inputValues.allOptionsStringFormat.value === defaults.twoLists ||
+        this.inputValues.allOptionsStringFormat.value === defaults.list
+      );
     }
+  }
 
-    clearUnusedAttributes(newInputFormat) {
-        let allAttributesToCheck = [...Object.values(inputTypeToOutputAttributeName), ...Object.values(inputTypeToInputAttributeName)];
-        let curDataSourceOptions = this.selectDataSourceOptions.find(curDataSource => curDataSource.value === newInputFormat);
-        allAttributesToCheck.forEach(curAttribute => {
-            if (this.inputValues[curAttribute].value && (!curDataSourceOptions || !curDataSourceOptions.allowedAttributes.includes(curAttribute))) {
-                this.inputValues[curAttribute].value = null;
-                this.dispatchFlowValueChangeEvent(curAttribute, null, defaults.typeString);
-            }
-        });
+  get isTwoLists() {
+    if (this.inputValues.allOptionsStringFormat) {
+      return (
+        this.inputValues.allOptionsStringFormat.value === defaults.twoLists
+      );
     }
+  }
 
-    get isLists() {
-        if (this.inputValues.allOptionsStringFormat) {
-            return this.inputValues.allOptionsStringFormat.value === defaults.twoLists || this.inputValues.allOptionsStringFormat.value === defaults.list;
-        }
-
+  get isCSV() {
+    if (this.inputValues.allOptionsStringFormat) {
+      return this.inputValues.allOptionsStringFormat.value === defaults.csv;
     }
+  }
 
-    get isTwoLists() {
-        if (this.inputValues.allOptionsStringFormat) {
-            return this.inputValues.allOptionsStringFormat.value === defaults.twoLists;
-        }
+  get isObject() {
+    if (this.inputValues.allOptionsStringFormat) {
+      return (
+        this.inputValues.allOptionsStringFormat.value ===
+        defaults.originalObject
+      );
     }
+  }
 
-    get isCSV() {
-        if (this.inputValues.allOptionsStringFormat) {
-            return this.inputValues.allOptionsStringFormat.value === defaults.csv;
-        }
+  get isPicklist() {
+    if (this.inputValues.allOptionsStringFormat) {
+      return (
+        this.inputValues.allOptionsStringFormat.value === defaults.picklist
+      );
     }
-
-    get isObject() {
-        if (this.inputValues.allOptionsStringFormat) {
-            return this.inputValues.allOptionsStringFormat.value === defaults.originalObject;
-        }
-
-    }
-
-    get isPicklist() {
-        if (this.inputValues.allOptionsStringFormat) {
-            return (
-                this.inputValues.allOptionsStringFormat.value === defaults.picklist
-            );
-        }
-    }
-
-    get objectApiNameValue() {
-        return this.inputValues.objectApiName
-            ? this.inputValues.objectApiName.value
-            : null;
-    }
-
-    get fieldApiNameValue() {
-        return this.inputValues.fieldApiName
-            ? this.inputValues.fieldApiName.value
-            : null;
-    }
-
+  }
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxCPE/fsc_dualListBoxCPE.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>51.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Dual List Box Cpe</description>
     <isExposed>true</isExposed>
     <masterLabel>Dual List Box Cpe</masterLabel>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js
@@ -3,6 +3,7 @@ const defaults = {
     list: 'list',
     twoLists: 'twoLists',
     originalObject: 'object',
+    picklist: 'picklist',
     valueField: 'value',
     labelField: 'label',
     inputAttributePrefix: 'select_',
@@ -21,14 +22,16 @@ const inputTypeToOutputAttributeName = {
     csv: 'selectedOptionsCSV',
     list: 'selectedOptionsStringList',
     twoLists: 'selectedOptionsStringList',
-    object: 'selectedOptionsFieldDescriptorList'
+    object: 'selectedOptionsFieldDescriptorList',
+    picklist: 'selectedOptionsStringList'
 };
 
 const inputTypeToInputAttributeName = {
     csv: 'allOptionsCSV',
     list: 'allOptionsStringCollection',
     twoLists: 'allOptionsStringCollectionLabels',
-    object: 'allOptionsFieldDescriptorList'
+    object: 'allOptionsFieldDescriptorList',
+    picklist: 'allOptionsStringCollection'
 };
 
 export {

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js
@@ -1,41 +1,45 @@
 const defaults = {
-    csv: 'csv',
-    list: 'list',
-    twoLists: 'twoLists',
-    originalObject: 'object',
-    picklist: 'picklist',
-    valueField: 'value',
-    labelField: 'label',
-    inputAttributePrefix: 'select_',
-    defaultValueAttribute:'value',
-    defaultLabelAttribute:'label',
-    fieldDescriptorValueAttribute:'name',
-    typeString:'String',
-    useWhichObjectKeyForData: 'useWhichObjectKeyForData',
-    attributeNameAllOptionsStringFormat: 'allOptionsStringFormat',
-    originalObjectOutputNotSupported: 'Object output is not supported for this option type.',
-    valueLabelFieldNamesNotSupported: 'Value and Label field names should be left empty for this option type.',
-    canNotUseValuesForOutput: 'Values for output can be used only with "csv" or "list" input type.'
-};
-
-const inputTypeToOutputAttributeName = {
-    csv: 'selectedOptionsCSV',
-    list: 'selectedOptionsStringList',
-    twoLists: 'selectedOptionsStringList',
-    object: 'selectedOptionsFieldDescriptorList',
-    picklist: 'selectedOptionsStringList'
-};
-
-const inputTypeToInputAttributeName = {
-    csv: 'allOptionsCSV',
-    list: 'allOptionsStringCollection',
-    twoLists: 'allOptionsStringCollectionLabels',
-    object: 'allOptionsFieldDescriptorList',
-    picklist: 'allOptionsStringCollection'
-};
-
-export {
+    csv: "csv",
+    list: "list",
+    twoLists: "twoLists",
+    originalObject: "object",
+    picklist: "picklist",
+    valueField: "value",
+    labelField: "label",
+    inputAttributePrefix: "select_",
+    defaultValueAttribute: "value",
+    defaultLabelAttribute: "label",
+    fieldDescriptorValueAttribute: "name",
+    typeString: "String",
+    useWhichObjectKeyForData: "useWhichObjectKeyForData",
+    attributeNameAllOptionsStringFormat: "allOptionsStringFormat",
+    originalObjectOutputNotSupported:
+      "Object output is not supported for this option type.",
+    valueLabelFieldNamesNotSupported:
+      "Value and Label field names should be left empty for this option type.",
+    canNotUseValuesForOutput:
+      'Values for output can be used only with "csv" or "list" input type.',
+  };
+  
+  const inputTypeToOutputAttributeName = {
+    csv: "selectedOptionsCSV",
+    list: "selectedOptionsStringList",
+    twoLists: "selectedOptionsStringList",
+    object: "selectedOptionsFieldDescriptorList",
+    picklist: "selectedOptionsPicklist",
+  };
+  
+  const inputTypeToInputAttributeName = {
+    csv: "allOptionsCSV",
+    list: "allOptionsStringCollection",
+    twoLists: "allOptionsStringCollectionLabels",
+    object: "allOptionsFieldDescriptorList",
+    picklist: "allOptionsStringCollection",
+  };
+  
+  export {
     defaults,
     inputTypeToOutputAttributeName,
-    inputTypeToInputAttributeName
-};
+    inputTypeToInputAttributeName,
+  };
+  

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_dualListBoxUtils/fsc_dualListBoxUtils.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>46.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Dual List Box Utils</description>
     <isExposed>false</isExposed>
     <masterLabel>Dual List Box Utils</masterLabel>

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.html
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.html
@@ -7,6 +7,7 @@
                             source-label={sourceLabel}
                             field-level-help={fieldLevelHelp}
                             selected-label={selectedLabel}
+                            required={required}
                             min={min}
                             max={max}
                             disable-reordering={disableReordering}

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.js
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.js
@@ -1,190 +1,269 @@
-import {LightningElement, track, api} from 'lwc';
-import {
-    defaults
-} from 'c/fsc_dualListBoxUtils';
+import { LightningElement, track, api } from "lwc";
+import { defaults } from "c/fsc_dualListBoxUtils";
 
 export default class dualListBox extends LightningElement {
+  @api label;
+  @api sourceLabel;
+  @api fieldLevelHelp;
+  @api selectedLabel;
 
-    @api label;
-    @api sourceLabel;
-    @api fieldLevelHelp;
-    @api selectedLabel;
+  @api min;
+  @api max;
+  @api disableReordering;
+  @api size;
+  @api required;
+  @api requiredOptions;
 
-    @api min;
-    @api max;
-    @api disableReordering;
-    @api size;
-    @api required;
-    @api requiredOptions;
+  @api selectedValuesStringFormat;
+  @api allOptionsStringFormat = defaults.csv; //csv;list;object
+  @api useWhichObjectKeyForData = defaults.valueField;
+  @api useWhichObjectKeyForLabel = defaults.labelField;
+  @api useWhichObjectKeyForSort;
+  @api useObjectValueAsOutput = false; //used with csv or list
+  @track _options; //always json{label,value}
+  @track _optionsOriginal; //stores original values
+  _optionsOriginalMap;
+  @track _value; //['value1','value2','value3']
 
-    @api selectedValuesStringFormat;
-    @api allOptionsStringFormat = defaults.csv;//csv;list;object
-    @api useWhichObjectKeyForData = defaults.valueField;
-    @api useWhichObjectKeyForLabel = defaults.labelField;
-    @api useWhichObjectKeyForSort;
-    @api useObjectValueAsOutput = false; //used with csv or list
-    @track _options; //always json{label,value}
-    @track _optionsOriginal; //stores original values
-    _optionsOriginalMap;
-    @track _value; //['value1','value2','value3']
+  @api
+  getValues(valueType) {
+    return this.formatValuesGet(this._value, valueType);
+  }
 
-    @api
-    getValues(valueType) {
-        return this.formatValuesGet(this._value, valueType);
+  @api
+  getOptions(valueType) {
+    return this.formatOptionsGet(this._options, valueType);
+  }
+
+  @api
+  get selectedOptions() {
+    return this.getValues(this.selectedValuesStringFormat);
+  }
+
+  set selectedOptions(value) {
+    if (!this.isError) {
+      this._value = this.formatValuesSet(
+        value,
+        this.selectedValuesStringFormat
+      );
     }
+  }
 
-    @api
-    getOptions(valueType) {
-        return this.formatOptionsGet(this._options, valueType);
+  @api
+  get allOptions() {
+    return this.getOptions(this.allOptionsStringFormat);
+  }
+
+  set allOptions(value) {
+    console.log(
+      "allOptions setter called with:",
+      JSON.stringify(value),
+      "allOptionsStringFormat:",
+      this.allOptionsStringFormat
+    );
+    if (!this.isError) {
+      this._optionsOriginal = value;
+      if (
+        this.selectedValuesStringFormat === defaults.originalObject ||
+        this.selectedValuesStringFormat === defaults.twoLists
+      ) {
+        this.setOriginalObjectMap();
+      }
+      if (this.useWhichObjectKeyForSort) {
+        let formattedOptions = this.formatOptionsSet(
+          value,
+          this.allOptionsStringFormat
+        );
+        this._options = this.sortOptionsSet(
+          formattedOptions,
+          this.useWhichObjectKeyForSort
+        );
+      } else {
+        this._options = this.formatOptionsSet(
+          value,
+          this.allOptionsStringFormat
+        );
+      }
+      console.log(
+        "allOptions setter: final _options:",
+        JSON.stringify(this._options)
+      );
+    } else {
+      console.log("allOptions setter: isError is true");
     }
+  }
 
-    @api
-    get selectedOptions() {
-        return this.getValues(this.selectedValuesStringFormat);
+  setOriginalObjectMap() {
+    let resultValue = {};
+    this._optionsOriginal.forEach((curItem) => {
+      resultValue[curItem[this.useWhichObjectKeyForData]] = curItem;
+    });
+    this._optionsOriginalMap = resultValue;
+  }
+
+  get isError() {
+    // if (this.selectedValuesStringFormat === defaults.originalObject && this.allOptionsStringFormat !== defaults.originalObject) {
+    //     return defaults.originalObjectOutputNotSupported;
+    // }
+    // if (this.allOptionsStringFormat !== defaults.originalObject &&
+    //     (
+    //         (this.useWhichObjectKeyForData || this.useWhichObjectKeyForLabel) &&
+    //         this.useWhichObjectKeyForData !== defaults.valueField || this.useWhichObjectKeyForLabel !== defaults.labelField)
+    // ) {
+    //     return defaults.valueLabelFieldNamesNotSupported;
+    // }
+    // if (this.useObjectValueAsOutput && this.selectedValuesStringFormat === defaults.originalObject) {
+    //     return defaults.canNotUseValuesForOutput;
+    // }
+  }
+
+  sortOptionsSet(value, sortField) {
+    if (!value) {
+      return;
     }
-
-    set selectedOptions(value) {
-        if (!this.isError) {
-            this._value = this.formatValuesSet(value, this.selectedValuesStringFormat);
-        }
+    if (!sortField) {
+      return value;
     }
+    let fieldValue = (row) => row[sortField] || "";
+    return [
+      ...value.sort(
+        (a, b) => (
+          (a = fieldValue(a).toUpperCase()),
+          (b = fieldValue(b).toUpperCase()),
+          (a > b) - (b > a)
+        )
+      ),
+    ];
+  }
 
-    @api
-    get allOptions() {
-        return this.getOptions(this.allOptionsStringFormat);
+  formatValuesSet(value, optionType) {
+    if (!value) {
+      return;
     }
-
-    set allOptions(value) {
-        if (!this.isError) {
-            this._optionsOriginal = value;
-            if (this.selectedValuesStringFormat === defaults.originalObject || this.selectedValuesStringFormat === defaults.twoLists) {
-                this.setOriginalObjectMap();
-            }
-            if (this.useWhichObjectKeyForSort) {
-                let formattedOptions = this.formatOptionsSet(value, this.allOptionsStringFormat);
-                this._options = this.sortOptionsSet(formattedOptions, this.useWhichObjectKeyForSort);
-            } else {
-                this._options = this.formatOptionsSet(value, this.allOptionsStringFormat);
-            }
-        }
+    if (optionType === defaults.csv) {
+      return value.replace(/^ +| +$|( ) +/g, " ").split(",");
+    } else if (
+      optionType === defaults.list ||
+      optionType === defaults.twoLists
+    ) {
+      return value;
+    } else if (optionType === defaults.picklist) {
+      // For picklist format, return the array as-is (it should be an array of values)
+      return Array.isArray(value) ? value : [value];
+    } else if (optionType === defaults.originalObject) {
+      return value.map((curItem) => {
+        return curItem[this.useWhichObjectKeyForData]
+          ? curItem[this.useWhichObjectKeyForData]
+          : curItem;
+      });
     }
+  }
 
-    setOriginalObjectMap() {
-        let resultValue = {};
-        this._optionsOriginal.forEach(curItem => {
-            resultValue[curItem[this.useWhichObjectKeyForData]] = curItem;
+  formatValuesGet(items, optionType) {
+    if (!items) {
+      return;
+    }
+    let selectedValues = this.useObjectValueAsOutput
+      ? items
+      : items.map((curItem) => {
+          return this._options.find(
+            (curFilterItem) => curItem === curFilterItem.value
+          ).label;
         });
-        this._optionsOriginalMap = resultValue;
+    if (optionType === defaults.csv || optionType === defaults.picklist) {
+      return selectedValues.join(",");
+    } else if (
+      optionType === defaults.list ||
+      optionType === defaults.twoLists
+    ) {
+      return selectedValues;
+    } else if (optionType === defaults.originalObject) {
+      return items.map((curItemId) => {
+        return this._optionsOriginalMap
+          ? this._optionsOriginalMap[curItemId]
+          : {};
+      });
     }
+  }
 
-    get isError() {
-        // if (this.selectedValuesStringFormat === defaults.originalObject && this.allOptionsStringFormat !== defaults.originalObject) {
-        //     return defaults.originalObjectOutputNotSupported;
-        // }
-        // if (this.allOptionsStringFormat !== defaults.originalObject &&
-        //     (
-        //         (this.useWhichObjectKeyForData || this.useWhichObjectKeyForLabel) &&
-        //         this.useWhichObjectKeyForData !== defaults.valueField || this.useWhichObjectKeyForLabel !== defaults.labelField)
-        // ) {
-        //     return defaults.valueLabelFieldNamesNotSupported;
-        // }
-        // if (this.useObjectValueAsOutput && this.selectedValuesStringFormat === defaults.originalObject) {
-        //     return defaults.canNotUseValuesForOutput;
-        // }
+  formatOptionsSet(items, optionType) {
+    console.log(
+      "formatOptionsSet called with:",
+      JSON.stringify(items),
+      "optionType:",
+      optionType
+    );
+    if (!items) {
+      console.log("formatOptionsSet: items is null/undefined");
+      return;
     }
+    if (optionType === defaults.csv) {
+      let localItems = items.replace(/^ +| +$|( ) +/g, " ").split(",");
+      return localItems.map((curItem) => {
+        return { label: curItem, value: curItem };
+      });
+    } else if (optionType === defaults.list) {
+      return items.map((curItem) => {
+        return { label: curItem, value: curItem };
+      });
+    } else if (optionType === defaults.picklist) {
+      // Handle picklist format - items are already in {label, value} format
+      console.log("formatOptionsSet: processing picklist format");
+      const result = items.map((curItem) => {
+        return { label: curItem.label, value: curItem.value };
+      });
+      console.log("formatOptionsSet: picklist result:", JSON.stringify(result));
+      return result;
+    } else if (
+      optionType === defaults.originalObject ||
+      optionType === defaults.twoLists
+    ) {
+      return items.map((curItem) => {
+        return {
+          label: curItem[this.useWhichObjectKeyForLabel],
+          value: curItem[this.useWhichObjectKeyForData],
+        };
+      });
+    }
+  }
 
-    sortOptionsSet(value, sortField) {
-        if (!value) {
-            return;
-        }
-        if (!sortField) {
-            return value;
-        }
-        let fieldValue = row => row[sortField] || '';
-        return [...value.sort(
-            (a,b)=>(a=fieldValue(a).toUpperCase(),b=fieldValue(b).toUpperCase(),((a>b)-(b>a)))
-        )];
+  formatOptionsGet(items, optionType) {
+    if (!items) {
+      return;
     }
+    if (optionType === defaults.csv) {
+      return items
+        .map((curItem) =>
+          this.useObjectValueAsOutput ? curItem.value : curItem.label
+        )
+        .join(",");
+    } else if (optionType === defaults.list) {
+      return items.map((curItem) =>
+        this.useObjectValueAsOutput ? curItem.value : curItem.label
+      );
+    } else if (
+      optionType === defaults.originalObject ||
+      optionType === defaults.twoLists
+    ) {
+      return items.map((curItem) => {
+        return this._optionsOriginalMap
+          ? this._optionsOriginalMap[curItem.value]
+          : {};
+      });
+    }
+  }
 
-    formatValuesSet(value, optionType) {
-        if (!value) {
-            return;
-        }
-        if (optionType === defaults.csv) {
-            return value.replace(/^ +| +$|( ) +/g, ' ').split(',');
-        } else if (optionType === defaults.list || optionType === defaults.twoLists) {
-            return value;
-        } else if (optionType === defaults.originalObject) {
-            return value.map(curItem => {
-                return curItem[this.useWhichObjectKeyForData] ? curItem[this.useWhichObjectKeyForData] : curItem
-            });
-        }
-    }
+  handleChange(event) {
+    this._value = event.detail.value;
+    this.dispatchValueChangedEvent();
+  }
 
-    formatValuesGet(items, optionType) {
-        if (!items) {
-            return;
-        }
-        let selectedValues = this.useObjectValueAsOutput ? items : items.map(curItem => {
-            return this._options.find(curFilterItem => curItem === curFilterItem.value).label;
-        });
-        if (optionType === defaults.csv) {
-            return selectedValues.join(',');
-        } else if (optionType === defaults.list || optionType === defaults.twoLists) {
-            return selectedValues;
-        } else if (optionType === defaults.originalObject) {
-            return items.map(curItemId => {
-                return this._optionsOriginalMap ? this._optionsOriginalMap[curItemId] : {};
-            });
-        }
-    }
-
-    formatOptionsSet(items, optionType) {
-        if (!items) {
-            return;
-        }
-        if (optionType === defaults.csv) {
-            let localItems = items.replace(/^ +| +$|( ) +/g, ' ').split(',');
-            return localItems.map(curItem => {
-                return {label: curItem, value: curItem}
-            });
-        } else if (optionType === defaults.list) {
-            return items.map(curItem => {
-                return {label: curItem, value: curItem}
-            });
-        } else if (optionType === defaults.originalObject || optionType === defaults.twoLists) {
-            return items.map(curItem => {
-                return {label: curItem[this.useWhichObjectKeyForLabel], value: curItem[this.useWhichObjectKeyForData]}
-            });
-        }
-    }
-
-    formatOptionsGet(items, optionType) {
-        if (!items) {
-            return;
-        }
-        if (optionType === defaults.csv) {
-            return items.map(curItem => this.useObjectValueAsOutput ? curItem.value : curItem.label).join(',');
-        } else if (optionType === defaults.list) {
-            return items.map(curItem => this.useObjectValueAsOutput ? curItem.value : curItem.label);
-        } else if (optionType === defaults.originalObject || optionType === defaults.twoLists) {
-            return items.map(curItem => {
-                return this._optionsOriginalMap ? this._optionsOriginalMap[curItem.value] : {};
-            });
-        }
-    }
-
-    handleChange(event) {
-        this._value = event.detail.value;
-        this.dispatchValueChangedEvent();
-    }
-
-    dispatchValueChangedEvent() {
-        const valueChangedEvent = new CustomEvent('valuechanged', {
-            detail: {
-                value: this.getValues(this.selectedValuesStringFormat)
-            }
-        });
-        this.dispatchEvent(valueChangedEvent);
-    }
+  dispatchValueChangedEvent() {
+    const valueChangedEvent = new CustomEvent("valuechanged", {
+      detail: {
+        value: this.getValues(this.selectedValuesStringFormat),
+      },
+    });
+    this.dispatchEvent(valueChangedEvent);
+  }
 }

--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_extendedBaseDualListBox/fsc_extendedBaseDualListBox.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>47.0</apiVersion>
+    <apiVersion>64.0</apiVersion>
     <description>Dual List Box</description>
     <isExposed>true</isExposed>
     <masterLabel>Dual List Box</masterLabel>


### PR DESCRIPTION
- Add picklist integration to fsc_dualListBoxCPE component
  - New picklist properties (usePicklistValues, objectApiName, fieldApiName)
  - New data source option for Salesforce picklist fields
  - New event handlers for object and field selection
  - New getter methods for picklist mode detection
  - New renderedCallback method for flow combobox initialization

- Add picklist integration to fsc_dualListBox3 component
  - New API properties for picklist configuration
  - New wire methods for object info and picklist values
  - New tracked properties for picklist data management
  - New updateOptionsFromPicklist method
  - New event handlers for picklist property changes

- Add HTML template updates for picklist configuration UI
  - New picklist configuration section with object and field selectors
  - Conditional rendering based on picklist mode

- Update utility files and metadata as needed

This enhancement allows users to select Salesforce objects and multipicklist fields to dynamically populate dual list box options directly from Salesforce metadata.