### PR TITLE
Fix checkbox for send async

### DIFF
--- a/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailRequest.cls
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailRequest.cls
@@ -3,7 +3,7 @@
  * @author            : Alex Edelstein - etal
  * @license
  * @group            SendBetterEmail
- * @since  2021-07-30
+ * @since  2026-04-07
  * @author  Jack D. Pond
  * @License				: LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * Modifications Log
@@ -12,6 +12,7 @@
  * 2.00.02	10-12-2020	Jack D. Pond		Reverted names for backward compatibility
  * 2.00.05	02-12-2021	Jack D. Pond		setTreatTargetObjectAsRecipient Fix: #586,ReplyEmail with SendBetterEmail #595
  * 2.01.06	02-12-2021	Jack D. Pond		Fix remainder of checkboxes default/save Fix: #702,#831
+ * 			07-04-2026	camro				Fix checkbox for send async
  **/
 @SuppressWarnings('PMD')
 public inherited sharing class SendBetterEmailRequest {
@@ -242,4 +243,9 @@ public inherited sharing class SendBetterEmailRequest {
     )
     @AuraEnabled
     public Boolean sendAsync;
+
+
+    @invocableVariable(description='!(Defaults to False)')
+    @AuraEnabled
+    public String cb_sendAsync;
 }

--- a/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailRequest.cls
+++ b/flow_action_components/SendBetterEmail/force-app/main/default/classes/SendBetterEmailRequest.cls
@@ -3,7 +3,7 @@
  * @author            : Alex Edelstein - etal
  * @license
  * @group            SendBetterEmail
- * @since  2026-04-07
+ * @since  2021-07-30
  * @author  Jack D. Pond
  * @License				: LICENSE found in https://github.com/alexed1/LightningFlowComponents
  * Modifications Log


### PR DESCRIPTION
Prevents an error when ticking send email asynchronously.

Similar to fix in #835

<img width="643" height="346" alt="image" src="https://github.com/user-attachments/assets/e6a1269c-f7ad-4076-8f33-f282ad0b3ee2" />

> TypeError: can't access property "cb_sendAsync", e is undefined throws at https://alpha--cameron.sandbox.lightning.force.com/auraFW/javascript/TXFWNVprQUZzQnEtNXVXYTFLQ2ppdzJEa1N5enhOU3R5QWl2VzNveFZTbGcxMy4tMjE0NzQ4MzY0OC4xMzEwNzIwMA/aura_prod.js line 330 > eval:1:29293