### PR TITLE
Update CountRecordsAndFields for Boolean field values.cls

### DIFF
--- a/flow_action_components/CollectionProcessors/force-app/main/default/classes/CountRecordsAndFields.cls
+++ b/flow_action_components/CollectionProcessors/force-app/main/default/classes/CountRecordsAndFields.cls
@@ -12,13 +12,15 @@ global with sharing class CountRecordsAndFields {
             try {
                 for (SObject record : records) {
                     if (!String.isBlank(fieldName) && !String.isBlank(fieldValue)) {
-                        if (record.get(fieldName) == fieldValue) {
+                        Object recValue = record.get(fieldName);
+                        if (recValue != null &&
+                        String.valueOf(recValue).equalsIgnoreCase(fieldValue)) {
                             response.matchedNumber++;
                         }
                     }
-    
                     response.totalNumber++;
                 }
+
             } catch (Exception ex) {
                 response.errors = ex.getMessage();
             }


### PR DESCRIPTION
I found that CountRecordsAndFields did not recognize boolean field values. I added recValue object variable to pull whatever the value is of the record. Then cast recValue as a string so that it can be compared to the fieldvalue input string.