### PR TITLE
refactor(apex): ensure unique RecordType mapping

### DIFF
--- a/flow_action_components/GetRecordTypeInfobyObject/force-app/main/default/classes/GetRecordTypeInfobyObject.cls
+++ b/flow_action_components/GetRecordTypeInfobyObject/force-app/main/default/classes/GetRecordTypeInfobyObject.cls
@@ -23,7 +23,7 @@ global with sharing class GetRecordTypeInfobyObject {
                 // Send the email you have created.
                 try {
                     
-                    Map<String, Schema.RecordTypeInfo> recTypeInfoMap = Schema.getGlobalDescribe().get(objectName).getDescribe().getRecordTypeInfosByName();
+                    Map<String, Schema.RecordTypeInfo> recTypeInfoMap = Schema.getGlobalDescribe().get(objectName).getDescribe().getRecordTypegetRecordTypeInfosByDeveloperName();
                     List<Schema.RecordTypeInfo> recTypeInfoList = recTypeInfoMap.values();
                     
                     //extract the names and recordIds and return them as List<String> 

--- a/flow_action_components/GetRecordTypeInfobyObject/force-app/main/default/classes/GetRecordTypeInfobyObject.cls
+++ b/flow_action_components/GetRecordTypeInfobyObject/force-app/main/default/classes/GetRecordTypeInfobyObject.cls
@@ -23,7 +23,7 @@ global with sharing class GetRecordTypeInfobyObject {
                 // Send the email you have created.
                 try {
                     
-                    Map<String, Schema.RecordTypeInfo> recTypeInfoMap = Schema.getGlobalDescribe().get(objectName).getDescribe().getRecordTypegetRecordTypeInfosByDeveloperName();
+                    Map<String, Schema.RecordTypeInfo> recTypeInfoMap = Schema.getGlobalDescribe().get(objectName).getDescribe().getRecordTypeInfosByDeveloperName();
                     List<Schema.RecordTypeInfo> recTypeInfoList = recTypeInfoMap.values();
                     
                     //extract the names and recordIds and return them as List<String> 


### PR DESCRIPTION
## Description

Replaced the use of [`getRecordTypeInfosByName()`](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_sobject_describe.htm#apex_Schema_DescribeSObjectResult_getRecordTypeInfosByName) with [`getRecordTypeInfosByDeveloperName()`](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_sobject_describe.htm#apex_Schema_DescribeSObjectResult_getRecordTypeInfosByDeveloperName) in the `GetRecordtypeInfobyObjects` class.

The purpose of this change is to ensure that the keys of the map returned by the `Schema.DescribeSObjectResult` call are unique and stable, preventing potential key collisions when translated Record Type labels are identical.

## Technical context
The `getRecordTypeInfosByName()` method returns a `Map<String, Schema.RecordTypeInfo>` whose keys are **the translated labels** of the Record Types. That is, the label displayed in the user interface, depending on the user’s active language.

In Salesforce, different Record Types can share the same translated label. However, map keys **must be unique** (they behave like a Set), so if two Record Types share the same label, one of them will **overwrite** the other in the map, leading to inconsistent or unexpected results.

The standard `getRecordTypeInfosByDeveloperName()` method solves this issue because it returns a Map<String, Schema.RecordTypeInfo> whose keys are the **Developer Names** (API Names) of the Record Types, which are **unique per object** and **language-independent**.

---

This change does not alter the functional behavior of the component. It only improves code reliability in environments with translated Record Type labels.