### PR TITLE
Scan Salesforce Flows in Pull Requests

### DIFF
--- a/.flow-scanner.yml
+++ b/.flow-scanner.yml
@@ -1,0 +1,14 @@
+# Disables layout and documentation related rules for Flow Scanner
+rules:
+  missing-flow-description:
+    enabled: false
+  inactive-flow:
+    enabled: false
+  missing-fault-path:
+    enabled: false
+  invalid-naming-convention:
+    enabled: false
+  invalid-api-version:
+    enabled: false
+  unspecified-trigger-order:
+    enabled: false

--- a/.flow-scanner.yml
+++ b/.flow-scanner.yml
@@ -12,3 +12,9 @@ rules:
     enabled: false
   unspecified-trigger-order:
     enabled: false
+  missing-auto-layout:
+    enabled: false
+  unused-variable:
+    enabled: false
+  unreachable-element:
+    enabled: false

--- a/.github/workflows/scanAndTest.yml
+++ b/.github/workflows/scanAndTest.yml
@@ -154,6 +154,18 @@ jobs:
             - name: 'Authenticate to Integration Org'
               run: sfdx auth:sfdxurl:store -f ./SFDX_INTEGRATION_URL.txt -s -a integration
 
+            # Run Lightning Flow Scanner
+            - name: Run Flow Scanner
+              id: scanner
+              uses: Flow-Scanner/lightning-flow-scanner-action@v2.1.1
+              with:
+                outputMode: sarif      # optional (default)
+
+            - name: Upload SARIF to Code Scanning
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                sarif_file: ${{ steps.scanner.outputs.sarifPath }}
+
             # We use SFDX Git Delta to create a directory with only the metadata that has changed.
             # this allows us to deploy only those changes, as opposed to deploying the entire branch. 
             # This helps reducing deployment times
@@ -181,20 +193,6 @@ jobs:
             # We do a check-only deploy and we only run the tests specified in the PR
             # If the env variable does not equal 'all', we know that there is a list of
             # tests that can be run
-
-            - name: Checkout repository
-              uses: actions/checkout@v4
-
-            - name: Run Flow Scanner
-              id: scanner
-              uses: Flow-Scanner/lightning-flow-scanner-action@v2.1.1
-              with:
-                outputMode: sarif      # optional (default)
-
-            - name: Upload SARIF to Code Scanning
-              uses: github/codeql-action/upload-sarif@v3
-              with:
-                sarif_file: ${{ steps.scanner.outputs.sarifPath }}
 
             - name: 'Check-only deploy delta changes - run specified tests'
               if: ${{ env.APEX_TESTS != 'all' }}

--- a/.github/workflows/scanAndTest.yml
+++ b/.github/workflows/scanAndTest.yml
@@ -182,6 +182,20 @@ jobs:
             # If the env variable does not equal 'all', we know that there is a list of
             # tests that can be run
 
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Run Flow Scanner
+              id: scanner
+              uses: Flow-Scanner/lightning-flow-scanner-action@v2.1.1
+              with:
+                outputMode: sarif      # optional (default)
+
+            - name: Upload SARIF to Code Scanning
+              uses: github/codeql-action/upload-sarif@v3
+              with:
+                sarif_file: ${{ steps.scanner.outputs.sarifPath }}
+
             - name: 'Check-only deploy delta changes - run specified tests'
               if: ${{ env.APEX_TESTS != 'all' }}
               run: |

--- a/.github/workflows/scanAndTest.yml
+++ b/.github/workflows/scanAndTest.yml
@@ -154,18 +154,6 @@ jobs:
             - name: 'Authenticate to Integration Org'
               run: sfdx auth:sfdxurl:store -f ./SFDX_INTEGRATION_URL.txt -s -a integration
 
-            # Run Lightning Flow Scanner
-            - name: Run Flow Scanner
-              id: scanner
-              uses: Flow-Scanner/lightning-flow-scanner-action@v2.1.1
-              with:
-                outputMode: sarif      # optional (default)
-
-            - name: Upload SARIF to Code Scanning
-              uses: github/codeql-action/upload-sarif@v3
-              with:
-                sarif_file: ${{ steps.scanner.outputs.sarifPath }}
-
             # We use SFDX Git Delta to create a directory with only the metadata that has changed.
             # this allows us to deploy only those changes, as opposed to deploying the entire branch. 
             # This helps reducing deployment times

--- a/.github/workflows/scanFlows.yml
+++ b/.github/workflows/scanFlows.yml
@@ -1,0 +1,31 @@
+name: Scan Flows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  scan-flows:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read           # Read flow files
+      pull-requests: read      # List changed files in PR
+      security-events: write   # Upload SARIF to Code Scanning
+      actions: read            # Required to gather metadata for telemetry
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lightning Flow Scan
+        id: flowscanner
+        uses: Flow-Scanner/lightning-flow-scanner@action-v3.5.0
+        with:
+          sarif-only: true
+          
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.flowscanner.outputs.sarifPath }}

--- a/.github/workflows/scanFlows.yml
+++ b/.github/workflows/scanFlows.yml
@@ -23,9 +23,9 @@ jobs:
         id: flowscanner
         uses: Flow-Scanner/lightning-flow-scanner@action-v3.5.0
         with:
-          sarif-only: true
+          sarif-only: false
           
-      - name: Upload SARIF to Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ steps.flowscanner.outputs.sarifPath }}
+      # - name: Upload SARIF to Code Scanning
+      #   uses: github/codeql-action/upload-sarif@v3
+      #   with:
+      #     sarif_file: ${{ steps.flowscanner.outputs.sarifPath }}


### PR DESCRIPTION
Addresses #1685 and implements LFS as a GitHub Action to scan Salesforce Flows in Pull Requests.

A few notes on the implementation:

- The action automatically handles deltas.
- By default, it runs all built-in rules. This behavior can be customized by adding a .flow-scanner.yml configuration file.
- Only in SARIF mode does the action block pull requests when there are unaddressed issues, so I chose not to implement blocking behavior outside of that mode.